### PR TITLE
feat(droid): add nix-on-droid support + slab host (Samsung tablet)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2191,6 +2191,32 @@
         "type": "github"
       }
     },
+    "nix-formatter-pack": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-on-droid",
+          "nixpkgs"
+        ],
+        "nmd": [
+          "nix-on-droid",
+          "nmd"
+        ],
+        "nmt": "nmt"
+      },
+      "locked": {
+        "lastModified": 1705252799,
+        "narHash": "sha256-HgSTREh7VoXjGgNDwKQUYcYo13rPkltW7IitHrTPA5c=",
+        "owner": "Gerschtli",
+        "repo": "nix-formatter-pack",
+        "rev": "2de39dedd79aab14c01b9e2934842051a160ffa5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Gerschtli",
+        "repo": "nix-formatter-pack",
+        "type": "github"
+      }
+    },
     "nix-gaming": {
       "inputs": {
         "flake-parts": [
@@ -2298,6 +2324,33 @@
       "original": {
         "owner": "farcaller",
         "repo": "nix-kube-generators",
+        "type": "github"
+      }
+    },
+    "nix-on-droid": {
+      "inputs": {
+        "home-manager": [
+          "home-manager-unstable"
+        ],
+        "nix-formatter-pack": "nix-formatter-pack",
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-docs": "nixpkgs-docs",
+        "nixpkgs-for-bootstrap": "nixpkgs-for-bootstrap",
+        "nmd": "nmd"
+      },
+      "locked": {
+        "lastModified": 1765031149,
+        "narHash": "sha256-4ZtlnCp4blhsjGnQIxAXDAj7nCJKy7tozoBRtklmwcU=",
+        "owner": "nix-community",
+        "repo": "nix-on-droid",
+        "rev": "55b6449b4582a4ba3ce712543c973360a026db7d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-on-droid",
         "type": "github"
       }
     },
@@ -2578,6 +2631,38 @@
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-docs": {
+      "locked": {
+        "lastModified": 1705957679,
+        "narHash": "sha256-Q8LJaVZGJ9wo33wBafvZSzapYsjOaNjP/pOnSiKVGHY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9a333eaa80901efe01df07eade2c16d183761fa3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-for-bootstrap": {
+      "locked": {
+        "lastModified": 1720244366,
+        "narHash": "sha256-WrDV0FPMVd2Sq9hkR5LNHudS3OSMmUrs90JUTN+MXpA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "49ee0e94463abada1de470c9c07bfc12b36dcf40",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "49ee0e94463abada1de470c9c07bfc12b36dcf40",
         "type": "github"
       }
     },
@@ -2886,6 +2971,44 @@
         "type": "github"
       }
     },
+    "nmd": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-on-droid",
+          "nixpkgs-docs"
+        ],
+        "scss-reset": "scss-reset"
+      },
+      "locked": {
+        "lastModified": 1705050560,
+        "narHash": "sha256-x3zzcdvhJpodsmdjqB4t5mkVW22V3wqHLOun0KRBzUI=",
+        "owner": "~rycee",
+        "repo": "nmd",
+        "rev": "66d9334933119c36f91a78d565c152a4fdc8d3d3",
+        "type": "sourcehut"
+      },
+      "original": {
+        "owner": "~rycee",
+        "repo": "nmd",
+        "type": "sourcehut"
+      }
+    },
+    "nmt": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1648075362,
+        "narHash": "sha256-u36WgzoA84dMVsGXzml4wZ5ckGgfnvS0ryzo/3zn/Pc=",
+        "owner": "rycee",
+        "repo": "nmt",
+        "rev": "d83601002c99b78c89ea80e5e6ba21addcfe12ae",
+        "type": "gitlab"
+      },
+      "original": {
+        "owner": "rycee",
+        "repo": "nmt",
+        "type": "gitlab"
+      }
+    },
     "noctalia": {
       "inputs": {
         "nixpkgs": [
@@ -3183,6 +3306,7 @@
         "nix-gaming": "nix-gaming",
         "nix-index-database": "nix-index-database",
         "nix-kube-generators": "nix-kube-generators",
+        "nix-on-droid": "nix-on-droid",
         "nix-topology": "nix-topology",
         "nix-vscode-extensions": "nix-vscode-extensions",
         "nix-wrapper-modules": "nix-wrapper-modules",
@@ -3266,6 +3390,22 @@
       "original": {
         "owner": "sini",
         "repo": "scope-engine",
+        "type": "github"
+      }
+    },
+    "scss-reset": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631450058,
+        "narHash": "sha256-muDlZJPtXDIGevSEWkicPP0HQ6VtucbkMNygpGlBEUM=",
+        "owner": "andreymatin",
+        "repo": "scss-reset",
+        "rev": "0cf50e27a4e95e9bb5b1715eedf9c54dee1a5a91",
+        "type": "github"
+      },
+      "original": {
+        "owner": "andreymatin",
+        "repo": "scss-reset",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -200,6 +200,13 @@
       inputs.nixpkgs.follows = "nixpkgs-unstable";
     };
     nix-kube-generators.url = "github:farcaller/nix-kube-generators";
+    nix-on-droid = {
+      url = "github:nix-community/nix-on-droid";
+      inputs = {
+        home-manager.follows = "home-manager-unstable";
+        nixpkgs.follows = "nixpkgs-unstable";
+      };
+    };
     nix-topology = {
       url = "github:oddlama/nix-topology";
       inputs = {

--- a/modules/den/aspects/core/nix-on-droid-base.nix
+++ b/modules/den/aspects/core/nix-on-droid-base.nix
@@ -1,0 +1,59 @@
+# nix-on-droid system baseline (the `droid` class). Supplies what NixOS-oriented
+# roles cannot on a Termux host: base packages, nix flags, stateVersion, shell,
+# and the home-manager wiring (stateVersion + nixpkgs policy) that a droid host
+# would otherwise get from core.users.home-manager (which it does not include —
+# a droid host does not pull roles.default).
+{
+  den.aspects.core.nix-on-droid-base.droid =
+    {
+      pkgs,
+      config,
+      lib,
+      ...
+    }:
+    {
+      environment.packages = with pkgs; [
+        coreutils
+        findutils
+        gnugrep
+        gnused
+        which
+        openssh
+      ];
+
+      # experimental-features for flakes; keep-* supplies what direnv's NixOS
+      # os block would (nix-on-droid has nix.extraOptions, not nix.settings).
+      nix.extraOptions = ''
+        experimental-features = nix-command flakes
+        keep-outputs = true
+        keep-derivations = true
+      '';
+
+      # Read the nix-on-droid changelog before bumping. Confirm against the
+      # pinned nix-on-droid release (stateVersion enum max is 24.05 at rev 55b6449).
+      system.stateVersion = "24.05";
+
+      # Login shell. zsh HM config arrives via apps.shell.zsh (homeManager).
+      user.shell = "${pkgs.zsh}/bin/zsh";
+
+      # nix-on-droid does not pass osConfig into its home-manager modules, so the
+      # bridged home-manager.config needs an explicit home.stateVersion. The droid
+      # HM evaluates its own nixpkgs (home-manager.useGlobalPkgs = false), so the
+      # system pkgs' allowUnfree (set in the battery instantiate) does not reach
+      # it — set the fleet allowUnfree policy here too.
+      #
+      # den.batteries.define-user (applied to every user globally) forwards a
+      # NixOS-style home.username/home.homeDirectory into the bridged
+      # home-manager.config, which conflicts with the values nix-on-droid sets
+      # from `user.*`. mkForce nix-on-droid's own values so they win the merge
+      # (resolves the conflict without forking the stock define-user battery).
+      home-manager.sharedModules = [
+        {
+          home.stateVersion = config.system.stateVersion;
+          nixpkgs.config.allowUnfree = true;
+          home.username = lib.mkForce config.user.userName;
+          home.homeDirectory = lib.mkForce config.user.home;
+        }
+      ];
+    };
+}

--- a/modules/den/batteries/agenix.nix
+++ b/modules/den/batteries/agenix.nix
@@ -14,6 +14,12 @@
 let
   agenixGeneratorsModule = import ../aspects/secrets/_generators-module.nix;
 
+  # agenix ships nixos/darwin/homeManager modules only; there is no
+  # droidModules. nix-on-droid has no system-level agenix integration, so the
+  # droid branch skips the system agenix module and system age config, but still
+  # imports the agenix homeManager modules into home-manager.sharedModules so the
+  # bridged home-manager.config gains the `age` option (the per-user agenix
+  # config emitted by agenixUserAspect rides there).
   agenixHostAspect =
     { host, secretsConfig, ... }:
     let
@@ -23,52 +29,66 @@ let
     {
       name = "agenix/${host.name}";
       ${host.class} =
-        { config, lib, ... }:
-        {
-          imports = [
-            inputs.agenix."${host.class}Modules".default
-            inputs.agenix-rekey."${host.class}Modules".default
-            agenixGeneratorsModule
-          ];
-
-          age = {
-            # Agenix decrypts before impermanence creates mounts
-            identityPaths = [
-              "${persistPrefix}/etc/ssh/ssh_host_ed25519_key"
+        if host.class == "droid" then
+          {
+            home-manager.sharedModules = [
+              inputs.agenix.homeManagerModules.default
+              inputs.agenix-rekey.homeManagerModules.default
+              (
+                { config, lib, ... }:
+                {
+                  _module.args.secrets = lib.mapAttrs (_: v: v.path) config.age.secrets;
+                }
+              )
+            ];
+          }
+        else
+          { config, lib, ... }:
+          {
+            imports = [
+              inputs.agenix."${host.class}Modules".default
+              inputs.agenix-rekey."${host.class}Modules".default
+              agenixGeneratorsModule
             ];
 
-            rekey = {
-              inherit (secretsConfig) masterIdentities;
-              storageMode = "local";
-              hostPubkey = builtins.readFile host.public_key;
-              generatedSecretsDir = host.secretPath + "/generated";
-              localStorageDir = host.secretPath + "/rekeyed";
+            age = {
+              # Agenix decrypts before impermanence creates mounts
+              identityPaths = [
+                "${persistPrefix}/etc/ssh/ssh_host_ed25519_key"
+              ];
+
+              rekey = {
+                inherit (secretsConfig) masterIdentities;
+                storageMode = "local";
+                hostPubkey = builtins.readFile host.public_key;
+                generatedSecretsDir = host.secretPath + "/generated";
+                localStorageDir = host.secretPath + "/rekeyed";
+              };
+
+              # Per-user identity secrets are emitted by agenixUserAspect at user scope
             };
 
-            # Per-user identity secrets are emitted by agenixUserAspect at user scope
+            # Remove agenix directory before switching if it's a dir instead of link
+            system.activationScripts = lib.mkIf (host.class == "nixos" && config.age.secrets != { }) {
+              removeAgenixLink.text = "[[ ! -L /run/agenix ]] && [[ -d /run/agenix ]] && rm -rf /run/agenix";
+              agenixNewGeneration.deps = [ "removeAgenixLink" ];
+            };
+
+            # Make secrets paths available as module arg
+            _module.args.secrets = lib.mapAttrs (_: v: v.path) config.age.secrets;
+
+            # Make agenix home-manager module available
+            home-manager.sharedModules = [
+              inputs.agenix.homeManagerModules.default
+              inputs.agenix-rekey.homeManagerModules.default
+              (
+                { config, lib, ... }:
+                {
+                  _module.args.secrets = lib.mapAttrs (_: v: v.path) config.age.secrets;
+                }
+              )
+            ];
           };
-
-          # Remove agenix directory before switching if it's a dir instead of link
-          system.activationScripts = lib.mkIf (host.class == "nixos" && config.age.secrets != { }) {
-            removeAgenixLink.text = "[[ ! -L /run/agenix ]] && [[ -d /run/agenix ]] && rm -rf /run/agenix";
-            agenixNewGeneration.deps = [ "removeAgenixLink" ];
-          };
-
-          # Make secrets paths available as module arg
-          _module.args.secrets = lib.mapAttrs (_: v: v.path) config.age.secrets;
-
-          # Make agenix home-manager module available
-          home-manager.sharedModules = [
-            inputs.agenix.homeManagerModules.default
-            inputs.agenix-rekey.homeManagerModules.default
-            (
-              { config, lib, ... }:
-              {
-                _module.args.secrets = lib.mapAttrs (_: v: v.path) config.age.secrets;
-              }
-            )
-          ];
-        };
     };
   # At cluster scope, bridge age-secrets quirk data into the k8s-manifests
   # class. Den's wrapClassModule binds the age-secrets pipe data (post-
@@ -95,20 +115,36 @@ let
     }:
     {
       name = "agenix-identity/${user.name}@${host.name}";
-      ${host.class} = _: {
-        age.secrets."user-identity-${user.name}" = {
-          rekeyFile = rootPath + "/.secrets/users/${user.name}/id_agenix.age";
-          owner = user.name;
-          group = user.name;
-          mode = "600";
-          generator.script = "age-identity";
-        };
-      };
+      # droid has no system agenix module (see agenixHostAspect note), so the
+      # per-user system identity secret is skipped there.
+      ${host.class} =
+        if host.class == "droid" then
+          (_: { })
+        else
+          _: {
+            age.secrets."user-identity-${user.name}" = {
+              rekeyFile = rootPath + "/.secrets/users/${user.name}/id_agenix.age";
+              owner = user.name;
+              group = user.name;
+              mode = "600";
+              generator.script = "age-identity";
+            };
+          };
       homeManager =
         { osConfig, ... }:
+        let
+          # On droid osConfig (nix-on-droid) has no `age` option; there is no
+          # system identity secret and no provisioned host SSH key, so fall back
+          # to the per-user agenix pubkey path. agenix-rekey reads hostPubkey
+          # lazily (only when secrets actually need rekeying), so passing a path
+          # that may not yet exist is safe for a secret-less tablet.
+          hasOsAge = osConfig ? age;
+          hasUserIdentity = hasOsAge && osConfig.age.secrets ? "user-identity-${user.name}";
+          userPubkeyPath = rootPath + "/.secrets/users/${user.name}/id_agenix.pub";
+        in
         {
           age = {
-            identityPaths = lib.optionals (osConfig.age.secrets ? "user-identity-${user.name}") [
+            identityPaths = lib.optionals hasUserIdentity [
               osConfig.age.secrets."user-identity-${user.name}".path
             ];
 
@@ -118,10 +154,12 @@ let
               generatedSecretsDir = rootPath + "/.secrets/generated/${user.name}/${host.name}";
               localStorageDir = rootPath + "/.secrets/rekeyed/${user.name}/${host.name}";
               hostPubkey =
-                if (osConfig.age.secrets ? "user-identity-${user.name}") then
-                  (rootPath + "/.secrets/users/${user.name}/id_agenix.pub")
+                if hasUserIdentity then
+                  userPubkeyPath
+                else if hasOsAge then
+                  osConfig.age.rekey.hostPubkey
                 else
-                  osConfig.age.rekey.hostPubkey;
+                  userPubkeyPath;
             };
           };
         };

--- a/modules/den/batteries/colmena.nix
+++ b/modules/den/batteries/colmena.nix
@@ -13,8 +13,10 @@
   ...
 }:
 let
-  allHosts = lib.foldl' (acc: system: acc // (config.den.hosts.${system} or { })) { } (
-    builtins.attrNames (config.den.hosts or { })
+  allHosts = lib.filterAttrs (_: h: (h.class or "nixos") != "droid") (
+    lib.foldl' (acc: system: acc // (config.den.hosts.${system} or { })) { } (
+      builtins.attrNames (config.den.hosts or { })
+    )
   );
 
   # Channel → nixpkgs input mapping.  Duplicates the table in host.nix but

--- a/modules/den/batteries/nix-on-droid.nix
+++ b/modules/den/batteries/nix-on-droid.nix
@@ -1,0 +1,215 @@
+# nix-on-droid battery: wires Android (Termux) hosts into the fleet.
+#
+# A host with `class = "droid"` instantiates via
+# nix-on-droid.lib.nixOnDroidConfiguration and emits to
+# flake.nixOnDroidConfigurations.<name>. The homeManager bridge (a second
+# makeHomeEnv) forwards user homeManager aspects into nix-on-droid's singular
+# home-manager.config — this is the only aspect reuse a droid host relies on.
+#
+# Design: a droid host does NOT pull the NixOS host baseline (no `roles.default`,
+# no `os`-class route). Its system layer comes from `core.nix-on-droid-base`,
+# its tooling from `homeManager`-class aspects (bridged). A few batteries that
+# den applies to EVERY host globally still emit NixOS-shaped config that throws
+# on nix-on-droid — these are excluded for droid hosts below.
+#
+# Deploying slab — two paths:
+#
+#   On-device (primary): on the tablet itself, after the initial nix-on-droid
+#   app bootstrap install, run
+#       nix-on-droid switch --flake <repo>#slab
+#   This is nix-on-droid's native switch flow: it builds
+#   nixOnDroidConfigurations.slab.activationPackage and executes the resulting
+#   <activationPackage>/activate script.
+#
+#   Remote (convenience): from a dev shell on a workstation, run
+#       deploy-slab [target]      # target defaults to `slab`
+#   It builds the slab activationPackage, copies its closure to the tablet's
+#   Termux sshd (reachable as `target`) via nix-copy-closure, then runs
+#   <activationPackage>/activate over SSH. Best-effort: nix-on-droid has no
+#   native remote-switch, so this needs the tablet reachable over SSH and an
+#   aarch64 builder/substituter available to build the closure.
+{
+  den,
+  lib,
+  inputs,
+  config,
+  ...
+}:
+let
+  # Channel → nixpkgs / home-manager input tables (mirrors schema/host.nix
+  # channels and colmena.nix channelNixpkgs; avoids forcing nixosConfigurations).
+  channelNixpkgs = {
+    nixos-unstable = inputs.nixpkgs-unstable;
+    nixpkgs-master = inputs.nixpkgs-master;
+    nixos-stable = inputs.nixpkgs;
+    nixpkgs-stable-darwin = inputs.nixpkgs-stable-darwin;
+  };
+  channelHM = {
+    nixos-unstable = inputs.home-manager-unstable;
+    nixpkgs-master = inputs.home-manager-master;
+    nixos-stable = inputs.home-manager;
+    nixpkgs-stable-darwin = inputs.home-manager-stable-darwin;
+  };
+
+  # homeManager bridge: reuse className "homeManager" (collects existing HM
+  # aspect emissions) but scope to droid hosts and forward into nix-on-droid's
+  # singular home-manager.config. supportedOses=["droid"] makes the standard
+  # home-manager battery skip droid hosts (its getModule is a lazy option
+  # default, only read when detection passes). getModule is empty: nix-on-droid
+  # provides the home-manager option itself. schemaIncludes forwarded so a future
+  # fleet-wide hm-host schema include is not silently skipped on slab.
+  droidHome = den.lib.home-env.makeHomeEnv {
+    className = "homeManager";
+    ctxName = "droidHm";
+    supportedOses = [ "droid" ];
+    optionPath = "nixOnDroidHome";
+    getModule = { ... }: { };
+    forwardPathFn = _: [
+      "home-manager"
+      "config"
+    ];
+    schemaIncludes = config.den.schema.hm-host.includes or [ ];
+  };
+in
+{
+  flake-file.inputs.nix-on-droid = {
+    url = "github:nix-community/nix-on-droid";
+    inputs = {
+      nixpkgs.follows = "nixpkgs-unstable";
+      home-manager.follows = "home-manager-unstable";
+    };
+  };
+
+  den.classes.droid.description = "nix-on-droid (Android/Termux) system modules";
+
+  # den.batteries.os-user's `user-to-host` policy routes the `user` class into
+  # `${host.class}.users.users.<name>` and (via ensureEntry) materialises a
+  # `users.users.<name>` skeleton even with no user-class content. On droid that
+  # targets a nonexistent `users` option, so exclude the policy for droid hosts.
+  # (This one is a top-level den.policies aspect, so policy.exclude matches it by
+  # identity. The other two global breakers — the `hostname` battery's inner
+  # `hostname/os` emission and `define-user`'s homeManager `home.*` — cannot be
+  # reached by exclude, as their effective identity keys are inner/ctx-qualified;
+  # they are absorbed instead: a `networking.hostName` shim in the instantiate
+  # modules below, and an mkForce on home.username/homeDirectory in
+  # core.nix-on-droid-base. All three keep the stock den batteries untouched, so
+  # nixos/darwin hosts stay byte-identical.)
+  den.policies.drop-user-to-host-on-droid =
+    { host, ... }:
+    lib.optional (host.class == "droid") (den.lib.policy.exclude den.policies.user-to-host);
+
+  # Registered at default scope (not host scope) to mirror den's os-class.nix:
+  # user content is emitted at host AND user scope, so the exclude must fire in
+  # every scope where `host` is bound.
+  den.default.includes = [ den.policies.drop-user-to-host-on-droid ];
+
+  # Droid-host instantiation. Fires only for class == "droid"; non-mkDefault
+  # assignments win over schema/host.nix's mkDefault nixos picks, and setting
+  # intoAttr overrides the den-entity default that throws for an unknown class.
+  #
+  # NOTE on pkgs: den registers each host via `den.lib.policy.instantiate host`
+  # (den modules/policies/flake.nix), so the whole host config becomes the
+  # instantiate `spec`. resolve.nix's `if spec ? pkgs` therefore keys off
+  # whether the *host option* `pkgs` exists. Declaring a host-wide `pkgs`
+  # option would make `spec ? pkgs` true for every host — including darwin,
+  # whose `darwinSystem` then receives `pkgs = <default>` and breaks. So we do
+  # NOT introduce a `pkgs` host option. Instead `instantiate` builds the
+  # nix-on-droid nixpkgs (channel + overlay) internally from `config`. den thus
+  # stays on its pkgs-less calling convention (`instantiate { modules }`),
+  # leaving nixos/darwin hosts untouched.
+  den.schema.host.imports = [
+    (
+      { config, ... }:
+      lib.mkIf (config.class == "droid") {
+        instantiate =
+          { modules, ... }:
+          inputs.nix-on-droid.lib.nixOnDroidConfiguration {
+            # Fleet nixpkgs policy: allowUnfree. nix-on-droid uses this `pkgs`
+            # directly and ignores `nixpkgs.config`, so set it here; the droid HM
+            # evaluates its own nixpkgs (useGlobalPkgs = false) so it is also set
+            # as an HM sharedModule in core.nix-on-droid-base.
+            pkgs = import channelNixpkgs.${config.channel} {
+              system = config.system;
+              overlays = [ inputs.nix-on-droid.overlays.default ];
+              config.allowUnfree = true;
+            };
+            # Inert option shims absorbing global-battery emissions that nix-on-droid
+            # has no option for. Keeping these here (droid-only) means the stock den
+            # batteries stay untouched, so nixos/darwin hosts are byte-identical.
+            #   nixpkgs.hostPlatform: den's resolve appends `{ nixpkgs.hostPlatform =
+            #     mkDefault system; }` for a host with `system` but no `pkgs` option
+            #     (this battery deliberately omits a pkgs host option — see NOTE).
+            #   networking.hostName: den.batteries.hostname emits
+            #     `${host.class}.networking.hostName`; nix-on-droid's networking
+            #     submodule has no hostName (Android owns the device hostname).
+            modules = [
+              (
+                { lib, ... }:
+                {
+                  options.nixpkgs.hostPlatform = lib.mkOption {
+                    type = lib.types.raw;
+                    default = config.system;
+                    description = "Inert shim absorbing den's nixpkgs.hostPlatform default on droid.";
+                  };
+                  options.networking.hostName = lib.mkOption {
+                    type = lib.types.str;
+                    default = config.name;
+                    description = "Inert shim absorbing den's hostname battery emission on droid.";
+                  };
+                }
+              )
+            ]
+            ++ modules;
+            home-manager-path = channelHM.${config.channel}.outPath;
+          };
+        intoAttr = [
+          "nixOnDroidConfigurations"
+          config.name
+        ];
+      }
+    )
+    # homeManager option (home-manager.config) for droid hosts
+    droidHome.hostConf
+  ];
+
+  den.schema.host.includes = [ droidHome.battery ];
+  den.schema.user.includes = [ droidHome.userDetect ];
+
+  # Remote-deploy convenience command (see header for both deploy paths).
+  # Best-effort: nix-on-droid has no native remote-switch, so this builds the
+  # slab activationPackage, copies the closure to the tablet's Termux sshd, and
+  # runs `<activationPackage>/activate` over SSH — mirroring nix-on-droid's own
+  # `switch` flow (build activationPackage → run <generationDir>/activate).
+  den.aspects.devshell.deploy-slab = {
+    devshell =
+      { pkgs, ... }:
+      let
+        deploy-slab = pkgs.writeShellApplication {
+          name = "deploy-slab";
+          runtimeInputs = with pkgs; [
+            nix
+            openssh
+          ];
+          text = ''
+            target="''${1:-slab}"
+            echo "==> Building slab activation package..."
+            drv=$(nix build --no-link --print-out-paths ".#nixOnDroidConfigurations.slab.activationPackage")
+            echo "==> Copying closure to $target..."
+            nix-copy-closure --to "ssh://$target" "$drv"
+            echo "==> Activating on $target..."
+            ssh "$target" "$drv/activate"
+          '';
+        };
+      in
+      {
+        packages = [ deploy-slab ];
+        commands = [
+          {
+            package = deploy-slab;
+            help = "Remote-deploy the slab nix-on-droid config over SSH (Termux sshd)";
+          }
+        ];
+      };
+  };
+  den.schema.flake-parts.includes = [ den.aspects.devshell.deploy-slab ];
+}

--- a/modules/den/hosts/slab.nix
+++ b/modules/den/hosts/slab.nix
@@ -1,0 +1,27 @@
+{ den, ... }:
+{
+  den.hosts.slab = {
+    class = "droid";
+    system = "aarch64-linux";
+    channel = "nixos-unstable";
+    environment = "dev";
+    system-owner = "sini";
+
+    users.sini = { };
+  };
+
+  # A droid host does NOT pull roles.default (the NixOS host baseline — boot,
+  # systemd, networking, impermanence, agenix, openssh, …, none of which apply
+  # to a Termux env). Its system layer is core.nix-on-droid-base; its tooling is
+  # the homeManager half of roles.dev (bridged into nix-on-droid's
+  # home-manager.config). The few NixOS-shaped emissions that den applies to
+  # every host globally (define-user/hostname/user-to-host, system agenix) are
+  # excluded/gated for droid hosts in batteries/nix-on-droid.nix and agenix.nix —
+  # so nothing needs excluding here. roles.dev's nixos/os emissions (e.g.
+  # hardware.adb) are simply not extracted for the droid class.
+  den.aspects.slab.includes = with den.aspects; [
+    roles.dev
+    apps.shell.zsh
+    core.nix-on-droid-base
+  ];
+}


### PR DESCRIPTION
Wires nix-on-droid into the den fleet and adds `slab`, a single-user aarch64 Samsung tablet. A host with `class = "droid"` builds via `nix-on-droid.lib.nixOnDroidConfiguration` → `flake.nixOnDroidConfigurations.<name>`.

## What's here
- **`batteries/nix-on-droid.nix`** — input + `den.classes.droid`; droid instantiate (builds nix-on-droid pkgs from the host channel internally — no host `pkgs` option, which would break darwin via `spec ? pkgs`); a `makeHomeEnv` bridge (`supportedOses=["droid"]`) forwarding the user's `homeManager` aspects into nix-on-droid's singular `home-manager.config`; a `deploy-slab` devshell command; colmena-hive exclusion.
- **`aspects/core/nix-on-droid-base.nix`** — the droid system layer (packages, `nix.extraOptions`, stateVersion, shell) + HM wiring.
- **`hosts/slab.nix`** — `roles.dev + apps.shell.zsh + core.nix-on-droid-base`, zero excludes.

## Design notes
A droid host does **not** pull the NixOS host baseline (`roles.default`) or an `os→droid` route — that kept the change minimal. The handful of batteries den applies to *every* host globally are handled in the least-invasive way that leaves stock den untouched:
- `user-to-host` → droid-gated `policy.exclude`
- `hostname` → inert `networking.hostName` option shim
- `define-user` HM `home.*` conflict → `lib.mkForce` nix-on-droid's own values
- `agenix` → HM-only droid branch (keeps home-manager-level agenix, so slab is secrets-capable once it has an SSH identity) — the single shared-den edit

## Verification
- `slab` resolves: `user.shell`→zsh, `programs.git`/`programs.zsh` enabled (dev tooling bridged), `home.homeDirectory`→`/data/data/com.termux.nix/files/home`, `age` option present.
- No nixos/darwin regression: `patch` drvPath byte-identical without slab; `defaults.nix`/`home-manager.nix`/`direnv.nix` are stock; cortex/devshell/hive evaluate.
- `.activationPackage.drvPath` is aarch64/IFD-bound, so it's an on-device build step; pure-eval config checks above stand in.

## Deploy
- On-device: `nix-on-droid switch --flake .#slab`
- Remote (best-effort): `deploy-slab [target]` from the dev shell