### PR TITLE
chore: regenerate prod-axon manifests for media stack

### DIFF
--- a/generated/manifests/prod-axon/apps/Application-bazarr.yaml
+++ b/generated/manifests/prod-axon/apps/Application-bazarr.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: bazarr
+  namespace: argocd
+spec:
+  destination:
+    namespace: media
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/bazarr
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/apps/Application-cloudnative-pg.yaml
+++ b/generated/manifests/prod-axon/apps/Application-cloudnative-pg.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: cloudnative-pg
+  namespace: argocd
+spec:
+  destination:
+    namespace: cnpg-system
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/cloudnative-pg
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/generated/manifests/prod-axon/apps/Application-configarr.yaml
+++ b/generated/manifests/prod-axon/apps/Application-configarr.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: configarr
+  namespace: argocd
+spec:
+  destination:
+    namespace: media
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/configarr
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/apps/Application-dash.yaml
+++ b/generated/manifests/prod-axon/apps/Application-dash.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dash
+  namespace: argocd
+spec:
+  destination:
+    namespace: media
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/dash
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/apps/Application-flaresolverr.yaml
+++ b/generated/manifests/prod-axon/apps/Application-flaresolverr.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: flaresolverr
+  namespace: argocd
+spec:
+  destination:
+    namespace: media
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/flaresolverr
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/apps/Application-glance.yaml
+++ b/generated/manifests/prod-axon/apps/Application-glance.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: glance
+  namespace: argocd
+spec:
+  destination:
+    namespace: media
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/glance
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/apps/Application-komga.yaml
+++ b/generated/manifests/prod-axon/apps/Application-komga.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: komga
+  namespace: argocd
+spec:
+  destination:
+    namespace: media
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/komga
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/apps/Application-lidarr.yaml
+++ b/generated/manifests/prod-axon/apps/Application-lidarr.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: lidarr
+  namespace: argocd
+spec:
+  destination:
+    namespace: media
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/lidarr
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/apps/Application-media-base.yaml
+++ b/generated/manifests/prod-axon/apps/Application-media-base.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: media-base
+  namespace: argocd
+spec:
+  destination:
+    namespace: media
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/media-base
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/apps/Application-media-network-policy.yaml
+++ b/generated/manifests/prod-axon/apps/Application-media-network-policy.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: media-network-policy
+  namespace: argocd
+spec:
+  destination:
+    namespace: media
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/media-network-policy
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/apps/Application-media-pg.yaml
+++ b/generated/manifests/prod-axon/apps/Application-media-pg.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: media-pg
+  namespace: argocd
+spec:
+  destination:
+    namespace: media
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/media-pg
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/apps/Application-media-secrets.yaml
+++ b/generated/manifests/prod-axon/apps/Application-media-secrets.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: media-secrets
+  namespace: argocd
+spec:
+  destination:
+    namespace: media
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/media-secrets
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/apps/Application-prowlarr.yaml
+++ b/generated/manifests/prod-axon/apps/Application-prowlarr.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: prowlarr
+  namespace: argocd
+spec:
+  destination:
+    namespace: media
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/prowlarr
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/apps/Application-qbittorrent.yaml
+++ b/generated/manifests/prod-axon/apps/Application-qbittorrent.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: qbittorrent
+  namespace: argocd
+spec:
+  destination:
+    namespace: media
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/qbittorrent
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/apps/Application-radarr.yaml
+++ b/generated/manifests/prod-axon/apps/Application-radarr.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: radarr
+  namespace: argocd
+spec:
+  destination:
+    namespace: media
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/radarr
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/apps/Application-romm.yaml
+++ b/generated/manifests/prod-axon/apps/Application-romm.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: romm
+  namespace: argocd
+spec:
+  destination:
+    namespace: media
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/romm
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/apps/Application-sabnzbd.yaml
+++ b/generated/manifests/prod-axon/apps/Application-sabnzbd.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sabnzbd
+  namespace: argocd
+spec:
+  destination:
+    namespace: media
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/sabnzbd
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/apps/Application-sonarr.yaml
+++ b/generated/manifests/prod-axon/apps/Application-sonarr.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sonarr
+  namespace: argocd
+spec:
+  destination:
+    namespace: media
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/sonarr
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/apps/Application-unpackerr.yaml
+++ b/generated/manifests/prod-axon/apps/Application-unpackerr.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: unpackerr
+  namespace: argocd
+spec:
+  destination:
+    namespace: media
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/unpackerr
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/apps/Application-whisparr.yaml
+++ b/generated/manifests/prod-axon/apps/Application-whisparr.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: whisparr
+  namespace: argocd
+spec:
+  destination:
+    namespace: media
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/whisparr
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/bazarr/CiliumNetworkPolicy-allow-dns-egress-bazarr.yaml
+++ b/generated/manifests/prod-axon/bazarr/CiliumNetworkPolicy-allow-dns-egress-bazarr.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-dns-egress-bazarr
+  namespace: media
+spec:
+  description: Allow bazarr to resolve via kube-dns.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: bazarr

--- a/generated/manifests/prod-axon/bazarr/CiliumNetworkPolicy-allow-gateway-ingress-bazarr.yaml
+++ b/generated/manifests/prod-axon/bazarr/CiliumNetworkPolicy-allow-gateway-ingress-bazarr.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-gateway-ingress-bazarr
+  namespace: media
+spec:
+  description: Allow Envoy Gateway proxies to reach bazarr.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: bazarr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+      toPorts:
+        - ports:
+            - port: "6767"
+              protocol: TCP

--- a/generated/manifests/prod-axon/bazarr/CiliumNetworkPolicy-allow-postgres-egress-bazarr.yaml
+++ b/generated/manifests/prod-axon/bazarr/CiliumNetworkPolicy-allow-postgres-egress-bazarr.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-postgres-egress-bazarr
+  namespace: media
+spec:
+  description: Allow bazarr to reach the media-pg CNPG cluster.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/cluster: media-pg
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: bazarr

--- a/generated/manifests/prod-axon/bazarr/Deployment-bazarr.yaml
+++ b/generated/manifests/prod-axon/bazarr/Deployment-bazarr.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: bazarr
+    app.kubernetes.io/name: bazarr
+  name: bazarr
+  namespace: media
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/controller: main
+      app.kubernetes.io/instance: bazarr
+      app.kubernetes.io/name: bazarr
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/controller: main
+        app.kubernetes.io/instance: bazarr
+        app.kubernetes.io/name: bazarr
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: PGID
+              value: "65536"
+            - name: POSTGRES_DATABASE
+              value: bazarr
+            - name: POSTGRES_ENABLED
+              value: "true"
+            - name: POSTGRES_HOST
+              value: media-pg-rw
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: media-pg-bazarr-password
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: media-pg-bazarr-password
+            - name: PUID
+              value: "1027"
+            - name: TZ
+              value: America/Los_Angeles
+          image: lscr.io/linuxserver/bazarr:1.5.6
+          name: main
+          volumeMounts:
+            - mountPath: /config
+              name: config
+            - mountPath: /data
+              name: data
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      serviceAccountName: bazarr
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: bazarr
+        - name: data
+          persistentVolumeClaim:
+            claimName: media-data-nfs

--- a/generated/manifests/prod-axon/bazarr/HTTPRoute-bazarr.yaml
+++ b/generated/manifests/prod-axon/bazarr/HTTPRoute-bazarr.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: bazarr
+  namespace: media
+spec:
+  hostnames:
+    - bazarr.json64.dev
+  parentRefs:
+    - name: default-gateway
+      namespace: gateways
+      sectionName: json64-dev-https
+  rules:
+    - backendRefs:
+        - name: bazarr
+          port: 6767

--- a/generated/manifests/prod-axon/bazarr/PersistentVolumeClaim-bazarr.yaml
+++ b/generated/manifests/prod-axon/bazarr/PersistentVolumeClaim-bazarr.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: bazarr
+    app.kubernetes.io/name: bazarr
+  name: bazarr
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: longhorn

--- a/generated/manifests/prod-axon/bazarr/SecurityPolicy-bazarr-oidc.yaml
+++ b/generated/manifests/prod-axon/bazarr/SecurityPolicy-bazarr-oidc.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: bazarr-oidc
+  namespace: media
+spec:
+  oidc:
+    clientID: bazarr
+    clientSecret:
+      name: bazarr-oidc-client-secret
+    forwardAccessToken: true
+    provider:
+      issuer: https://idm.json64.dev/oauth2/openid/bazarr
+    scopes:
+      - email
+      - openid
+      - profile
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: bazarr

--- a/generated/manifests/prod-axon/bazarr/Service-bazarr.yaml
+++ b/generated/manifests/prod-axon/bazarr/Service-bazarr.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: bazarr
+    app.kubernetes.io/name: bazarr
+    app.kubernetes.io/service: bazarr
+  name: bazarr
+  namespace: media
+spec:
+  ports:
+    - name: http
+      port: 6767
+      protocol: TCP
+      targetPort: 6767
+  selector:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: bazarr
+    app.kubernetes.io/name: bazarr
+  type: ClusterIP

--- a/generated/manifests/prod-axon/bazarr/ServiceAccount-bazarr.yaml
+++ b/generated/manifests/prod-axon/bazarr/ServiceAccount-bazarr.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: bazarr
+    app.kubernetes.io/name: bazarr
+  name: bazarr
+  namespace: media

--- a/generated/manifests/prod-axon/bazarr/SopsSecret-bazarr-oidc-client-secret.yaml
+++ b/generated/manifests/prod-axon/bazarr/SopsSecret-bazarr-oidc-client-secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: bazarr-oidc-client-secret
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: 3fa68be204ba026203548a0fcac20cf57a45a3500d98be933bcbcd6ea5dc22dd
+spec:
+    secretTemplates:
+        - name: bazarr-oidc-client-secret
+          stringData:
+            client-secret: ENC[AES256_GCM,data:+s4ihUGpV4ESPkFA/3N4t+9xUSrfbPNBeQGmrxXq838uLcX1/Jt+grwzrsdiS1Jx2r0QIocjOK0xKhRWxbD5/6ea23eqiaHU,iv:dG04Lfp5zzFqUTG49qSOjMqU9rHfk9PwC/bQGdfN6bs=,tag:pEsK5lpEdiY8IhFLIoPduA==,type:str]
+          type: Opaque
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5SngwcFJnT2lNUDlKREhD
+            bVlZbUdxUWdnTHlvbFNBa1BjSndhQjY2SkhNCjlZZWQrUDRWQTQ5R01yMDhVbnlQ
+            SUt5RkxqemlTaCtmYStmbkNRWDhibXMKLS0tIElqU1hON2xHSThJY1YzZytxWE5m
+            dC9HUkdZM0dEdi9vSCtObEpFbzM3TlEK145KBq1mucpond0mjFsqoHXf4nwPNkSQ
+            y2/EGQqfknXkPA7oByjZN5U/9jFiBdpAOBO1QvPOLJHu7Vn+/iefxA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:44Z"
+    mac: ENC[AES256_GCM,data:e110yBaG4tR1Rbi/ODzM+7INqktja4joN24PTN+NJvi6M9f4p/RDQbbrTFjatZKA8rfHrQ4d8A0j6LOOS/i7LE/sM03dC2NLPpVmuLn+kfRE3LWEnmv4HupQys7+EvaPU7aVb3PVvxNem/oJeYGliUX746ppovi8E5nKjudTExY=,iv:0R9FZCxEzQ79hIhKV66nHlPatE4NEm4FHPUGTpqI3gQ=,tag:L7704W0J4fAxQp6Xhugn/Q==,type:str]
+    version: 3.13.1

--- a/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-backups-postgresql-cnpg-io.yaml
+++ b/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-backups-postgresql-cnpg-io.yaml
@@ -1,0 +1,456 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+    helm.sh/resource-policy: keep
+  name: backups.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: Backup
+    listKind: BackupList
+    plural: backups
+    singular: backup
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.cluster.name
+          name: Cluster
+          type: string
+        - jsonPath: .spec.method
+          name: Method
+          type: string
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .status.error
+          name: Error
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: A Backup resource is a request for a PostgreSQL backup by the user.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Specification of the desired behavior of the backup.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                cluster:
+                  description: The cluster to backup
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                method:
+                  default: barmanObjectStore
+                  description: |-
+                    The backup method to be used, possible options are `barmanObjectStore`,
+                    `volumeSnapshot` or `plugin`. Defaults to: `barmanObjectStore`.
+                  enum:
+                    - barmanObjectStore
+                    - volumeSnapshot
+                    - plugin
+                  type: string
+                online:
+                  description: |-
+                    Whether the default type of backup with volume snapshots is
+                    online/hot (`true`, default) or offline/cold (`false`)
+                    Overrides the default setting specified in the cluster field '.spec.backup.volumeSnapshot.online'
+                  type: boolean
+                onlineConfiguration:
+                  description: |-
+                    Configuration parameters to control the online/hot backup with volume snapshots
+                    Overrides the default settings specified in the cluster '.backup.volumeSnapshot.onlineConfiguration' stanza
+                  properties:
+                    immediateCheckpoint:
+                      description: |-
+                        Control whether the I/O workload for the backup initial checkpoint will
+                        be limited, according to the `checkpoint_completion_target` setting on
+                        the PostgreSQL server. If set to true, an immediate checkpoint will be
+                        used, meaning PostgreSQL will complete the checkpoint as soon as
+                        possible. `false` by default.
+                      type: boolean
+                    waitForArchive:
+                      default: true
+                      description: |-
+                        If false, the function will return immediately after the backup is completed,
+                        without waiting for WAL to be archived.
+                        This behavior is only useful with backup software that independently monitors WAL archiving.
+                        Otherwise, WAL required to make the backup consistent might be missing and make the backup useless.
+                        By default, or when this parameter is true, pg_backup_stop will wait for WAL to be archived when archiving is
+                        enabled.
+                        On a standby, this means that it will wait only when archive_mode = always.
+                        If write activity on the primary is low, it may be useful to run pg_switch_wal on the primary in order to trigger
+                        an immediate segment switch.
+                      type: boolean
+                  type: object
+                pluginConfiguration:
+                  description: Configuration parameters passed to the plugin managing this backup
+                  properties:
+                    name:
+                      description: Name is the name of the plugin managing this backup
+                      type: string
+                    parameters:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Parameters are the configuration parameters passed to the backup
+                        plugin for this backup
+                      type: object
+                  required:
+                    - name
+                  type: object
+                target:
+                  description: |-
+                    The policy to decide which instance should perform this backup. If empty,
+                    it defaults to `cluster.spec.backup.target`.
+                    Available options are empty string, `primary` and `prefer-standby`.
+                    `primary` to have backups run always on primary instances,
+                    `prefer-standby` to have backups run preferably on the most updated
+                    standby, if available.
+                  enum:
+                    - primary
+                    - prefer-standby
+                  type: string
+              required:
+                - cluster
+              type: object
+              x-kubernetes-validations:
+                - message: BackupSpec is immutable once set
+                  rule: oldSelf == self
+            status:
+              description: |-
+                Most recently observed status of the backup. This data may not be up to
+                date. Populated by the system. Read-only.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                azureCredentials:
+                  description: The credentials to use to upload data to Azure Blob Storage
+                  properties:
+                    connectionString:
+                      description: The connection string to be used
+                      properties:
+                        key:
+                          description: The key to select
+                          type: string
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                        - key
+                        - name
+                      type: object
+                    inheritFromAzureAD:
+                      description: Use the Azure AD based authentication without providing explicitly the keys.
+                      type: boolean
+                    storageAccount:
+                      description: The storage account where to upload data
+                      properties:
+                        key:
+                          description: The key to select
+                          type: string
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                        - key
+                        - name
+                      type: object
+                    storageKey:
+                      description: |-
+                        The storage account key to be used in conjunction
+                        with the storage account name
+                      properties:
+                        key:
+                          description: The key to select
+                          type: string
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                        - key
+                        - name
+                      type: object
+                    storageSasToken:
+                      description: |-
+                        A shared-access-signature to be used in conjunction with
+                        the storage account name
+                      properties:
+                        key:
+                          description: The key to select
+                          type: string
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                        - key
+                        - name
+                      type: object
+                    useDefaultAzureCredentials:
+                      description: |-
+                        Use the default Azure authentication flow, which includes DefaultAzureCredential.
+                        This allows authentication using environment variables and managed identities.
+                      type: boolean
+                  type: object
+                backupId:
+                  description: The ID of the Barman backup
+                  type: string
+                backupLabelFile:
+                  description: Backup label file content as returned by Postgres in case of online (hot) backups
+                  format: byte
+                  type: string
+                backupName:
+                  description: The Name of the Barman backup
+                  type: string
+                beginLSN:
+                  description: The starting xlog
+                  type: string
+                beginWal:
+                  description: The starting WAL
+                  type: string
+                commandError:
+                  description: The backup command output in case of error
+                  type: string
+                commandOutput:
+                  description: Unused. Retained for compatibility with old versions.
+                  type: string
+                destinationPath:
+                  description: |-
+                    The path where to store the backup (i.e. s3://bucket/path/to/folder)
+                    this path, with different destination folders, will be used for WALs
+                    and for data. This may not be populated in case of errors.
+                  type: string
+                encryption:
+                  description: Encryption method required to S3 API
+                  type: string
+                endLSN:
+                  description: The ending xlog
+                  type: string
+                endWal:
+                  description: The ending WAL
+                  type: string
+                endpointCA:
+                  description: |-
+                    EndpointCA store the CA bundle of the barman endpoint.
+                    Useful when using self-signed certificates to avoid
+                    errors with certificate issuer and barman-cloud-wal-archive.
+                  properties:
+                    key:
+                      description: The key to select
+                      type: string
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - key
+                    - name
+                  type: object
+                endpointURL:
+                  description: |-
+                    Endpoint to be used to upload data to the cloud,
+                    overriding the automatic endpoint discovery
+                  type: string
+                error:
+                  description: The detected error
+                  type: string
+                googleCredentials:
+                  description: The credentials to use to upload data to Google Cloud Storage
+                  properties:
+                    applicationCredentials:
+                      description: The secret containing the Google Cloud Storage JSON file with the credentials
+                      properties:
+                        key:
+                          description: The key to select
+                          type: string
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                        - key
+                        - name
+                      type: object
+                    gkeEnvironment:
+                      description: |-
+                        If set to true, will presume that it's running inside a GKE environment,
+                        default to false.
+                      type: boolean
+                  type: object
+                instanceID:
+                  description: Information to identify the instance where the backup has been taken from
+                  properties:
+                    ContainerID:
+                      description: The container ID
+                      type: string
+                    podName:
+                      description: The pod name
+                      type: string
+                    sessionID:
+                      description: |-
+                        The instance manager session ID. This is a unique identifier generated at instance manager
+                        startup and changes on every restart (including container reboots). Used to detect if
+                        the instance manager was restarted during long-running operations like backups, which
+                        would terminate any running backup process.
+                      type: string
+                  type: object
+                majorVersion:
+                  description: |-
+                    The PostgreSQL major version that was running when the
+                    backup was taken.
+                  type: integer
+                method:
+                  description: The backup method being used
+                  type: string
+                online:
+                  description: Whether the backup was online/hot (`true`) or offline/cold (`false`)
+                  type: boolean
+                phase:
+                  description: The last backup status
+                  type: string
+                pluginMetadata:
+                  additionalProperties:
+                    type: string
+                  description: A map containing the plugin metadata
+                  type: object
+                reconciliationStartedAt:
+                  description: When the backup process was started by the operator
+                  format: date-time
+                  type: string
+                reconciliationTerminatedAt:
+                  description: When the reconciliation was terminated by the operator (either successfully or not)
+                  format: date-time
+                  type: string
+                s3Credentials:
+                  description: The credentials to use to upload data to S3
+                  properties:
+                    accessKeyId:
+                      description: The reference to the access key id
+                      properties:
+                        key:
+                          description: The key to select
+                          type: string
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                        - key
+                        - name
+                      type: object
+                    inheritFromIAMRole:
+                      description: Use the role based authentication without providing explicitly the keys.
+                      type: boolean
+                    region:
+                      description: The reference to the secret containing the region name
+                      properties:
+                        key:
+                          description: The key to select
+                          type: string
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                        - key
+                        - name
+                      type: object
+                    secretAccessKey:
+                      description: The reference to the secret access key
+                      properties:
+                        key:
+                          description: The key to select
+                          type: string
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                        - key
+                        - name
+                      type: object
+                    sessionToken:
+                      description: The references to the session key
+                      properties:
+                        key:
+                          description: The key to select
+                          type: string
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                        - key
+                        - name
+                      type: object
+                  type: object
+                serverName:
+                  description: |-
+                    The server name on S3, the cluster name is used if this
+                    parameter is omitted
+                  type: string
+                snapshotBackupStatus:
+                  description: Status of the volumeSnapshot backup
+                  properties:
+                    elements:
+                      description: The elements list, populated with the gathered volume snapshots
+                      items:
+                        description: BackupSnapshotElementStatus is a volume snapshot that is part of a volume snapshot method backup
+                        properties:
+                          name:
+                            description: Name is the snapshot resource name
+                            type: string
+                          tablespaceName:
+                            description: |-
+                              TablespaceName is the name of the snapshotted tablespace. Only set
+                              when type is PG_TABLESPACE
+                            type: string
+                          type:
+                            description: Type is tho role of the snapshot in the cluster, such as PG_DATA, PG_WAL and PG_TABLESPACE
+                            type: string
+                        required:
+                          - name
+                          - type
+                        type: object
+                      type: array
+                  type: object
+                startedAt:
+                  description: When the backup execution was started by the backup tool
+                  format: date-time
+                  type: string
+                stoppedAt:
+                  description: When the backup execution was terminated by the backup tool
+                  format: date-time
+                  type: string
+                tablespaceMapFile:
+                  description: Tablespace map file content as returned by Postgres in case of online (hot) backups
+                  format: byte
+                  type: string
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-clusterimagecatalogs-postgresql-cnpg-io.yaml
+++ b/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-clusterimagecatalogs-postgresql-cnpg-io.yaml
@@ -1,0 +1,184 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+    helm.sh/resource-policy: keep
+  name: clusterimagecatalogs.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: ClusterImageCatalog
+    listKind: ClusterImageCatalogList
+    plural: clusterimagecatalogs
+    singular: clusterimagecatalog
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterImageCatalog is the Schema for the clusterimagecatalogs API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Specification of the desired behavior of the ClusterImageCatalog.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                images:
+                  description: List of CatalogImages available in the catalog
+                  items:
+                    description: CatalogImage defines the image and major version
+                    properties:
+                      extensions:
+                        description: The configuration of the extensions to be added
+                        items:
+                          description: |-
+                            ExtensionConfiguration is the configuration used to add
+                            PostgreSQL extensions to the Cluster.
+                          properties:
+                            bin_path:
+                              description: |-
+                                A list of directories within the image to be appended to the
+                                PostgreSQL process's `PATH` environment variable.
+                              items:
+                                type: string
+                              type: array
+                            dynamic_library_path:
+                              description: |-
+                                The list of directories inside the image which should be added to dynamic_library_path.
+                                If not defined, defaults to "/lib".
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: |-
+                                Env is a list of custom environment variables to be set in the
+                                PostgreSQL process for this extension. It is the responsibility of the
+                                cluster administrator to ensure the variables are correct for the
+                                specific extension. Note that changes to these variables require
+                                a manual cluster restart to take effect.
+                              items:
+                                description: |-
+                                  ExtensionEnvVar defines an environment variable for a specific extension
+                                  image volume.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the environment variable to be injected into the
+                                      PostgreSQL process.
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value of the environment variable. CloudNativePG performs a direct
+                                      replacement of this value, with support for placeholder expansion.
+                                      The ${`image_root`} placeholder resolves to the absolute mount path
+                                      of the extension's volume (e.g., `/extensions/my-extension`). This
+                                      is particularly useful for allowing applications or libraries to
+                                      locate specific directories within the mounted image.
+                                      Unrecognized placeholders are rejected. To include a literal ${...}
+                                      in the value, escape it as $${...}.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            extension_control_path:
+                              description: |-
+                                The list of directories inside the image which should be added to extension_control_path.
+                                If not defined, defaults to "/share".
+                              items:
+                                type: string
+                              type: array
+                            image:
+                              description: The image containing the extension.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                              type: object
+                            ld_library_path:
+                              description: The list of directories inside the image which should be added to ld_library_path.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the extension, required
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                      image:
+                        description: The image reference
+                        type: string
+                      major:
+                        description: The PostgreSQL major version of the image. Must be unique within the catalog.
+                        minimum: 10
+                        type: integer
+                    required:
+                      - image
+                      - major
+                    type: object
+                  maxItems: 8
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: Images must have unique major versions
+                      rule: self.all(e, self.filter(f, f.major==e.major).size() == 1)
+              required:
+                - images
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-clusters-postgresql-cnpg-io.yaml
+++ b/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-clusters-postgresql-cnpg-io.yaml
@@ -1,0 +1,7258 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+    helm.sh/resource-policy: keep
+  name: clusters.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    singular: cluster
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: Number of instances
+          jsonPath: .status.instances
+          name: Instances
+          type: integer
+        - description: Number of ready instances
+          jsonPath: .status.readyInstances
+          name: Ready
+          type: integer
+        - description: Cluster current status
+          jsonPath: .status.phase
+          name: Status
+          type: string
+        - description: Primary pod
+          jsonPath: .status.currentPrimary
+          name: Primary
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Cluster defines the API schema for a highly available PostgreSQL database cluster
+            managed by CloudNativePG.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Specification of the desired behavior of the cluster.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                affinity:
+                  description: Affinity/Anti-affinity rules for Pods
+                  properties:
+                    additionalPodAffinity:
+                      description: AdditionalPodAffinity allows to specify pod affinity terms to be passed to all the cluster's pods.
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: |-
+                            The scheduler will prefer to schedule pods to nodes that satisfy
+                            the affinity expressions specified by this field, but it may choose
+                            a node that violates one or more of the expressions. The node that is
+                            most preferred is the one with the greatest sum of weights, i.e.
+                            for each node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling affinity expressions, etc.),
+                            compute a sum by iterating through the elements of this field and adding
+                            "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                            node(s) with the highest sum are the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  topologyKey:
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                description: |-
+                                  weight associated with matching the corresponding podAffinityTerm,
+                                  in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: |-
+                            If the affinity requirements specified by this field are not met at
+                            scheduling time, the pod will not be scheduled onto the node.
+                            If the affinity requirements specified by this field cease to be met
+                            at some point during pod execution (e.g. due to a pod label update), the
+                            system may or may not try to eventually evict the pod from its node.
+                            When there are multiple elements, the lists of nodes corresponding to each
+                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                          items:
+                            description: |-
+                              Defines a set of pods (namely those matching the labelSelector
+                              relative to the given namespace(s)) that this pod should be
+                              co-located (affinity) or not co-located (anti-affinity) with,
+                              where co-located is defined as running on a node whose value of
+                              the label with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: |-
+                                  A label query over a set of resources, in this case pods.
+                                  If it's null, this PodAffinityTerm matches with no Pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                description: |-
+                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mismatchLabelKeys:
+                                description: |-
+                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              namespaceSelector:
+                                description: |-
+                                  A label query over the set of namespaces that the term applies to.
+                                  The term is applied to the union of the namespaces selected by this field
+                                  and the ones listed in the namespaces field.
+                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                  An empty selector ({}) matches all namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaces:
+                                description: |-
+                                  namespaces specifies a static list of namespace names that the term applies to.
+                                  The term is applied to the union of the namespaces listed in this field
+                                  and the ones selected by namespaceSelector.
+                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              topologyKey:
+                                description: |-
+                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                  selected pods is running.
+                                  Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    additionalPodAntiAffinity:
+                      description: |-
+                        AdditionalPodAntiAffinity allows to specify pod anti-affinity terms to be added to the ones generated
+                        by the operator if EnablePodAntiAffinity is set to true (default) or to be used exclusively if set to false.
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: |-
+                            The scheduler will prefer to schedule pods to nodes that satisfy
+                            the anti-affinity expressions specified by this field, but it may choose
+                            a node that violates one or more of the expressions. The node that is
+                            most preferred is the one with the greatest sum of weights, i.e.
+                            for each node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling anti-affinity expressions, etc.),
+                            compute a sum by iterating through the elements of this field and subtracting
+                            "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                            node(s) with the highest sum are the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  topologyKey:
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                description: |-
+                                  weight associated with matching the corresponding podAffinityTerm,
+                                  in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: |-
+                            If the anti-affinity requirements specified by this field are not met at
+                            scheduling time, the pod will not be scheduled onto the node.
+                            If the anti-affinity requirements specified by this field cease to be met
+                            at some point during pod execution (e.g. due to a pod label update), the
+                            system may or may not try to eventually evict the pod from its node.
+                            When there are multiple elements, the lists of nodes corresponding to each
+                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                          items:
+                            description: |-
+                              Defines a set of pods (namely those matching the labelSelector
+                              relative to the given namespace(s)) that this pod should be
+                              co-located (affinity) or not co-located (anti-affinity) with,
+                              where co-located is defined as running on a node whose value of
+                              the label with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: |-
+                                  A label query over a set of resources, in this case pods.
+                                  If it's null, this PodAffinityTerm matches with no Pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                description: |-
+                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mismatchLabelKeys:
+                                description: |-
+                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              namespaceSelector:
+                                description: |-
+                                  A label query over the set of namespaces that the term applies to.
+                                  The term is applied to the union of the namespaces selected by this field
+                                  and the ones listed in the namespaces field.
+                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                  An empty selector ({}) matches all namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaces:
+                                description: |-
+                                  namespaces specifies a static list of namespace names that the term applies to.
+                                  The term is applied to the union of the namespaces listed in this field
+                                  and the ones selected by namespaceSelector.
+                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              topologyKey:
+                                description: |-
+                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                  selected pods is running.
+                                  Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    enablePodAntiAffinity:
+                      description: |-
+                        Activates anti-affinity for the pods. The operator will define pods
+                        anti-affinity unless this field is explicitly set to false
+                      type: boolean
+                    nodeAffinity:
+                      description: |-
+                        NodeAffinity describes node affinity scheduling rules for the pod.
+                        More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: |-
+                            The scheduler will prefer to schedule pods to nodes that satisfy
+                            the affinity expressions specified by this field, but it may choose
+                            a node that violates one or more of the expressions. The node that is
+                            most preferred is the one with the greatest sum of weights, i.e.
+                            for each node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling affinity expressions, etc.),
+                            compute a sum by iterating through the elements of this field and adding
+                            "weight" to the sum if the node matches the corresponding matchExpressions; the
+                            node(s) with the highest sum are the most preferred.
+                          items:
+                            description: |-
+                              An empty preferred scheduling term matches all objects with implicit weight 0
+                              (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                            properties:
+                              preference:
+                                description: A node selector term, associated with the corresponding weight.
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements by node's labels.
+                                    items:
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchFields:
+                                    description: A list of node selector requirements by node's fields.
+                                    items:
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              weight:
+                                description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - preference
+                              - weight
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: |-
+                            If the affinity requirements specified by this field are not met at
+                            scheduling time, the pod will not be scheduled onto the node.
+                            If the affinity requirements specified by this field cease to be met
+                            at some point during pod execution (e.g. due to an update), the system
+                            may or may not try to eventually evict the pod from its node.
+                          properties:
+                            nodeSelectorTerms:
+                              description: Required. A list of node selector terms. The terms are ORed.
+                              items:
+                                description: |-
+                                  A null or empty node selector term matches no objects. The requirements of
+                                  them are ANDed.
+                                  The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements by node's labels.
+                                    items:
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchFields:
+                                    description: A list of node selector requirements by node's fields.
+                                    items:
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - nodeSelectorTerms
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        NodeSelector is map of key-value pairs used to define the nodes on which
+                        the pods can run.
+                        More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                      type: object
+                    podAntiAffinityType:
+                      description: |-
+                        PodAntiAffinityType allows the user to decide whether pod anti-affinity between cluster instance has to be
+                        considered a strong requirement during scheduling or not. Allowed values are: "preferred" (default if empty) or
+                        "required". Setting it to "required", could lead to instances remaining pending until new kubernetes nodes are
+                        added if all the existing nodes don't match the required pod anti-affinity rule.
+                        More info:
+                        https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+                      type: string
+                    tolerations:
+                      description: |-
+                        Tolerations is a list of Tolerations that should be set for all the pods, in order to allow them to run
+                        on tainted nodes.
+                        More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                      items:
+                        description: |-
+                          The pod this Toleration is attached to tolerates any taint that matches
+                          the triple <key,value,effect> using the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: |-
+                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value.
+                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                              Exists is equivalent to wildcard for value, so that a pod can
+                              tolerate all taints of a particular category.
+                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                            type: string
+                          tolerationSeconds:
+                            description: |-
+                              TolerationSeconds represents the period of time the toleration (which must be
+                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                              negative values will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: |-
+                              Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                    topologyKey:
+                      description: |-
+                        TopologyKey to use for anti-affinity configuration. See k8s documentation
+                        for more info on that
+                      type: string
+                  type: object
+                backup:
+                  description: The configuration to be used for backups
+                  properties:
+                    barmanObjectStore:
+                      description: The configuration for the barman-cloud tool suite
+                      properties:
+                        azureCredentials:
+                          description: The credentials to use to upload data to Azure Blob Storage
+                          properties:
+                            connectionString:
+                              description: The connection string to be used
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - key
+                                - name
+                              type: object
+                            inheritFromAzureAD:
+                              description: Use the Azure AD based authentication without providing explicitly the keys.
+                              type: boolean
+                            storageAccount:
+                              description: The storage account where to upload data
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - key
+                                - name
+                              type: object
+                            storageKey:
+                              description: |-
+                                The storage account key to be used in conjunction
+                                with the storage account name
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - key
+                                - name
+                              type: object
+                            storageSasToken:
+                              description: |-
+                                A shared-access-signature to be used in conjunction with
+                                the storage account name
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - key
+                                - name
+                              type: object
+                            useDefaultAzureCredentials:
+                              description: |-
+                                Use the default Azure authentication flow, which includes DefaultAzureCredential.
+                                This allows authentication using environment variables and managed identities.
+                              type: boolean
+                          type: object
+                        data:
+                          description: |-
+                            The configuration to be used to backup the data files
+                            When not defined, base backups files will be stored uncompressed and may
+                            be unencrypted in the object store, according to the bucket default
+                            policy.
+                          properties:
+                            additionalCommandArgs:
+                              description: |-
+                                AdditionalCommandArgs represents additional arguments that can be appended
+                                to the 'barman-cloud-backup' command-line invocation. These arguments
+                                provide flexibility to customize the backup process further according to
+                                specific requirements or configurations.
+
+                                Example:
+                                In a scenario where specialized backup options are required, such as setting
+                                a specific timeout or defining custom behavior, users can use this field
+                                to specify additional command arguments.
+
+                                Note:
+                                It's essential to ensure that the provided arguments are valid and supported
+                                by the 'barman-cloud-backup' command, to avoid potential errors or unintended
+                                behavior during execution.
+                              items:
+                                type: string
+                              type: array
+                            compression:
+                              description: |-
+                                Compress a backup file (a tar file per tablespace) while streaming it
+                                to the object store. Available options are empty string (no
+                                compression, default), `gzip`, `bzip2`, and `snappy`.
+                              enum:
+                                - bzip2
+                                - gzip
+                                - snappy
+                              type: string
+                            encryption:
+                              description: |-
+                                Whenever to force the encryption of files (if the bucket is
+                                not already configured for that).
+                                Allowed options are empty string (use the bucket policy, default),
+                                `AES256` and `aws:kms`
+                              enum:
+                                - AES256
+                                - aws:kms
+                              type: string
+                            immediateCheckpoint:
+                              description: |-
+                                Control whether the I/O workload for the backup initial checkpoint will
+                                be limited, according to the `checkpoint_completion_target` setting on
+                                the PostgreSQL server. If set to true, an immediate checkpoint will be
+                                used, meaning PostgreSQL will complete the checkpoint as soon as
+                                possible. `false` by default.
+                              type: boolean
+                            jobs:
+                              description: |-
+                                The number of parallel jobs to be used to upload the backup, defaults
+                                to 2
+                              format: int32
+                              minimum: 1
+                              type: integer
+                          type: object
+                        destinationPath:
+                          description: |-
+                            The path where to store the backup (i.e. s3://bucket/path/to/folder)
+                            this path, with different destination folders, will be used for WALs
+                            and for data
+                          minLength: 1
+                          type: string
+                        endpointCA:
+                          description: |-
+                            EndpointCA store the CA bundle of the barman endpoint.
+                            Useful when using self-signed certificates to avoid
+                            errors with certificate issuer and barman-cloud-wal-archive
+                          properties:
+                            key:
+                              description: The key to select
+                              type: string
+                            name:
+                              description: Name of the referent.
+                              type: string
+                          required:
+                            - key
+                            - name
+                          type: object
+                        endpointURL:
+                          description: |-
+                            Endpoint to be used to upload data to the cloud,
+                            overriding the automatic endpoint discovery
+                          type: string
+                        googleCredentials:
+                          description: The credentials to use to upload data to Google Cloud Storage
+                          properties:
+                            applicationCredentials:
+                              description: The secret containing the Google Cloud Storage JSON file with the credentials
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - key
+                                - name
+                              type: object
+                            gkeEnvironment:
+                              description: |-
+                                If set to true, will presume that it's running inside a GKE environment,
+                                default to false.
+                              type: boolean
+                          type: object
+                        historyTags:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            HistoryTags is a list of key value pairs that will be passed to the
+                            Barman --history-tags option.
+                          type: object
+                        s3Credentials:
+                          description: The credentials to use to upload data to S3
+                          properties:
+                            accessKeyId:
+                              description: The reference to the access key id
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - key
+                                - name
+                              type: object
+                            inheritFromIAMRole:
+                              description: Use the role based authentication without providing explicitly the keys.
+                              type: boolean
+                            region:
+                              description: The reference to the secret containing the region name
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - key
+                                - name
+                              type: object
+                            secretAccessKey:
+                              description: The reference to the secret access key
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - key
+                                - name
+                              type: object
+                            sessionToken:
+                              description: The references to the session key
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - key
+                                - name
+                              type: object
+                          type: object
+                        serverName:
+                          description: |-
+                            The server name on S3, the cluster name is used if this
+                            parameter is omitted
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Tags is a list of key value pairs that will be passed to the
+                            Barman --tags option.
+                          type: object
+                        wal:
+                          description: |-
+                            The configuration for the backup of the WAL stream.
+                            When not defined, WAL files will be stored uncompressed and may be
+                            unencrypted in the object store, according to the bucket default policy.
+                          properties:
+                            archiveAdditionalCommandArgs:
+                              description: |-
+                                Additional arguments that can be appended to the 'barman-cloud-wal-archive'
+                                command-line invocation. These arguments provide flexibility to customize
+                                the WAL archive process further, according to specific requirements or configurations.
+
+                                Example:
+                                In a scenario where specialized backup options are required, such as setting
+                                a specific timeout or defining custom behavior, users can use this field
+                                to specify additional command arguments.
+
+                                Note:
+                                It's essential to ensure that the provided arguments are valid and supported
+                                by the 'barman-cloud-wal-archive' command, to avoid potential errors or unintended
+                                behavior during execution.
+                              items:
+                                type: string
+                              type: array
+                            compression:
+                              description: |-
+                                Compress a WAL file before sending it to the object store. Available
+                                options are empty string (no compression, default), `gzip`, `bzip2`,
+                                `lz4`, `snappy`, `xz`, and `zstd`.
+                              enum:
+                                - bzip2
+                                - gzip
+                                - lz4
+                                - snappy
+                                - xz
+                                - zstd
+                              type: string
+                            encryption:
+                              description: |-
+                                Whenever to force the encryption of files (if the bucket is
+                                not already configured for that).
+                                Allowed options are empty string (use the bucket policy, default),
+                                `AES256` and `aws:kms`
+                              enum:
+                                - AES256
+                                - aws:kms
+                              type: string
+                            maxParallel:
+                              description: |-
+                                Number of WAL files to be either archived in parallel (when the
+                                PostgreSQL instance is archiving to a backup object store) or
+                                restored in parallel (when a PostgreSQL standby is fetching WAL
+                                files from a recovery object store). If not specified, WAL files
+                                will be processed one at a time. It accepts a positive integer as a
+                                value - with 1 being the minimum accepted value.
+                              minimum: 1
+                              type: integer
+                            restoreAdditionalCommandArgs:
+                              description: |-
+                                Additional arguments that can be appended to the 'barman-cloud-wal-restore'
+                                command-line invocation. These arguments provide flexibility to customize
+                                the WAL restore process further, according to specific requirements or configurations.
+
+                                Example:
+                                In a scenario where specialized backup options are required, such as setting
+                                a specific timeout or defining custom behavior, users can use this field
+                                to specify additional command arguments.
+
+                                Note:
+                                It's essential to ensure that the provided arguments are valid and supported
+                                by the 'barman-cloud-wal-restore' command, to avoid potential errors or unintended
+                                behavior during execution.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                      required:
+                        - destinationPath
+                      type: object
+                    retentionPolicy:
+                      description: |-
+                        RetentionPolicy is the retention policy to be used for backups
+                        and WALs (i.e. '60d'). The retention policy is expressed in the form
+                        of `XXu` where `XX` is a positive integer and `u` is in `[dwm]` -
+                        days, weeks, months.
+                        It's currently only applicable when using the BarmanObjectStore method.
+                      pattern: ^[1-9][0-9]*[dwm]$
+                      type: string
+                    target:
+                      default: prefer-standby
+                      description: |-
+                        The policy to decide which instance should perform backups. Available
+                        options are empty string, which will default to `prefer-standby` policy,
+                        `primary` to have backups run always on primary instances, `prefer-standby`
+                        to have backups run preferably on the most updated standby, if available.
+                      enum:
+                        - primary
+                        - prefer-standby
+                      type: string
+                    volumeSnapshot:
+                      description: VolumeSnapshot provides the configuration for the execution of volume snapshot backups.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations key-value pairs that will be added to .metadata.annotations snapshot resources.
+                          type: object
+                        className:
+                          description: |-
+                            ClassName specifies the Snapshot Class to be used for PG_DATA PersistentVolumeClaim.
+                            It is the default class for the other types if no specific class is present
+                          type: string
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels are key-value pairs that will be added to .metadata.labels snapshot resources.
+                          type: object
+                        online:
+                          default: true
+                          description: |-
+                            Whether the default type of backup with volume snapshots is
+                            online/hot (`true`, default) or offline/cold (`false`)
+                          type: boolean
+                        onlineConfiguration:
+                          default:
+                            immediateCheckpoint: false
+                            waitForArchive: true
+                          description: Configuration parameters to control the online/hot backup with volume snapshots
+                          properties:
+                            immediateCheckpoint:
+                              description: |-
+                                Control whether the I/O workload for the backup initial checkpoint will
+                                be limited, according to the `checkpoint_completion_target` setting on
+                                the PostgreSQL server. If set to true, an immediate checkpoint will be
+                                used, meaning PostgreSQL will complete the checkpoint as soon as
+                                possible. `false` by default.
+                              type: boolean
+                            waitForArchive:
+                              default: true
+                              description: |-
+                                If false, the function will return immediately after the backup is completed,
+                                without waiting for WAL to be archived.
+                                This behavior is only useful with backup software that independently monitors WAL archiving.
+                                Otherwise, WAL required to make the backup consistent might be missing and make the backup useless.
+                                By default, or when this parameter is true, pg_backup_stop will wait for WAL to be archived when archiving is
+                                enabled.
+                                On a standby, this means that it will wait only when archive_mode = always.
+                                If write activity on the primary is low, it may be useful to run pg_switch_wal on the primary in order to trigger
+                                an immediate segment switch.
+                              type: boolean
+                          type: object
+                        snapshotOwnerReference:
+                          default: none
+                          description: SnapshotOwnerReference indicates the type of owner reference the snapshot should have
+                          enum:
+                            - none
+                            - cluster
+                            - backup
+                          type: string
+                        tablespaceClassName:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            TablespaceClassName specifies the Snapshot Class to be used for the tablespaces.
+                            defaults to the PGDATA Snapshot Class, if set
+                          type: object
+                        walClassName:
+                          description: WalClassName specifies the Snapshot Class to be used for the PG_WAL PersistentVolumeClaim.
+                          type: string
+                      type: object
+                  type: object
+                bootstrap:
+                  description: Instructions to bootstrap this cluster
+                  properties:
+                    initdb:
+                      description: Bootstrap the cluster via initdb
+                      properties:
+                        builtinLocale:
+                          description: |-
+                            Specifies the locale name when the builtin provider is used.
+                            This option requires `localeProvider` to be set to `builtin`.
+                            Available from PostgreSQL 17.
+                          type: string
+                        dataChecksums:
+                          description: |-
+                            Whether the `-k` option should be passed to initdb,
+                            enabling checksums on data pages (default: `false`)
+                          type: boolean
+                        database:
+                          description: 'Name of the database used by the application. Default: `app`.'
+                          type: string
+                        encoding:
+                          description: The value to be passed as option `--encoding` for initdb (default:`UTF8`)
+                          type: string
+                        icuLocale:
+                          description: |-
+                            Specifies the ICU locale when the ICU provider is used.
+                            This option requires `localeProvider` to be set to `icu`.
+                            Available from PostgreSQL 15.
+                          type: string
+                        icuRules:
+                          description: |-
+                            Specifies additional collation rules to customize the behavior of the default collation.
+                            This option requires `localeProvider` to be set to `icu`.
+                            Available from PostgreSQL 16.
+                          type: string
+                        import:
+                          description: |-
+                            Bootstraps the new cluster by importing data from an existing PostgreSQL
+                            instance using logical backup (`pg_dump` and `pg_restore`)
+                          properties:
+                            databases:
+                              description: The databases to import
+                              items:
+                                type: string
+                              type: array
+                            pgDumpExtraOptions:
+                              description: |-
+                                List of custom options to pass to the `pg_dump` command.
+
+                                IMPORTANT: Use with caution. The operator does not validate these options,
+                                and certain flags may interfere with its intended functionality or design.
+                                You are responsible for ensuring that the provided options are compatible
+                                with your environment and desired behavior.
+                              items:
+                                type: string
+                              type: array
+                            pgRestoreDataOptions:
+                              description: |-
+                                Custom options to pass to the `pg_restore` command during the `data`
+                                section. This setting overrides the generic `pgRestoreExtraOptions` value.
+
+                                IMPORTANT: Use with caution. The operator does not validate these options,
+                                and certain flags may interfere with its intended functionality or design.
+                                You are responsible for ensuring that the provided options are compatible
+                                with your environment and desired behavior.
+                              items:
+                                type: string
+                              type: array
+                            pgRestoreExtraOptions:
+                              description: |-
+                                List of custom options to pass to the `pg_restore` command.
+
+                                IMPORTANT: Use with caution. The operator does not validate these options,
+                                and certain flags may interfere with its intended functionality or design.
+                                You are responsible for ensuring that the provided options are compatible
+                                with your environment and desired behavior.
+                              items:
+                                type: string
+                              type: array
+                            pgRestorePostdataOptions:
+                              description: |-
+                                Custom options to pass to the `pg_restore` command during the `post-data`
+                                section. This setting overrides the generic `pgRestoreExtraOptions` value.
+
+                                IMPORTANT: Use with caution. The operator does not validate these options,
+                                and certain flags may interfere with its intended functionality or design.
+                                You are responsible for ensuring that the provided options are compatible
+                                with your environment and desired behavior.
+                              items:
+                                type: string
+                              type: array
+                            pgRestorePredataOptions:
+                              description: |-
+                                Custom options to pass to the `pg_restore` command during the `pre-data`
+                                section. This setting overrides the generic `pgRestoreExtraOptions` value.
+
+                                IMPORTANT: Use with caution. The operator does not validate these options,
+                                and certain flags may interfere with its intended functionality or design.
+                                You are responsible for ensuring that the provided options are compatible
+                                with your environment and desired behavior.
+                              items:
+                                type: string
+                              type: array
+                            postImportApplicationSQL:
+                              description: |-
+                                List of SQL queries to be executed as a superuser in the application
+                                database right after is imported - to be used with extreme care
+                                (by default empty). Only available in microservice type.
+                              items:
+                                type: string
+                              type: array
+                            roles:
+                              description: The roles to import
+                              items:
+                                type: string
+                              type: array
+                            schemaOnly:
+                              description: |-
+                                When set to true, only the `pre-data` and `post-data` sections of
+                                `pg_restore` are invoked, avoiding data import. Default: `false`.
+                              type: boolean
+                            source:
+                              description: The source of the import
+                              properties:
+                                externalCluster:
+                                  description: The name of the externalCluster used for import
+                                  type: string
+                              required:
+                                - externalCluster
+                              type: object
+                            type:
+                              description: The import type. Can be `microservice` or `monolith`.
+                              enum:
+                                - microservice
+                                - monolith
+                              type: string
+                          required:
+                            - databases
+                            - source
+                            - type
+                          type: object
+                        locale:
+                          description: Sets the default collation order and character classification in the new database.
+                          type: string
+                        localeCType:
+                          description: The value to be passed as option `--lc-ctype` for initdb (default:`C`)
+                          type: string
+                        localeCollate:
+                          description: The value to be passed as option `--lc-collate` for initdb (default:`C`)
+                          type: string
+                        localeProvider:
+                          description: |-
+                            This option sets the locale provider for databases created in the new cluster.
+                            Available from PostgreSQL 16.
+                          type: string
+                        options:
+                          description: |-
+                            The list of options that must be passed to initdb when creating the cluster.
+
+                            Deprecated: This could lead to inconsistent configurations,
+                            please use the explicit provided parameters instead.
+                            If defined, explicit values will be ignored.
+                          items:
+                            type: string
+                          type: array
+                        owner:
+                          description: |-
+                            Name of the owner of the database in the instance to be used
+                            by applications. Defaults to the value of the `database` key.
+                          type: string
+                        postInitApplicationSQL:
+                          description: |-
+                            List of SQL queries to be executed as a superuser in the application
+                            database right after the cluster has been created - to be used with extreme care
+                            (by default empty)
+                          items:
+                            type: string
+                          type: array
+                        postInitApplicationSQLRefs:
+                          description: |-
+                            List of references to ConfigMaps or Secrets containing SQL files
+                            to be executed as a superuser in the application database right after
+                            the cluster has been created. The references are processed in a specific order:
+                            first, all Secrets are processed, followed by all ConfigMaps.
+                            Within each group, the processing order follows the sequence specified
+                            in their respective arrays.
+                            (by default empty)
+                          properties:
+                            configMapRefs:
+                              description: ConfigMapRefs holds a list of references to ConfigMaps
+                              items:
+                                description: |-
+                                  ConfigMapKeySelector contains enough information to let you locate
+                                  the key of a ConfigMap
+                                properties:
+                                  key:
+                                    description: The key to select
+                                    type: string
+                                  name:
+                                    description: Name of the referent.
+                                    type: string
+                                required:
+                                  - key
+                                  - name
+                                type: object
+                              type: array
+                            secretRefs:
+                              description: SecretRefs holds a list of references to Secrets
+                              items:
+                                description: |-
+                                  SecretKeySelector contains enough information to let you locate
+                                  the key of a Secret
+                                properties:
+                                  key:
+                                    description: The key to select
+                                    type: string
+                                  name:
+                                    description: Name of the referent.
+                                    type: string
+                                required:
+                                  - key
+                                  - name
+                                type: object
+                              type: array
+                          type: object
+                        postInitSQL:
+                          description: |-
+                            List of SQL queries to be executed as a superuser in the `postgres`
+                            database right after the cluster has been created - to be used with extreme care
+                            (by default empty)
+                          items:
+                            type: string
+                          type: array
+                        postInitSQLRefs:
+                          description: |-
+                            List of references to ConfigMaps or Secrets containing SQL files
+                            to be executed as a superuser in the `postgres` database right after
+                            the cluster has been created. The references are processed in a specific order:
+                            first, all Secrets are processed, followed by all ConfigMaps.
+                            Within each group, the processing order follows the sequence specified
+                            in their respective arrays.
+                            (by default empty)
+                          properties:
+                            configMapRefs:
+                              description: ConfigMapRefs holds a list of references to ConfigMaps
+                              items:
+                                description: |-
+                                  ConfigMapKeySelector contains enough information to let you locate
+                                  the key of a ConfigMap
+                                properties:
+                                  key:
+                                    description: The key to select
+                                    type: string
+                                  name:
+                                    description: Name of the referent.
+                                    type: string
+                                required:
+                                  - key
+                                  - name
+                                type: object
+                              type: array
+                            secretRefs:
+                              description: SecretRefs holds a list of references to Secrets
+                              items:
+                                description: |-
+                                  SecretKeySelector contains enough information to let you locate
+                                  the key of a Secret
+                                properties:
+                                  key:
+                                    description: The key to select
+                                    type: string
+                                  name:
+                                    description: Name of the referent.
+                                    type: string
+                                required:
+                                  - key
+                                  - name
+                                type: object
+                              type: array
+                          type: object
+                        postInitTemplateSQL:
+                          description: |-
+                            List of SQL queries to be executed as a superuser in the `template1`
+                            database right after the cluster has been created - to be used with extreme care
+                            (by default empty)
+                          items:
+                            type: string
+                          type: array
+                        postInitTemplateSQLRefs:
+                          description: |-
+                            List of references to ConfigMaps or Secrets containing SQL files
+                            to be executed as a superuser in the `template1` database right after
+                            the cluster has been created. The references are processed in a specific order:
+                            first, all Secrets are processed, followed by all ConfigMaps.
+                            Within each group, the processing order follows the sequence specified
+                            in their respective arrays.
+                            (by default empty)
+                          properties:
+                            configMapRefs:
+                              description: ConfigMapRefs holds a list of references to ConfigMaps
+                              items:
+                                description: |-
+                                  ConfigMapKeySelector contains enough information to let you locate
+                                  the key of a ConfigMap
+                                properties:
+                                  key:
+                                    description: The key to select
+                                    type: string
+                                  name:
+                                    description: Name of the referent.
+                                    type: string
+                                required:
+                                  - key
+                                  - name
+                                type: object
+                              type: array
+                            secretRefs:
+                              description: SecretRefs holds a list of references to Secrets
+                              items:
+                                description: |-
+                                  SecretKeySelector contains enough information to let you locate
+                                  the key of a Secret
+                                properties:
+                                  key:
+                                    description: The key to select
+                                    type: string
+                                  name:
+                                    description: Name of the referent.
+                                    type: string
+                                required:
+                                  - key
+                                  - name
+                                type: object
+                              type: array
+                          type: object
+                        secret:
+                          description: |-
+                            Name of the secret containing the initial credentials for the
+                            owner of the user database. If empty a new secret will be
+                            created from scratch
+                          properties:
+                            name:
+                              description: Name of the referent.
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        walSegmentSize:
+                          description: |-
+                            The value in megabytes (1 to 1024) to be passed to the `--wal-segsize`
+                            option for initdb (default: empty, resulting in PostgreSQL default: 16MB)
+                          maximum: 1024
+                          minimum: 1
+                          type: integer
+                      type: object
+                      x-kubernetes-validations:
+                        - message: builtinLocale is only available when localeProvider is set to `builtin`
+                          rule: '!has(self.builtinLocale) || self.localeProvider == ''builtin'''
+                        - message: icuLocale is only available when localeProvider is set to `icu`
+                          rule: '!has(self.icuLocale) || self.localeProvider == ''icu'''
+                        - message: icuRules is only available when localeProvider is set to `icu`
+                          rule: '!has(self.icuRules) || self.localeProvider == ''icu'''
+                    pg_basebackup:
+                      description: |-
+                        Bootstrap the cluster taking a physical backup of another compatible
+                        PostgreSQL instance
+                      properties:
+                        database:
+                          description: 'Name of the database used by the application. Default: `app`.'
+                          type: string
+                        owner:
+                          description: |-
+                            Name of the owner of the database in the instance to be used
+                            by applications. Defaults to the value of the `database` key.
+                          type: string
+                        secret:
+                          description: |-
+                            Name of the secret containing the initial credentials for the
+                            owner of the user database. If empty a new secret will be
+                            created from scratch
+                          properties:
+                            name:
+                              description: Name of the referent.
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        source:
+                          description: The name of the server of which we need to take a physical backup
+                          minLength: 1
+                          type: string
+                      required:
+                        - source
+                      type: object
+                    recovery:
+                      description: Bootstrap the cluster from a backup
+                      properties:
+                        backup:
+                          description: |-
+                            The backup object containing the physical base backup from which to
+                            initiate the recovery procedure.
+                            Mutually exclusive with `source` and `volumeSnapshots`.
+                          properties:
+                            endpointCA:
+                              description: |-
+                                EndpointCA store the CA bundle of the barman endpoint.
+                                Useful when using self-signed certificates to avoid
+                                errors with certificate issuer and barman-cloud-wal-archive.
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - key
+                                - name
+                              type: object
+                            name:
+                              description: Name of the referent.
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        database:
+                          description: 'Name of the database used by the application. Default: `app`.'
+                          type: string
+                        owner:
+                          description: |-
+                            Name of the owner of the database in the instance to be used
+                            by applications. Defaults to the value of the `database` key.
+                          type: string
+                        recoveryTarget:
+                          description: |-
+                            By default, the recovery process applies all the available
+                            WAL files in the archive (full recovery). However, you can also
+                            end the recovery as soon as a consistent state is reached or
+                            recover to a point-in-time (PITR) by specifying a `RecoveryTarget` object,
+                            as expected by PostgreSQL (i.e., timestamp, transaction Id, LSN, ...).
+                            More info: https://www.postgresql.org/docs/current/runtime-config-wal.html#RUNTIME-CONFIG-WAL-RECOVERY-TARGET
+                          properties:
+                            backupID:
+                              description: |-
+                                The ID of the backup from which to start the recovery process.
+                                If empty (default) the operator will automatically detect the backup
+                                based on targetTime or targetLSN if specified. Otherwise use the
+                                latest available backup in chronological order.
+                              type: string
+                            exclusive:
+                              description: |-
+                                Set the target to be exclusive. If omitted, defaults to false, so that
+                                in Postgres, `recovery_target_inclusive` will be true
+                              type: boolean
+                            targetImmediate:
+                              description: End recovery as soon as a consistent state is reached
+                              type: boolean
+                            targetLSN:
+                              description: The target LSN (Log Sequence Number)
+                              type: string
+                            targetName:
+                              description: |-
+                                The target name (to be previously created
+                                with `pg_create_restore_point`)
+                              type: string
+                            targetTLI:
+                              description: The target timeline ("latest" or a positive integer)
+                              type: string
+                            targetTime:
+                              description: |-
+                                The target time as a timestamp in RFC3339 format or PostgreSQL timestamp format.
+                                Timestamps without an explicit timezone are interpreted as UTC.
+                              type: string
+                            targetXID:
+                              description: The target transaction ID
+                              type: string
+                          type: object
+                        secret:
+                          description: |-
+                            Name of the secret containing the initial credentials for the
+                            owner of the user database. If empty a new secret will be
+                            created from scratch
+                          properties:
+                            name:
+                              description: Name of the referent.
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        source:
+                          description: |-
+                            The external cluster whose backup we will restore. This is also
+                            used as the name of the folder under which the backup is stored,
+                            so it must be set to the name of the source cluster
+                            Mutually exclusive with `backup`.
+                          type: string
+                        volumeSnapshots:
+                          description: |-
+                            The static PVC data source(s) from which to initiate the
+                            recovery procedure. Currently supporting `VolumeSnapshot`
+                            and `PersistentVolumeClaim` resources that map an existing
+                            PVC group, compatible with CloudNativePG, and taken with
+                            a cold backup copy on a fenced Postgres instance (limitation
+                            which will be removed in the future when online backup
+                            will be implemented).
+                            Mutually exclusive with `backup`.
+                          properties:
+                            storage:
+                              description: Configuration of the storage of the instances
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being referenced
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            tablespaceStorage:
+                              additionalProperties:
+                                description: |-
+                                  TypedLocalObjectReference contains enough information to let you locate the
+                                  typed referenced object inside the same namespace.
+                                properties:
+                                  apiGroup:
+                                    description: |-
+                                      APIGroup is the group for the resource being referenced.
+                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is required.
+                                    type: string
+                                  kind:
+                                    description: Kind is the type of resource being referenced
+                                    type: string
+                                  name:
+                                    description: Name is the name of resource being referenced
+                                    type: string
+                                required:
+                                  - kind
+                                  - name
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              description: Configuration of the storage for PostgreSQL tablespaces
+                              type: object
+                            walStorage:
+                              description: Configuration of the storage for PostgreSQL WAL (Write-Ahead Log)
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being referenced
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          required:
+                            - storage
+                          type: object
+                      type: object
+                  type: object
+                certificates:
+                  description: The configuration for the CA and related certificates
+                  properties:
+                    clientCASecret:
+                      description: |-
+                        The secret containing the Client CA certificate. If not defined, a new secret will be created
+                        with a self-signed CA and will be used to generate all the client certificates.<br />
+                        <br />
+                        Contains:<br />
+                        <br />
+                        - `ca.crt`: CA that should be used to validate the client certificates,
+                        used as `ssl_ca_file` of all the instances.<br />
+                        - `ca.key`: key used to generate client certificates, if ReplicationTLSSecret is provided,
+                        this can be omitted.<br />
+                      type: string
+                    replicationTLSSecret:
+                      description: |-
+                        The secret of type kubernetes.io/tls containing the client certificate to authenticate as
+                        the `streaming_replica` user.
+                        If not defined, ClientCASecret must provide also `ca.key`, and a new secret will be
+                        created using the provided CA.
+                      type: string
+                    serverAltDNSNames:
+                      description: The list of the server alternative DNS names to be added to the generated server TLS certificates, when required.
+                      items:
+                        type: string
+                      type: array
+                    serverCASecret:
+                      description: |-
+                        The secret containing the Server CA certificate. If not defined, a new secret will be created
+                        with a self-signed CA and will be used to generate the TLS certificate ServerTLSSecret.<br />
+                        <br />
+                        Contains:<br />
+                        <br />
+                        - `ca.crt`: CA that should be used to validate the server certificate,
+                        used as `sslrootcert` in client connection strings.<br />
+                        - `ca.key`: key used to generate Server SSL certs, if ServerTLSSecret is provided,
+                        this can be omitted.<br />
+                      type: string
+                    serverTLSSecret:
+                      description: |-
+                        The secret of type kubernetes.io/tls containing the server TLS certificate and key that will be set as
+                        `ssl_cert_file` and `ssl_key_file` so that clients can connect to postgres securely.
+                        If not defined, ServerCASecret must provide also `ca.key` and a new secret will be
+                        created using the provided CA.
+                      type: string
+                  type: object
+                description:
+                  description: Description of this PostgreSQL cluster
+                  type: string
+                enablePDB:
+                  default: true
+                  description: |-
+                    Manage the `PodDisruptionBudget` resources within the cluster. When
+                    configured as `true` (default setting), the pod disruption budgets
+                    will safeguard the primary node from being terminated. Conversely,
+                    setting it to `false` will result in the absence of any
+                    `PodDisruptionBudget` resource, permitting the shutdown of all nodes
+                    hosting the PostgreSQL cluster. This latter configuration is
+                    advisable for any PostgreSQL cluster employed for
+                    development/staging purposes.
+                  type: boolean
+                enableSuperuserAccess:
+                  default: false
+                  description: |-
+                    When this option is enabled, the operator will use the `SuperuserSecret`
+                    to update the `postgres` user password (if the secret is
+                    not present, the operator will automatically create one). When this
+                    option is disabled, the operator will ignore the `SuperuserSecret` content, delete
+                    it when automatically created, and then blank the password of the `postgres`
+                    user by setting it to `NULL`. Disabled by default.
+                  type: boolean
+                env:
+                  description: |-
+                    Env follows the Env format to pass environment variables
+                    to the pods created in the cluster
+                  items:
+                    description: EnvVar represents an environment variable present in a Container.
+                    properties:
+                      name:
+                        description: |-
+                          Name of the environment variable.
+                          May consist of any printable ASCII characters except '='.
+                        type: string
+                      value:
+                        description: |-
+                          Variable references $(VAR_NAME) are expanded
+                          using the previously defined environment variables in the container and
+                          any service environment variables. If a variable cannot be resolved,
+                          the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                          Escaped references will never be expanded, regardless of whether the variable
+                          exists or not.
+                          Defaults to "".
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value. Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fieldRef:
+                            description: |-
+                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified API version.
+                                type: string
+                            required:
+                              - fieldPath
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fileKeyRef:
+                            description: |-
+                              FileKeyRef selects a key of the env file.
+                              Requires the EnvFiles feature gate to be enabled.
+                            properties:
+                              key:
+                                description: |-
+                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                type: string
+                              optional:
+                                default: false
+                                description: |-
+                                  Specify whether the file or its key must be defined. If the file or key
+                                  does not exist, then the env var is not published.
+                                  If optional is set to true and the specified key does not exist,
+                                  the environment variable will not be set in the Pod's containers.
+
+                                  If optional is set to false and the specified key does not exist,
+                                  an error will be returned during Pod creation.
+                                type: boolean
+                              path:
+                                description: |-
+                                  The path within the volume from which to select the file.
+                                  Must be relative and may not contain the '..' path or start with '..'.
+                                type: string
+                              volumeName:
+                                description: The name of the volume mount containing the env file.
+                                type: string
+                            required:
+                              - key
+                              - path
+                              - volumeName
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          resourceFieldRef:
+                            description: |-
+                              Selects a resource of the container: only resources limits and requests
+                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes, optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                              - resource
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    required:
+                      - name
+                    type: object
+                  type: array
+                envFrom:
+                  description: |-
+                    EnvFrom follows the EnvFrom format to pass environment variables
+                    sources to the pods to be used by Env
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      prefix:
+                        description: |-
+                          Optional text to prepend to the name of each environment variable.
+                          May consist of any printable ASCII characters except '='.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  type: array
+                ephemeralVolumeSource:
+                  description: EphemeralVolumeSource allows the user to configure the source of ephemeral volumes.
+                  properties:
+                    volumeClaimTemplate:
+                      description: |-
+                        Will be used to create a stand-alone PVC to provision the volume.
+                        The pod in which this EphemeralVolumeSource is embedded will be the
+                        owner of the PVC, i.e. the PVC will be deleted together with the
+                        pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                        `<volume name>` is the name from the `PodSpec.Volumes` array
+                        entry. Pod validation will reject the pod if the concatenated name
+                        is not valid for a PVC (for example, too long).
+
+                        An existing PVC with that name that is not owned by the pod
+                        will *not* be used for the pod to avoid using an unrelated
+                        volume by mistake. Starting the pod is then blocked until
+                        the unrelated PVC is removed. If such a pre-created PVC is
+                        meant to be used by the pod, the PVC has to updated with an
+                        owner reference to the pod once the pod exists. Normally
+                        this should not be necessary, but it may be useful when
+                        manually reconstructing a broken cluster.
+
+                        This field is read-only and no changes will be made by Kubernetes
+                        to the PVC after it has been created.
+
+                        Required, must not be nil.
+                      properties:
+                        metadata:
+                          description: |-
+                            May contain labels and annotations that will be copied into the PVC
+                            when creating it. No other fields are allowed and will be rejected during
+                            validation.
+                          type: object
+                        spec:
+                          description: |-
+                            The specification for the PersistentVolumeClaim. The entire content is
+                            copied unchanged into the PVC that gets created from this
+                            template. The same fields as in a PersistentVolumeClaim
+                            are also valid here.
+                          properties:
+                            accessModes:
+                              description: |-
+                                accessModes contains the desired access modes the volume should have.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            dataSource:
+                              description: |-
+                                dataSource field can be used to specify either:
+                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                * An existing PVC (PersistentVolumeClaim)
+                                If the provisioner or an external controller can support the specified data source,
+                                it will create a new volume based on the contents of the specified data source.
+                                When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being referenced
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            dataSourceRef:
+                              description: |-
+                                dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                volume is desired. This may be any object from a non-empty API group (non
+                                core object) or a PersistentVolumeClaim object.
+                                When this field is specified, volume binding will only succeed if the type of
+                                the specified object matches some installed volume populator or dynamic
+                                provisioner.
+                                This field will replace the functionality of the dataSource field and as such
+                                if both fields are non-empty, they must have the same value. For backwards
+                                compatibility, when namespace isn't specified in dataSourceRef,
+                                both fields (dataSource and dataSourceRef) will be set to the same
+                                value automatically if one of them is empty and the other is non-empty.
+                                When namespace is specified in dataSourceRef,
+                                dataSource isn't set to the same value and must be empty.
+                                There are three important differences between dataSource and dataSourceRef:
+                                * While dataSource only allows two specific types of objects, dataSourceRef
+                                  allows any non-core object, as well as PersistentVolumeClaim objects.
+                                * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                  preserves all values, and generates an error if a disallowed value is
+                                  specified.
+                                * While dataSource only allows local objects, dataSourceRef allows objects
+                                  in any namespaces.
+                                (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being referenced
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace is the namespace of resource being referenced
+                                    Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                    (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                            resources:
+                              description: |-
+                                resources represents the minimum resources the volume should have.
+                                Users are allowed to specify resource requirements
+                                that are lower than previous value but must still be higher than capacity recorded in the
+                                status field of the claim.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            selector:
+                              description: selector is a label query over volumes to consider for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            storageClassName:
+                              description: |-
+                                storageClassName is the name of the StorageClass required by the claim.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                              type: string
+                            volumeAttributesClassName:
+                              description: |-
+                                volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                If specified, the CSI driver will create or update the volume with the attributes defined
+                                in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                it can be changed after the claim is created. An empty string or nil value indicates that no
+                                VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                this field can be reset to its previous value (including nil) to cancel the modification.
+                                If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                exists.
+                                More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                              type: string
+                            volumeMode:
+                              description: |-
+                                volumeMode defines what type of volume is required by the claim.
+                                Value of Filesystem is implied when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                      required:
+                        - spec
+                      type: object
+                  type: object
+                ephemeralVolumesSizeLimit:
+                  description: |-
+                    EphemeralVolumesSizeLimit allows the user to set the limits for the ephemeral
+                    volumes
+                  properties:
+                    shm:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: Shm is the size limit of the shared memory volume
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    temporaryData:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: TemporaryData is the size limit of the temporary data volume
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                externalClusters:
+                  description: The list of external clusters which are used in the configuration
+                  items:
+                    description: |-
+                      ExternalCluster represents the connection parameters to an
+                      external cluster which is used in the other sections of the configuration
+                    properties:
+                      barmanObjectStore:
+                        description: The configuration for the barman-cloud tool suite
+                        properties:
+                          azureCredentials:
+                            description: The credentials to use to upload data to Azure Blob Storage
+                            properties:
+                              connectionString:
+                                description: The connection string to be used
+                                properties:
+                                  key:
+                                    description: The key to select
+                                    type: string
+                                  name:
+                                    description: Name of the referent.
+                                    type: string
+                                required:
+                                  - key
+                                  - name
+                                type: object
+                              inheritFromAzureAD:
+                                description: Use the Azure AD based authentication without providing explicitly the keys.
+                                type: boolean
+                              storageAccount:
+                                description: The storage account where to upload data
+                                properties:
+                                  key:
+                                    description: The key to select
+                                    type: string
+                                  name:
+                                    description: Name of the referent.
+                                    type: string
+                                required:
+                                  - key
+                                  - name
+                                type: object
+                              storageKey:
+                                description: |-
+                                  The storage account key to be used in conjunction
+                                  with the storage account name
+                                properties:
+                                  key:
+                                    description: The key to select
+                                    type: string
+                                  name:
+                                    description: Name of the referent.
+                                    type: string
+                                required:
+                                  - key
+                                  - name
+                                type: object
+                              storageSasToken:
+                                description: |-
+                                  A shared-access-signature to be used in conjunction with
+                                  the storage account name
+                                properties:
+                                  key:
+                                    description: The key to select
+                                    type: string
+                                  name:
+                                    description: Name of the referent.
+                                    type: string
+                                required:
+                                  - key
+                                  - name
+                                type: object
+                              useDefaultAzureCredentials:
+                                description: |-
+                                  Use the default Azure authentication flow, which includes DefaultAzureCredential.
+                                  This allows authentication using environment variables and managed identities.
+                                type: boolean
+                            type: object
+                          data:
+                            description: |-
+                              The configuration to be used to backup the data files
+                              When not defined, base backups files will be stored uncompressed and may
+                              be unencrypted in the object store, according to the bucket default
+                              policy.
+                            properties:
+                              additionalCommandArgs:
+                                description: |-
+                                  AdditionalCommandArgs represents additional arguments that can be appended
+                                  to the 'barman-cloud-backup' command-line invocation. These arguments
+                                  provide flexibility to customize the backup process further according to
+                                  specific requirements or configurations.
+
+                                  Example:
+                                  In a scenario where specialized backup options are required, such as setting
+                                  a specific timeout or defining custom behavior, users can use this field
+                                  to specify additional command arguments.
+
+                                  Note:
+                                  It's essential to ensure that the provided arguments are valid and supported
+                                  by the 'barman-cloud-backup' command, to avoid potential errors or unintended
+                                  behavior during execution.
+                                items:
+                                  type: string
+                                type: array
+                              compression:
+                                description: |-
+                                  Compress a backup file (a tar file per tablespace) while streaming it
+                                  to the object store. Available options are empty string (no
+                                  compression, default), `gzip`, `bzip2`, and `snappy`.
+                                enum:
+                                  - bzip2
+                                  - gzip
+                                  - snappy
+                                type: string
+                              encryption:
+                                description: |-
+                                  Whenever to force the encryption of files (if the bucket is
+                                  not already configured for that).
+                                  Allowed options are empty string (use the bucket policy, default),
+                                  `AES256` and `aws:kms`
+                                enum:
+                                  - AES256
+                                  - aws:kms
+                                type: string
+                              immediateCheckpoint:
+                                description: |-
+                                  Control whether the I/O workload for the backup initial checkpoint will
+                                  be limited, according to the `checkpoint_completion_target` setting on
+                                  the PostgreSQL server. If set to true, an immediate checkpoint will be
+                                  used, meaning PostgreSQL will complete the checkpoint as soon as
+                                  possible. `false` by default.
+                                type: boolean
+                              jobs:
+                                description: |-
+                                  The number of parallel jobs to be used to upload the backup, defaults
+                                  to 2
+                                format: int32
+                                minimum: 1
+                                type: integer
+                            type: object
+                          destinationPath:
+                            description: |-
+                              The path where to store the backup (i.e. s3://bucket/path/to/folder)
+                              this path, with different destination folders, will be used for WALs
+                              and for data
+                            minLength: 1
+                            type: string
+                          endpointCA:
+                            description: |-
+                              EndpointCA store the CA bundle of the barman endpoint.
+                              Useful when using self-signed certificates to avoid
+                              errors with certificate issuer and barman-cloud-wal-archive
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                              - key
+                              - name
+                            type: object
+                          endpointURL:
+                            description: |-
+                              Endpoint to be used to upload data to the cloud,
+                              overriding the automatic endpoint discovery
+                            type: string
+                          googleCredentials:
+                            description: The credentials to use to upload data to Google Cloud Storage
+                            properties:
+                              applicationCredentials:
+                                description: The secret containing the Google Cloud Storage JSON file with the credentials
+                                properties:
+                                  key:
+                                    description: The key to select
+                                    type: string
+                                  name:
+                                    description: Name of the referent.
+                                    type: string
+                                required:
+                                  - key
+                                  - name
+                                type: object
+                              gkeEnvironment:
+                                description: |-
+                                  If set to true, will presume that it's running inside a GKE environment,
+                                  default to false.
+                                type: boolean
+                            type: object
+                          historyTags:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              HistoryTags is a list of key value pairs that will be passed to the
+                              Barman --history-tags option.
+                            type: object
+                          s3Credentials:
+                            description: The credentials to use to upload data to S3
+                            properties:
+                              accessKeyId:
+                                description: The reference to the access key id
+                                properties:
+                                  key:
+                                    description: The key to select
+                                    type: string
+                                  name:
+                                    description: Name of the referent.
+                                    type: string
+                                required:
+                                  - key
+                                  - name
+                                type: object
+                              inheritFromIAMRole:
+                                description: Use the role based authentication without providing explicitly the keys.
+                                type: boolean
+                              region:
+                                description: The reference to the secret containing the region name
+                                properties:
+                                  key:
+                                    description: The key to select
+                                    type: string
+                                  name:
+                                    description: Name of the referent.
+                                    type: string
+                                required:
+                                  - key
+                                  - name
+                                type: object
+                              secretAccessKey:
+                                description: The reference to the secret access key
+                                properties:
+                                  key:
+                                    description: The key to select
+                                    type: string
+                                  name:
+                                    description: Name of the referent.
+                                    type: string
+                                required:
+                                  - key
+                                  - name
+                                type: object
+                              sessionToken:
+                                description: The references to the session key
+                                properties:
+                                  key:
+                                    description: The key to select
+                                    type: string
+                                  name:
+                                    description: Name of the referent.
+                                    type: string
+                                required:
+                                  - key
+                                  - name
+                                type: object
+                            type: object
+                          serverName:
+                            description: |-
+                              The server name on S3, the cluster name is used if this
+                              parameter is omitted
+                            type: string
+                          tags:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Tags is a list of key value pairs that will be passed to the
+                              Barman --tags option.
+                            type: object
+                          wal:
+                            description: |-
+                              The configuration for the backup of the WAL stream.
+                              When not defined, WAL files will be stored uncompressed and may be
+                              unencrypted in the object store, according to the bucket default policy.
+                            properties:
+                              archiveAdditionalCommandArgs:
+                                description: |-
+                                  Additional arguments that can be appended to the 'barman-cloud-wal-archive'
+                                  command-line invocation. These arguments provide flexibility to customize
+                                  the WAL archive process further, according to specific requirements or configurations.
+
+                                  Example:
+                                  In a scenario where specialized backup options are required, such as setting
+                                  a specific timeout or defining custom behavior, users can use this field
+                                  to specify additional command arguments.
+
+                                  Note:
+                                  It's essential to ensure that the provided arguments are valid and supported
+                                  by the 'barman-cloud-wal-archive' command, to avoid potential errors or unintended
+                                  behavior during execution.
+                                items:
+                                  type: string
+                                type: array
+                              compression:
+                                description: |-
+                                  Compress a WAL file before sending it to the object store. Available
+                                  options are empty string (no compression, default), `gzip`, `bzip2`,
+                                  `lz4`, `snappy`, `xz`, and `zstd`.
+                                enum:
+                                  - bzip2
+                                  - gzip
+                                  - lz4
+                                  - snappy
+                                  - xz
+                                  - zstd
+                                type: string
+                              encryption:
+                                description: |-
+                                  Whenever to force the encryption of files (if the bucket is
+                                  not already configured for that).
+                                  Allowed options are empty string (use the bucket policy, default),
+                                  `AES256` and `aws:kms`
+                                enum:
+                                  - AES256
+                                  - aws:kms
+                                type: string
+                              maxParallel:
+                                description: |-
+                                  Number of WAL files to be either archived in parallel (when the
+                                  PostgreSQL instance is archiving to a backup object store) or
+                                  restored in parallel (when a PostgreSQL standby is fetching WAL
+                                  files from a recovery object store). If not specified, WAL files
+                                  will be processed one at a time. It accepts a positive integer as a
+                                  value - with 1 being the minimum accepted value.
+                                minimum: 1
+                                type: integer
+                              restoreAdditionalCommandArgs:
+                                description: |-
+                                  Additional arguments that can be appended to the 'barman-cloud-wal-restore'
+                                  command-line invocation. These arguments provide flexibility to customize
+                                  the WAL restore process further, according to specific requirements or configurations.
+
+                                  Example:
+                                  In a scenario where specialized backup options are required, such as setting
+                                  a specific timeout or defining custom behavior, users can use this field
+                                  to specify additional command arguments.
+
+                                  Note:
+                                  It's essential to ensure that the provided arguments are valid and supported
+                                  by the 'barman-cloud-wal-restore' command, to avoid potential errors or unintended
+                                  behavior during execution.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        required:
+                          - destinationPath
+                        type: object
+                      connectionParameters:
+                        additionalProperties:
+                          type: string
+                        description: The list of connection parameters, such as dbname, host, username, etc
+                        type: object
+                      name:
+                        description: The server name, required
+                        type: string
+                      password:
+                        description: |-
+                          The reference to the password to be used to connect to the server.
+                          If a password is provided, CloudNativePG creates a PostgreSQL
+                          passfile at `/controller/external/NAME/pass` (where "NAME" is the
+                          cluster's name). This passfile is automatically referenced in the
+                          connection string when establishing a connection to the remote
+                          PostgreSQL server from the current PostgreSQL `Cluster`. This ensures
+                          secure and efficient password management for external clusters.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be a valid secret key.
+                            type: string
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be defined
+                            type: boolean
+                        required:
+                          - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      plugin:
+                        description: |-
+                          The configuration of the plugin that is taking care
+                          of WAL archiving and backups for this external cluster
+                        properties:
+                          enabled:
+                            default: true
+                            description: Enabled is true if this plugin will be used
+                            type: boolean
+                          isWALArchiver:
+                            default: false
+                            description: |-
+                              Marks the plugin as the WAL archiver. At most one plugin can be
+                              designated as a WAL archiver. This cannot be enabled if the
+                              `.spec.backup.barmanObjectStore` configuration is present.
+                            type: boolean
+                          name:
+                            description: Name is the plugin name
+                            type: string
+                          parameters:
+                            additionalProperties:
+                              type: string
+                            description: Parameters is the configuration of the plugin
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      sslCert:
+                        description: |-
+                          The reference to an SSL certificate to be used to connect to this
+                          instance
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be a valid secret key.
+                            type: string
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be defined
+                            type: boolean
+                        required:
+                          - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      sslKey:
+                        description: |-
+                          The reference to an SSL private key to be used to connect to this
+                          instance
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be a valid secret key.
+                            type: string
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be defined
+                            type: boolean
+                        required:
+                          - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      sslRootCert:
+                        description: |-
+                          The reference to an SSL CA public key to be used to connect to this
+                          instance
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be a valid secret key.
+                            type: string
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be defined
+                            type: boolean
+                        required:
+                          - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                      - name
+                    type: object
+                  type: array
+                failoverDelay:
+                  default: 0
+                  description: |-
+                    The amount of time (in seconds) to wait before triggering a failover
+                    after the primary PostgreSQL instance in the cluster was detected
+                    to be unhealthy
+                  format: int32
+                  type: integer
+                imageCatalogRef:
+                  description: Defines the major PostgreSQL version we want to use within an ImageCatalog
+                  properties:
+                    apiGroup:
+                      description: |-
+                        APIGroup is the group for the resource being referenced.
+                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                        For any other third-party types, APIGroup is required.
+                      type: string
+                    kind:
+                      description: Kind is the type of resource being referenced
+                      type: string
+                    major:
+                      description: The major version of PostgreSQL we want to use from the ImageCatalog
+                      type: integer
+                    name:
+                      description: Name is the name of resource being referenced
+                      type: string
+                  required:
+                    - kind
+                    - major
+                    - name
+                  type: object
+                  x-kubernetes-map-type: atomic
+                  x-kubernetes-validations:
+                    - message: Only image catalogs are supported
+                      rule: self.kind == 'ImageCatalog' || self.kind == 'ClusterImageCatalog'
+                    - message: Only image catalogs are supported
+                      rule: self.apiGroup == 'postgresql.cnpg.io'
+                imageName:
+                  description: |-
+                    Name of the container image, supporting both tags (`<image>:<tag>`)
+                    and digests for deterministic and repeatable deployments
+                    (`<image>:<tag>@sha256:<digestValue>`)
+                  type: string
+                imagePullPolicy:
+                  description: |-
+                    Image pull policy.
+                    One of `Always`, `Never` or `IfNotPresent`.
+                    If not defined, it defaults to `IfNotPresent`.
+                    Cannot be updated.
+                    More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                  type: string
+                imagePullSecrets:
+                  description: The list of pull secrets to be used to pull the images
+                  items:
+                    description: |-
+                      LocalObjectReference contains enough information to let you locate a
+                      local object with a known type inside the same namespace
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                inheritedMetadata:
+                  description: Metadata that will be inherited by all objects related to the Cluster
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                instances:
+                  default: 1
+                  description: Number of instances required in the cluster
+                  minimum: 1
+                  type: integer
+                livenessProbeTimeout:
+                  description: |-
+                    LivenessProbeTimeout is the time (in seconds) that is allowed for a PostgreSQL instance
+                    to successfully respond to the liveness probe (default 30).
+                    The Liveness probe failure threshold is derived from this value using the formula:
+                    ceiling(livenessProbe / 10).
+                  format: int32
+                  type: integer
+                logLevel:
+                  default: info
+                  description: 'The instances'' log level, one of the following values: error, warning, info (default), debug, trace'
+                  enum:
+                    - error
+                    - warning
+                    - info
+                    - debug
+                    - trace
+                  type: string
+                managed:
+                  description: The configuration that is used by the portions of PostgreSQL that are managed by the instance manager
+                  properties:
+                    roles:
+                      description: Database roles managed by the `Cluster`
+                      items:
+                        description: |-
+                          RoleConfiguration is the representation, in Kubernetes, of a PostgreSQL role
+                          with the additional field Ensure specifying whether to ensure the presence or
+                          absence of the role in the database
+
+                          The defaults of the CREATE ROLE command are applied
+                          Reference: https://www.postgresql.org/docs/current/sql-createrole.html
+                        properties:
+                          bypassrls:
+                            description: |-
+                              Whether a role bypasses every row-level security (RLS) policy.
+                              Default is `false`.
+                            type: boolean
+                          comment:
+                            description: Description of the role
+                            type: string
+                          connectionLimit:
+                            default: -1
+                            description: |-
+                              If the role can log in, this specifies how many concurrent
+                              connections the role can make. `-1` (the default) means no limit.
+                            format: int64
+                            type: integer
+                          createdb:
+                            description: |-
+                              When set to `true`, the role being defined will be allowed to create
+                              new databases. Specifying `false` (default) will deny a role the
+                              ability to create databases.
+                            type: boolean
+                          createrole:
+                            description: |-
+                              Whether the role will be permitted to create, alter, drop, comment
+                              on, change the security label for, and grant or revoke membership in
+                              other roles. Default is `false`.
+                            type: boolean
+                          disablePassword:
+                            description: DisablePassword indicates that a role's password should be set to NULL in Postgres
+                            type: boolean
+                          ensure:
+                            default: present
+                            description: Ensure the role is `present` or `absent` - defaults to "present"
+                            enum:
+                              - present
+                              - absent
+                            type: string
+                          inRoles:
+                            description: |-
+                              List of one or more existing roles to which this role will be
+                              immediately added as a new member. Default empty.
+                            items:
+                              type: string
+                            type: array
+                          inherit:
+                            default: true
+                            description: |-
+                              Whether a role "inherits" the privileges of roles it is a member of.
+                              Defaults is `true`.
+                            type: boolean
+                          login:
+                            description: |-
+                              Whether the role is allowed to log in. A role having the `login`
+                              attribute can be thought of as a user. Roles without this attribute
+                              are useful for managing database privileges, but are not users in
+                              the usual sense of the word. Default is `false`.
+                            type: boolean
+                          name:
+                            description: Name of the role
+                            type: string
+                          passwordSecret:
+                            description: |-
+                              Secret containing the password of the role (if present)
+                              If null, the password will be ignored unless DisablePassword is set
+                            properties:
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          replication:
+                            description: |-
+                              Whether a role is a replication role. A role must have this
+                              attribute (or be a superuser) in order to be able to connect to the
+                              server in replication mode (physical or logical replication) and in
+                              order to be able to create or drop replication slots. A role having
+                              the `replication` attribute is a very highly privileged role, and
+                              should only be used on roles actually used for replication. Default
+                              is `false`.
+                            type: boolean
+                          superuser:
+                            description: |-
+                              Whether the role is a `superuser` who can override all access
+                              restrictions within the database - superuser status is dangerous and
+                              should be used only when really needed. You must yourself be a
+                              superuser to create a new superuser. Defaults is `false`.
+                            type: boolean
+                          validUntil:
+                            description: |-
+                              Date and time after which the role's password is no longer valid.
+                              When omitted, the password will never expire (default).
+                            format: date-time
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    services:
+                      description: Services roles managed by the `Cluster`
+                      properties:
+                        additional:
+                          description: Additional is a list of additional managed services specified by the user.
+                          items:
+                            description: |-
+                              ManagedService represents a specific service managed by the cluster.
+                              It includes the type of service and its associated template specification.
+                            properties:
+                              selectorType:
+                                description: |-
+                                  SelectorType specifies the type of selectors that the service will have.
+                                  Valid values are "rw", "r", and "ro", representing read-write, read, and read-only services.
+                                enum:
+                                  - rw
+                                  - r
+                                  - ro
+                                type: string
+                              serviceTemplate:
+                                description: ServiceTemplate is the template specification for the service.
+                                properties:
+                                  metadata:
+                                    description: |-
+                                      Standard object's metadata.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          Annotations is an unstructured key value map stored with a resource that may be
+                                          set by external tools to store and retrieve arbitrary metadata. They are not
+                                          queryable and should be preserved when modifying objects.
+                                          More info: http://kubernetes.io/docs/user-guide/annotations
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          Map of string keys and values that can be used to organize and categorize
+                                          (scope and select) objects. May match selectors of replication controllers
+                                          and services.
+                                          More info: http://kubernetes.io/docs/user-guide/labels
+                                        type: object
+                                      name:
+                                        description: The name of the resource. Only supported for certain types
+                                        type: string
+                                    type: object
+                                  spec:
+                                    description: |-
+                                      Specification of the desired behavior of the service.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                                    properties:
+                                      allocateLoadBalancerNodePorts:
+                                        description: |-
+                                          allocateLoadBalancerNodePorts defines if NodePorts will be automatically
+                                          allocated for services with type LoadBalancer.  Default is "true". It
+                                          may be set to "false" if the cluster load-balancer does not rely on
+                                          NodePorts.  If the caller requests specific NodePorts (by specifying a
+                                          value), those requests will be respected, regardless of this field.
+                                          This field may only be set for services with type LoadBalancer and will
+                                          be cleared if the type is changed to any other type.
+                                        type: boolean
+                                      clusterIP:
+                                        description: |-
+                                          clusterIP is the IP address of the service and is usually assigned
+                                          randomly. If an address is specified manually, is in-range (as per
+                                          system configuration), and is not in use, it will be allocated to the
+                                          service; otherwise creation of the service will fail. This field may not
+                                          be changed through updates unless the type field is also being changed
+                                          to ExternalName (which requires this field to be blank) or the type
+                                          field is being changed from ExternalName (in which case this field may
+                                          optionally be specified, as describe above).  Valid values are "None",
+                                          empty string (""), or a valid IP address. Setting this to "None" makes a
+                                          "headless service" (no virtual IP), which is useful when direct endpoint
+                                          connections are preferred and proxying is not required.  Only applies to
+                                          types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+                                          when creating a Service of type ExternalName, creation will fail. This
+                                          field will be wiped when updating a Service to type ExternalName.
+                                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                                        type: string
+                                      clusterIPs:
+                                        description: |-
+                                          ClusterIPs is a list of IP addresses assigned to this service, and are
+                                          usually assigned randomly.  If an address is specified manually, is
+                                          in-range (as per system configuration), and is not in use, it will be
+                                          allocated to the service; otherwise creation of the service will fail.
+                                          This field may not be changed through updates unless the type field is
+                                          also being changed to ExternalName (which requires this field to be
+                                          empty) or the type field is being changed from ExternalName (in which
+                                          case this field may optionally be specified, as describe above).  Valid
+                                          values are "None", empty string (""), or a valid IP address.  Setting
+                                          this to "None" makes a "headless service" (no virtual IP), which is
+                                          useful when direct endpoint connections are preferred and proxying is
+                                          not required.  Only applies to types ClusterIP, NodePort, and
+                                          LoadBalancer. If this field is specified when creating a Service of type
+                                          ExternalName, creation will fail. This field will be wiped when updating
+                                          a Service to type ExternalName.  If this field is not specified, it will
+                                          be initialized from the clusterIP field.  If this field is specified,
+                                          clients must ensure that clusterIPs[0] and clusterIP have the same
+                                          value.
+
+                                          This field may hold a maximum of two entries (dual-stack IPs, in either order).
+                                          These IPs must correspond to the values of the ipFamilies field. Both
+                                          clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+                                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      externalIPs:
+                                        description: |-
+                                          externalIPs is a list of IP addresses for which nodes in the cluster
+                                          will also accept traffic for this service.  These IPs are not managed by
+                                          Kubernetes.  The user is responsible for ensuring that traffic arrives
+                                          at a node with this IP.  A common example is external load-balancers
+                                          that are not part of the Kubernetes system.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      externalName:
+                                        description: |-
+                                          externalName is the external reference that discovery mechanisms will
+                                          return as an alias for this service (e.g. a DNS CNAME record). No
+                                          proxying will be involved.  Must be a lowercase RFC-1123 hostname
+                                          (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+                                        type: string
+                                      externalTrafficPolicy:
+                                        description: |-
+                                          externalTrafficPolicy describes how nodes distribute service traffic they
+                                          receive on one of the Service's "externally-facing" addresses (NodePorts,
+                                          ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure
+                                          the service in a way that assumes that external load balancers will take care
+                                          of balancing the service traffic between nodes, and so each node will deliver
+                                          traffic only to the node-local endpoints of the service, without masquerading
+                                          the client source IP. (Traffic mistakenly sent to a node with no endpoints will
+                                          be dropped.) The default value, "Cluster", uses the standard behavior of
+                                          routing to all endpoints evenly (possibly modified by topology and other
+                                          features). Note that traffic sent to an External IP or LoadBalancer IP from
+                                          within the cluster will always get "Cluster" semantics, but clients sending to
+                                          a NodePort from within the cluster may need to take traffic policy into account
+                                          when picking a node.
+                                        type: string
+                                      healthCheckNodePort:
+                                        description: |-
+                                          healthCheckNodePort specifies the healthcheck nodePort for the service.
+                                          This only applies when type is set to LoadBalancer and
+                                          externalTrafficPolicy is set to Local. If a value is specified, is
+                                          in-range, and is not in use, it will be used.  If not specified, a value
+                                          will be automatically allocated.  External systems (e.g. load-balancers)
+                                          can use this port to determine if a given node holds endpoints for this
+                                          service or not.  If this field is specified when creating a Service
+                                          which does not need it, creation will fail. This field will be wiped
+                                          when updating a Service to no longer need it (e.g. changing type).
+                                          This field cannot be updated once set.
+                                        format: int32
+                                        type: integer
+                                      internalTrafficPolicy:
+                                        description: |-
+                                          InternalTrafficPolicy describes how nodes distribute service traffic they
+                                          receive on the ClusterIP. If set to "Local", the proxy will assume that pods
+                                          only want to talk to endpoints of the service on the same node as the pod,
+                                          dropping the traffic if there are no local endpoints. The default value,
+                                          "Cluster", uses the standard behavior of routing to all endpoints evenly
+                                          (possibly modified by topology and other features).
+                                        type: string
+                                      ipFamilies:
+                                        description: |-
+                                          IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this
+                                          service. This field is usually assigned automatically based on cluster
+                                          configuration and the ipFamilyPolicy field. If this field is specified
+                                          manually, the requested family is available in the cluster,
+                                          and ipFamilyPolicy allows it, it will be used; otherwise creation of
+                                          the service will fail. This field is conditionally mutable: it allows
+                                          for adding or removing a secondary IP family, but it does not allow
+                                          changing the primary IP family of the Service. Valid values are "IPv4"
+                                          and "IPv6".  This field only applies to Services of types ClusterIP,
+                                          NodePort, and LoadBalancer, and does apply to "headless" services.
+                                          This field will be wiped when updating a Service to type ExternalName.
+
+                                          This field may hold a maximum of two entries (dual-stack families, in
+                                          either order).  These families must correspond to the values of the
+                                          clusterIPs field, if specified. Both clusterIPs and ipFamilies are
+                                          governed by the ipFamilyPolicy field.
+                                        items:
+                                          description: |-
+                                            IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                                            to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      ipFamilyPolicy:
+                                        description: |-
+                                          IPFamilyPolicy represents the dual-stack-ness requested or required by
+                                          this Service. If there is no value provided, then this field will be set
+                                          to SingleStack. Services can be "SingleStack" (a single IP family),
+                                          "PreferDualStack" (two IP families on dual-stack configured clusters or
+                                          a single IP family on single-stack clusters), or "RequireDualStack"
+                                          (two IP families on dual-stack configured clusters, otherwise fail). The
+                                          ipFamilies and clusterIPs fields depend on the value of this field. This
+                                          field will be wiped when updating a service to type ExternalName.
+                                        type: string
+                                      loadBalancerClass:
+                                        description: |-
+                                          loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                                          If specified, the value of this field must be a label-style identifier, with an optional prefix,
+                                          e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+                                          This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
+                                          balancer implementation is used, today this is typically done through the cloud provider integration,
+                                          but should apply for any default implementation. If set, it is assumed that a load balancer
+                                          implementation is watching for Services with a matching class. Any default load balancer
+                                          implementation (e.g. cloud providers) should ignore Services that set this field.
+                                          This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+                                          Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+                                        type: string
+                                      loadBalancerIP:
+                                        description: |-
+                                          Only applies to Service Type: LoadBalancer.
+                                          This feature depends on whether the underlying cloud-provider supports specifying
+                                          the loadBalancerIP when a load balancer is created.
+                                          This field will be ignored if the cloud-provider does not support the feature.
+                                          Deprecated: This field was under-specified and its meaning varies across implementations.
+                                          Using it is non-portable and it may not support dual-stack.
+                                          Users are encouraged to use implementation-specific annotations when available.
+                                        type: string
+                                      loadBalancerSourceRanges:
+                                        description: |-
+                                          If specified and supported by the platform, this will restrict traffic through the cloud-provider
+                                          load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+                                          cloud-provider does not support the feature."
+                                          More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      ports:
+                                        description: |-
+                                          The list of ports that are exposed by this service.
+                                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                                        items:
+                                          description: ServicePort contains information on service's port.
+                                          properties:
+                                            appProtocol:
+                                              description: |-
+                                                The application protocol for this port.
+                                                This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                                This field follows standard Kubernetes label syntax.
+                                                Valid values are either:
+
+                                                * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                                RFC-6335 and https://www.iana.org/assignments/service-names).
+
+                                                * Kubernetes-defined prefixed names:
+                                                  * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                                                  * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                                                  * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+
+                                                * Other protocols should use implementation-defined prefixed names such as
+                                                mycompany.com/my-custom-protocol.
+                                              type: string
+                                            name:
+                                              description: |-
+                                                The name of this port within the service. This must be a DNS_LABEL.
+                                                All ports within a ServiceSpec must have unique names. When considering
+                                                the endpoints for a Service, this must match the 'name' field in the
+                                                EndpointPort.
+                                                Optional if only one ServicePort is defined on this service.
+                                              type: string
+                                            nodePort:
+                                              description: |-
+                                                The port on each node on which this service is exposed when type is
+                                                NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                                                specified, in-range, and not in use it will be used, otherwise the
+                                                operation will fail.  If not specified, a port will be allocated if this
+                                                Service requires one.  If this field is specified when creating a
+                                                Service which does not need it, creation will fail. This field will be
+                                                wiped when updating a Service to no longer need it (e.g. changing type
+                                                from NodePort to ClusterIP).
+                                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+                                              format: int32
+                                              type: integer
+                                            port:
+                                              description: The port that will be exposed by this service.
+                                              format: int32
+                                              type: integer
+                                            protocol:
+                                              default: TCP
+                                              description: |-
+                                                The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                                Default is TCP.
+                                              type: string
+                                            targetPort:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              description: |-
+                                                Number or name of the port to access on the pods targeted by the service.
+                                                Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                If this is a string, it will be looked up as a named port in the
+                                                target Pod's container ports. If this is not specified, the value
+                                                of the 'port' field is used (an identity map).
+                                                This field is ignored for services with clusterIP=None, and should be
+                                                omitted or set equal to the 'port' field.
+                                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                            - port
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - port
+                                          - protocol
+                                        x-kubernetes-list-type: map
+                                      publishNotReadyAddresses:
+                                        description: |-
+                                          publishNotReadyAddresses indicates that any agent which deals with endpoints for this
+                                          Service should disregard any indications of ready/not-ready.
+                                          The primary use case for setting this field is for a StatefulSet's Headless Service to
+                                          propagate SRV DNS records for its Pods for the purpose of peer discovery.
+                                          The Kubernetes controllers that generate Endpoints and EndpointSlice resources for
+                                          Services interpret this to mean that all endpoints are considered "ready" even if the
+                                          Pods themselves are not. Agents which consume only Kubernetes generated endpoints
+                                          through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                                        type: boolean
+                                      selector:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          Route service traffic to pods with label keys and values matching this
+                                          selector. If empty or not present, the service is assumed to have an
+                                          external process managing its endpoints, which Kubernetes will not
+                                          modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+                                          Ignored if type is ExternalName.
+                                          More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      sessionAffinity:
+                                        description: |-
+                                          Supports "ClientIP" and "None". Used to maintain session affinity.
+                                          Enable client IP based session affinity.
+                                          Must be ClientIP or None.
+                                          Defaults to None.
+                                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                                        type: string
+                                      sessionAffinityConfig:
+                                        description: sessionAffinityConfig contains the configurations of session affinity.
+                                        properties:
+                                          clientIP:
+                                            description: clientIP contains the configurations of Client IP based session affinity.
+                                            properties:
+                                              timeoutSeconds:
+                                                description: |-
+                                                  timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                                                  The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                                                  Default value is 10800(for 3 hours).
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                        type: object
+                                      trafficDistribution:
+                                        description: |-
+                                          TrafficDistribution offers a way to express preferences for how traffic
+                                          is distributed to Service endpoints. Implementations can use this field
+                                          as a hint, but are not required to guarantee strict adherence. If the
+                                          field is not set, the implementation will apply its default routing
+                                          strategy. If set to "PreferClose", implementations should prioritize
+                                          endpoints that are in the same zone.
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type determines how the Service is exposed. Defaults to ClusterIP. Valid
+                                          options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+                                          "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                                          to endpoints. Endpoints are determined by the selector or if that is not
+                                          specified, by manual construction of an Endpoints object or
+                                          EndpointSlice objects. If clusterIP is "None", no virtual IP is
+                                          allocated and the endpoints are published as a set of endpoints rather
+                                          than a virtual IP.
+                                          "NodePort" builds on ClusterIP and allocates a port on every node which
+                                          routes to the same endpoints as the clusterIP.
+                                          "LoadBalancer" builds on NodePort and creates an external load-balancer
+                                          (if supported in the current cloud) which routes to the same endpoints
+                                          as the clusterIP.
+                                          "ExternalName" aliases this service to the specified externalName.
+                                          Several other fields do not apply to ExternalName services.
+                                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+                                        type: string
+                                    type: object
+                                type: object
+                              updateStrategy:
+                                default: patch
+                                description: UpdateStrategy describes how the service differences should be reconciled
+                                enum:
+                                  - patch
+                                  - replace
+                                type: string
+                            required:
+                              - selectorType
+                              - serviceTemplate
+                            type: object
+                          type: array
+                        disabledDefaultServices:
+                          description: |-
+                            DisabledDefaultServices is a list of service types that are disabled by default.
+                            Valid values are "r", and "ro", representing read, and read-only services.
+                          items:
+                            description: |-
+                              ServiceSelectorType describes a valid value for generating the service selectors.
+                              It indicates which type of service the selector applies to, such as read-write, read, or read-only
+                            enum:
+                              - rw
+                              - r
+                              - ro
+                            type: string
+                          type: array
+                      type: object
+                  type: object
+                maxSyncReplicas:
+                  default: 0
+                  description: |-
+                    The target value for the synchronous replication quorum, that can be
+                    decreased if the number of ready standbys is lower than this.
+                    Undefined or 0 disable synchronous replication.
+                  minimum: 0
+                  type: integer
+                minSyncReplicas:
+                  default: 0
+                  description: |-
+                    Minimum number of instances required in synchronous replication with the
+                    primary. Undefined or 0 allow writes to complete when no standby is
+                    available.
+                  minimum: 0
+                  type: integer
+                monitoring:
+                  description: The configuration of the monitoring infrastructure of this cluster
+                  properties:
+                    customQueriesConfigMap:
+                      description: The list of config maps containing the custom queries
+                      items:
+                        description: |-
+                          ConfigMapKeySelector contains enough information to let you locate
+                          the key of a ConfigMap
+                        properties:
+                          key:
+                            description: The key to select
+                            type: string
+                          name:
+                            description: Name of the referent.
+                            type: string
+                        required:
+                          - key
+                          - name
+                        type: object
+                      type: array
+                    customQueriesSecret:
+                      description: The list of secrets containing the custom queries
+                      items:
+                        description: |-
+                          SecretKeySelector contains enough information to let you locate
+                          the key of a Secret
+                        properties:
+                          key:
+                            description: The key to select
+                            type: string
+                          name:
+                            description: Name of the referent.
+                            type: string
+                        required:
+                          - key
+                          - name
+                        type: object
+                      type: array
+                    disableDefaultQueries:
+                      default: false
+                      description: |-
+                        Whether the default queries should be injected.
+                        Set it to `true` if you don't want to inject default queries into the cluster.
+                        Default: false.
+                      type: boolean
+                    enablePodMonitor:
+                      default: false
+                      description: |-
+                        Enable or disable the `PodMonitor`
+
+                        Deprecated: This feature will be removed in an upcoming release. If
+                        you need this functionality, you can create a PodMonitor manually.
+                      type: boolean
+                    metricsQueriesTTL:
+                      description: |-
+                        The interval during which metrics computed from queries are considered current.
+                        Once it is exceeded, a new scrape will trigger a rerun
+                        of the queries.
+                        If not set, defaults to 30 seconds, in line with Prometheus scraping defaults.
+                        Setting this to zero disables the caching mechanism and can cause heavy load on the PostgreSQL server.
+                      type: string
+                    podMonitorMetricRelabelings:
+                      description: |-
+                        The list of metric relabelings for the `PodMonitor`. Applied to samples before ingestion.
+
+                        Deprecated: This feature will be removed in an upcoming release. If
+                        you need this functionality, you can create a PodMonitor manually.
+                      items:
+                        description: |-
+                          RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                          scraped samples and remote write samples.
+
+                          More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                        properties:
+                          action:
+                            default: replace
+                            description: |-
+                              action to perform based on the regex matching.
+
+                              `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                              `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                              Default: "Replace"
+                            enum:
+                              - replace
+                              - Replace
+                              - keep
+                              - Keep
+                              - drop
+                              - Drop
+                              - hashmod
+                              - HashMod
+                              - labelmap
+                              - LabelMap
+                              - labeldrop
+                              - LabelDrop
+                              - labelkeep
+                              - LabelKeep
+                              - lowercase
+                              - Lowercase
+                              - uppercase
+                              - Uppercase
+                              - keepequal
+                              - KeepEqual
+                              - dropequal
+                              - DropEqual
+                            type: string
+                          modulus:
+                            description: |-
+                              modulus to take of the hash of the source label values.
+
+                              Only applicable when the action is `HashMod`.
+                            format: int64
+                            type: integer
+                          regex:
+                            description: regex defines the regular expression against which the extracted value is matched.
+                            type: string
+                          replacement:
+                            description: |-
+                              replacement value against which a Replace action is performed if the
+                              regular expression matches.
+
+                              Regex capture groups are available.
+                            type: string
+                          separator:
+                            description: separator defines the string between concatenated SourceLabels.
+                            type: string
+                          sourceLabels:
+                            description: |-
+                              sourceLabels defines the source labels select values from existing labels. Their content is
+                              concatenated using the configured Separator and matched against the
+                              configured regular expression.
+                            items:
+                              description: |-
+                                LabelName is a valid Prometheus label name.
+                                For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                                For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
+                              type: string
+                            type: array
+                          targetLabel:
+                            description: |-
+                              targetLabel defines the label to which the resulting string is written in a replacement.
+
+                              It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                              `KeepEqual` and `DropEqual` actions.
+
+                              Regex capture groups are available.
+                            type: string
+                        type: object
+                      type: array
+                    podMonitorRelabelings:
+                      description: |-
+                        The list of relabelings for the `PodMonitor`. Applied to samples before scraping.
+
+                        Deprecated: This feature will be removed in an upcoming release. If
+                        you need this functionality, you can create a PodMonitor manually.
+                      items:
+                        description: |-
+                          RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                          scraped samples and remote write samples.
+
+                          More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                        properties:
+                          action:
+                            default: replace
+                            description: |-
+                              action to perform based on the regex matching.
+
+                              `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                              `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                              Default: "Replace"
+                            enum:
+                              - replace
+                              - Replace
+                              - keep
+                              - Keep
+                              - drop
+                              - Drop
+                              - hashmod
+                              - HashMod
+                              - labelmap
+                              - LabelMap
+                              - labeldrop
+                              - LabelDrop
+                              - labelkeep
+                              - LabelKeep
+                              - lowercase
+                              - Lowercase
+                              - uppercase
+                              - Uppercase
+                              - keepequal
+                              - KeepEqual
+                              - dropequal
+                              - DropEqual
+                            type: string
+                          modulus:
+                            description: |-
+                              modulus to take of the hash of the source label values.
+
+                              Only applicable when the action is `HashMod`.
+                            format: int64
+                            type: integer
+                          regex:
+                            description: regex defines the regular expression against which the extracted value is matched.
+                            type: string
+                          replacement:
+                            description: |-
+                              replacement value against which a Replace action is performed if the
+                              regular expression matches.
+
+                              Regex capture groups are available.
+                            type: string
+                          separator:
+                            description: separator defines the string between concatenated SourceLabels.
+                            type: string
+                          sourceLabels:
+                            description: |-
+                              sourceLabels defines the source labels select values from existing labels. Their content is
+                              concatenated using the configured Separator and matched against the
+                              configured regular expression.
+                            items:
+                              description: |-
+                                LabelName is a valid Prometheus label name.
+                                For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                                For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
+                              type: string
+                            type: array
+                          targetLabel:
+                            description: |-
+                              targetLabel defines the label to which the resulting string is written in a replacement.
+
+                              It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                              `KeepEqual` and `DropEqual` actions.
+
+                              Regex capture groups are available.
+                            type: string
+                        type: object
+                      type: array
+                    tls:
+                      description: |-
+                        Configure TLS communication for the metrics endpoint.
+                        Changing tls.enabled option will force a rollout of all instances.
+                      properties:
+                        enabled:
+                          default: false
+                          description: |-
+                            Enable TLS for the monitoring endpoint.
+                            Changing this option will force a rollout of all instances.
+                          type: boolean
+                      type: object
+                  type: object
+                nodeMaintenanceWindow:
+                  description: Define a maintenance window for the Kubernetes nodes
+                  properties:
+                    inProgress:
+                      default: false
+                      description: Is there a node maintenance activity in progress?
+                      type: boolean
+                    reusePVC:
+                      default: true
+                      description: |-
+                        Reuse the existing PVC (wait for the node to come
+                        up again) or not (recreate it elsewhere - when `instances` >1)
+                      type: boolean
+                  type: object
+                plugins:
+                  description: |-
+                    The plugins configuration, containing
+                    any plugin to be loaded with the corresponding configuration
+                  items:
+                    description: |-
+                      PluginConfiguration specifies a plugin that need to be loaded for this
+                      cluster to be reconciled
+                    properties:
+                      enabled:
+                        default: true
+                        description: Enabled is true if this plugin will be used
+                        type: boolean
+                      isWALArchiver:
+                        default: false
+                        description: |-
+                          Marks the plugin as the WAL archiver. At most one plugin can be
+                          designated as a WAL archiver. This cannot be enabled if the
+                          `.spec.backup.barmanObjectStore` configuration is present.
+                        type: boolean
+                      name:
+                        description: Name is the plugin name
+                        type: string
+                      parameters:
+                        additionalProperties:
+                          type: string
+                        description: Parameters is the configuration of the plugin
+                        type: object
+                    required:
+                      - name
+                    type: object
+                  type: array
+                podSecurityContext:
+                  description: |-
+                    Override the PodSecurityContext applied to every Pod of the cluster.
+                    When set, this overrides the operator's default PodSecurityContext for the cluster.
+                    If omitted, the operator defaults are used.
+                    This field doesn't have any effect if SecurityContextConstraints are present.
+                  properties:
+                    appArmorProfile:
+                      description: |-
+                        appArmorProfile is the AppArmor options to use by the containers in this pod.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: |-
+                            localhostProfile indicates a profile loaded on the node that should be used.
+                            The profile must be preconfigured on the node to work.
+                            Must match the loaded name of the profile.
+                            Must be set if and only if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of AppArmor profile will be applied.
+                            Valid options are:
+                              Localhost - a profile pre-loaded on the node.
+                              RuntimeDefault - the container runtime's default profile.
+                              Unconfined - no AppArmor enforcement.
+                          type: string
+                      required:
+                        - type
+                      type: object
+                    fsGroup:
+                      description: |-
+                        A special supplemental group that applies to all containers in a pod.
+                        Some volume types allow the Kubelet to change the ownership of that volume
+                        to be owned by the pod:
+
+                        1. The owning GID will be the FSGroup
+                        2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                        3. The permission bits are OR'd with rw-rw----
+
+                        If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    fsGroupChangePolicy:
+                      description: |-
+                        fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                        before being exposed inside Pod. This field will only apply to
+                        volume types which support fsGroup based ownership(and permissions).
+                        It will have no effect on ephemeral volume types such as: secret, configmaps
+                        and emptydir.
+                        Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      type: string
+                    runAsGroup:
+                      description: |-
+                        The GID to run the entrypoint of the container process.
+                        Uses runtime default if unset.
+                        May also be set in SecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence
+                        for that container.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: |-
+                        Indicates that the container must run as a non-root user.
+                        If true, the Kubelet will validate the image at runtime to ensure that it
+                        does not run as UID 0 (root) and fail to start the container if it does.
+                        If unset or false, no such validation will be performed.
+                        May also be set in SecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: |-
+                        The UID to run the entrypoint of the container process.
+                        Defaults to user specified in image metadata if unspecified.
+                        May also be set in SecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence
+                        for that container.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    seLinuxChangePolicy:
+                      description: |-
+                        seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                        It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                        Valid values are "MountOption" and "Recursive".
+
+                        "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                        This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                        "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                        This requires all Pods that share the same volume to use the same SELinux label.
+                        It is not possible to share the same volume among privileged and unprivileged Pods.
+                        Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                        whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                        CSIDriver instance. Other volumes are always re-labelled recursively.
+                        "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                        If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                        If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                        and "Recursive" for all other volumes.
+
+                        This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                        All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      type: string
+                    seLinuxOptions:
+                      description: |-
+                        The SELinux context to be applied to all containers.
+                        If unspecified, the container runtime will allocate a random SELinux context for each
+                        container.  May also be set in SecurityContext.  If set in
+                        both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence for that container.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: |-
+                        The seccomp options to use by the containers in this pod.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: |-
+                            localhostProfile indicates a profile defined in a file on the node should be used.
+                            The profile must be preconfigured on the node to work.
+                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                            Must be set if type is "Localhost". Must NOT be set for any other type.
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied.
+                            Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used.
+                            RuntimeDefault - the container runtime default profile should be used.
+                            Unconfined - no profile should be applied.
+                          type: string
+                      required:
+                        - type
+                      type: object
+                    supplementalGroups:
+                      description: |-
+                        A list of groups applied to the first process run in each container, in
+                        addition to the container's primary GID and fsGroup (if specified).  If
+                        the SupplementalGroupsPolicy feature is enabled, the
+                        supplementalGroupsPolicy field determines whether these are in addition
+                        to or instead of any group memberships defined in the container image.
+                        If unspecified, no additional groups are added, though group memberships
+                        defined in the container image may still be used, depending on the
+                        supplementalGroupsPolicy field.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    supplementalGroupsPolicy:
+                      description: |-
+                        Defines how supplemental groups of the first container processes are calculated.
+                        Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                        (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                        and the container runtime must implement support for this feature.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      type: string
+                    sysctls:
+                      description: |-
+                        Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                        sysctls (by the container runtime) might fail to launch.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      items:
+                        description: Sysctl defines a kernel parameter to be set
+                        properties:
+                          name:
+                            description: Name of a property to set
+                            type: string
+                          value:
+                            description: Value of a property to set
+                            type: string
+                        required:
+                          - name
+                          - value
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    windowsOptions:
+                      description: |-
+                        The Windows specific settings applied to all containers.
+                        If unspecified, the options within a container's SecurityContext will be used.
+                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is linux.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: |-
+                            GMSACredentialSpec is where the GMSA admission webhook
+                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                            GMSA credential spec named by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: |-
+                            HostProcess determines if a container should be run as a 'Host Process' container.
+                            All of a Pod's containers must have the same effective HostProcess value
+                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                            In addition, if HostProcess is true then HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: |-
+                            The UserName in Windows to run the entrypoint of the container process.
+                            Defaults to the user specified in image metadata if unspecified.
+                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                podSelectorRefs:
+                  description: |-
+                    PodSelectorRefs defines named pod label selectors that can be referenced
+                    in pg_hba rules using the ${podselector:NAME} syntax in the address field.
+                    The operator resolves matching pod IPs and the instance manager expands
+                    pg_hba lines accordingly. Only pods in the Cluster's own namespace are considered.
+                  items:
+                    description: |-
+                      PodSelectorRef defines a named pod label selector for use in pg_hba rules.
+                      Pods matching the selector in the Cluster's namespace will have their IPs
+                      resolved and made available for pg_hba address expansion via the
+                      `${podselector:NAME}` syntax.
+                    properties:
+                      name:
+                        description: |-
+                          Name is the identifier used to reference this selector in pg_hba rules
+                          via the ${podselector:NAME} syntax in the address field.
+                        minLength: 1
+                        pattern: ^[a-z]([a-z0-9_-]*[a-z0-9])?$
+                        type: string
+                      selector:
+                        description: |-
+                          Selector is a label selector that identifies the pods whose IPs
+                          should be resolved. Only pods in the Cluster's namespace are considered.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                      - name
+                      - selector
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                postgresGID:
+                  default: 26
+                  description: The GID of the `postgres` user inside the image, defaults to `26`
+                  format: int64
+                  type: integer
+                postgresUID:
+                  default: 26
+                  description: The UID of the `postgres` user inside the image, defaults to `26`
+                  format: int64
+                  type: integer
+                postgresql:
+                  description: Configuration of the PostgreSQL server
+                  properties:
+                    enableAlterSystem:
+                      description: |-
+                        If this parameter is true, the user will be able to invoke `ALTER SYSTEM`
+                        on this CloudNativePG Cluster.
+                        This should only be used for debugging and troubleshooting.
+                        Defaults to false.
+                      type: boolean
+                    extensions:
+                      description: The configuration of the extensions to be added
+                      items:
+                        description: |-
+                          ExtensionConfiguration is the configuration used to add
+                          PostgreSQL extensions to the Cluster.
+                        properties:
+                          bin_path:
+                            description: |-
+                              A list of directories within the image to be appended to the
+                              PostgreSQL process's `PATH` environment variable.
+                            items:
+                              type: string
+                            type: array
+                          dynamic_library_path:
+                            description: |-
+                              The list of directories inside the image which should be added to dynamic_library_path.
+                              If not defined, defaults to "/lib".
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: |-
+                              Env is a list of custom environment variables to be set in the
+                              PostgreSQL process for this extension. It is the responsibility of the
+                              cluster administrator to ensure the variables are correct for the
+                              specific extension. Note that changes to these variables require
+                              a manual cluster restart to take effect.
+                            items:
+                              description: |-
+                                ExtensionEnvVar defines an environment variable for a specific extension
+                                image volume.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable to be injected into the
+                                    PostgreSQL process.
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value of the environment variable. CloudNativePG performs a direct
+                                    replacement of this value, with support for placeholder expansion.
+                                    The ${`image_root`} placeholder resolves to the absolute mount path
+                                    of the extension's volume (e.g., `/extensions/my-extension`). This
+                                    is particularly useful for allowing applications or libraries to
+                                    locate specific directories within the mounted image.
+                                    Unrecognized placeholders are rejected. To include a literal ${...}
+                                    in the value, escape it as $${...}.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
+                          extension_control_path:
+                            description: |-
+                              The list of directories inside the image which should be added to extension_control_path.
+                              If not defined, defaults to "/share".
+                            items:
+                              type: string
+                            type: array
+                          image:
+                            description: The image containing the extension.
+                            properties:
+                              pullPolicy:
+                                description: |-
+                                  Policy for pulling OCI objects. Possible values are:
+                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                type: string
+                              reference:
+                                description: |-
+                                  Required: Image or artifact reference to be used.
+                                  Behaves in the same way as pod.spec.containers[*].image.
+                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                            type: object
+                          ld_library_path:
+                            description: The list of directories inside the image which should be added to ld_library_path.
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            description: The name of the extension, required
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    ldap:
+                      description: Options to specify LDAP configuration
+                      properties:
+                        bindAsAuth:
+                          description: Bind as authentication configuration
+                          properties:
+                            prefix:
+                              description: Prefix for the bind authentication option
+                              type: string
+                            suffix:
+                              description: Suffix for the bind authentication option
+                              type: string
+                          type: object
+                        bindSearchAuth:
+                          description: Bind+Search authentication configuration
+                          properties:
+                            baseDN:
+                              description: Root DN to begin the user search
+                              type: string
+                            bindDN:
+                              description: DN of the user to bind to the directory
+                              type: string
+                            bindPassword:
+                              description: Secret with the password for the user to bind to the directory
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            searchAttribute:
+                              description: Attribute to match against the username
+                              type: string
+                            searchFilter:
+                              description: Search filter to use when doing the search+bind authentication
+                              type: string
+                          type: object
+                        port:
+                          description: LDAP server port
+                          type: integer
+                        scheme:
+                          description: LDAP schema to be used, possible options are `ldap` and `ldaps`
+                          enum:
+                            - ldap
+                            - ldaps
+                          type: string
+                        server:
+                          description: LDAP hostname or IP address
+                          type: string
+                        tls:
+                          description: Set to 'true' to enable LDAP over TLS. 'false' is default
+                          type: boolean
+                      type: object
+                    parameters:
+                      additionalProperties:
+                        type: string
+                      description: PostgreSQL configuration options (postgresql.conf)
+                      type: object
+                    pg_hba:
+                      description: |-
+                        PostgreSQL Host Based Authentication rules (lines to be appended
+                        to the pg_hba.conf file).
+                        Use the ${podselector:NAME} syntax to reference a pod selector;
+                        the rule will be expanded for each Pod IP matching that selector.
+                      items:
+                        type: string
+                      type: array
+                    pg_ident:
+                      description: |-
+                        PostgreSQL User Name Maps rules (lines to be appended
+                        to the pg_ident.conf file)
+                      items:
+                        type: string
+                      type: array
+                    promotionTimeout:
+                      description: |-
+                        Specifies the maximum number of seconds to wait when promoting an instance to primary.
+                        Default value is 40000000, greater than one year in seconds,
+                        big enough to simulate an infinite timeout
+                      format: int32
+                      type: integer
+                    shared_preload_libraries:
+                      description: Lists of shared preload libraries to add to the default ones
+                      items:
+                        type: string
+                      type: array
+                    syncReplicaElectionConstraint:
+                      description: |-
+                        Requirements to be met by sync replicas. This will affect how the "synchronous_standby_names" parameter will be
+                        set up.
+                      properties:
+                        enabled:
+                          description: This flag enables the constraints for sync replicas
+                          type: boolean
+                        nodeLabelsAntiAffinity:
+                          description: A list of node labels values to extract and compare to evaluate if the pods reside in the same topology or not
+                          items:
+                            type: string
+                          type: array
+                      required:
+                        - enabled
+                      type: object
+                    synchronous:
+                      description: Configuration of the PostgreSQL synchronous replication feature
+                      properties:
+                        dataDurability:
+                          description: |-
+                            If set to "required", data durability is strictly enforced. Write operations
+                            with synchronous commit settings (`on`, `remote_write`, or `remote_apply`) will
+                            block if there are insufficient healthy replicas, ensuring data persistence.
+                            If set to "preferred", data durability is maintained when healthy replicas
+                            are available, but the required number of instances will adjust dynamically
+                            if replicas become unavailable. This setting relaxes strict durability enforcement
+                            to allow for operational continuity. This setting is only applicable if both
+                            `standbyNamesPre` and `standbyNamesPost` are unset (empty).
+                          enum:
+                            - required
+                            - preferred
+                          type: string
+                        failoverQuorum:
+                          description: |-
+                            FailoverQuorum enables a quorum-based check before failover, improving
+                            data durability and safety during failover events in CloudNativePG-managed
+                            PostgreSQL clusters.
+                          type: boolean
+                        maxStandbyNamesFromCluster:
+                          description: |-
+                            Specifies the maximum number of local cluster pods that can be
+                            automatically included in the `synchronous_standby_names` option in
+                            PostgreSQL.
+                          type: integer
+                        method:
+                          description: |-
+                            Method to select synchronous replication standbys from the listed
+                            servers, accepting 'any' (quorum-based synchronous replication) or
+                            'first' (priority-based synchronous replication) as values.
+                          enum:
+                            - any
+                            - first
+                          type: string
+                        number:
+                          description: |-
+                            Specifies the number of synchronous standby servers that
+                            transactions must wait for responses from.
+                          type: integer
+                          x-kubernetes-validations:
+                            - message: The number of synchronous replicas should be greater than zero
+                              rule: self > 0
+                        standbyNamesPost:
+                          description: |-
+                            A user-defined list of application names to be added to
+                            `synchronous_standby_names` after local cluster pods (the order is
+                            only useful for priority-based synchronous replication).
+                          items:
+                            type: string
+                          type: array
+                        standbyNamesPre:
+                          description: |-
+                            A user-defined list of application names to be added to
+                            `synchronous_standby_names` before local cluster pods (the order is
+                            only useful for priority-based synchronous replication).
+                          items:
+                            type: string
+                          type: array
+                      required:
+                        - method
+                        - number
+                      type: object
+                      x-kubernetes-validations:
+                        - message: dataDurability set to 'preferred' requires empty 'standbyNamesPre' and empty 'standbyNamesPost'
+                          rule: self.dataDurability!='preferred' || ((!has(self.standbyNamesPre) || self.standbyNamesPre.size()==0) && (!has(self.standbyNamesPost) || self.standbyNamesPost.size()==0))
+                  type: object
+                primaryUpdateMethod:
+                  default: restart
+                  description: |-
+                    Method to follow to upgrade the primary server during a rolling
+                    update procedure, after all replicas have been successfully updated:
+                    it can be with a switchover (`switchover`) or in-place (`restart` - default).
+                    Note: when using `switchover`, the operator will reject updates that change both
+                    the image name and PostgreSQL configuration parameters simultaneously to avoid
+                    configuration mismatches during the switchover process.
+                  enum:
+                    - switchover
+                    - restart
+                  type: string
+                primaryUpdateStrategy:
+                  default: unsupervised
+                  description: |-
+                    Deployment strategy to follow to upgrade the primary server during a rolling
+                    update procedure, after all replicas have been successfully updated:
+                    it can be automated (`unsupervised` - default) or manual (`supervised`)
+                  enum:
+                    - unsupervised
+                    - supervised
+                  type: string
+                priorityClassName:
+                  description: |-
+                    Name of the priority class which will be used in every generated Pod, if the PriorityClass
+                    specified does not exist, the pod will not be able to schedule.  Please refer to
+                    https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
+                    for more information
+                  type: string
+                probes:
+                  description: |-
+                    The configuration of the probes to be injected
+                    in the PostgreSQL Pods.
+                  properties:
+                    liveness:
+                      description: The liveness probe configuration
+                      properties:
+                        failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          format: int32
+                          type: integer
+                        isolationCheck:
+                          description: |-
+                            Configure the feature that extends the liveness probe for a primary
+                            instance. In addition to the basic checks, this verifies whether the
+                            primary is isolated from the Kubernetes API server and from its
+                            replicas, ensuring that it can be safely shut down if network
+                            partition or API unavailability is detected. Enabled by default.
+                          properties:
+                            connectionTimeout:
+                              default: 1000
+                              description: Timeout in milliseconds for connections during the primary isolation check
+                              type: integer
+                            enabled:
+                              default: true
+                              description: Whether primary isolation checking is enabled for the liveness probe
+                              type: boolean
+                            requestTimeout:
+                              default: 1000
+                              description: Timeout in milliseconds for requests during the primary isolation check
+                              type: integer
+                          type: object
+                        periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        terminationGracePeriodSeconds:
+                          description: |-
+                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                            The grace period is the duration in seconds after the processes running in the pod are sent
+                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                            Set this value longer than the expected cleanup time for your process.
+                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                            value overrides the value provided by the pod spec.
+                            Value must be non-negative integer. The value zero indicates stop immediately via
+                            the kill signal (no opportunity to shut down).
+                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                          format: int64
+                          type: integer
+                        timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          format: int32
+                          type: integer
+                      type: object
+                    readiness:
+                      description: The readiness probe configuration
+                      properties:
+                        failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          format: int32
+                          type: integer
+                        maximumLag:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: Lag limit. Used only for `streaming` strategy
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        terminationGracePeriodSeconds:
+                          description: |-
+                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                            The grace period is the duration in seconds after the processes running in the pod are sent
+                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                            Set this value longer than the expected cleanup time for your process.
+                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                            value overrides the value provided by the pod spec.
+                            Value must be non-negative integer. The value zero indicates stop immediately via
+                            the kill signal (no opportunity to shut down).
+                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                          format: int64
+                          type: integer
+                        timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          format: int32
+                          type: integer
+                        type:
+                          description: The probe strategy
+                          enum:
+                            - pg_isready
+                            - streaming
+                            - query
+                          type: string
+                      type: object
+                    startup:
+                      description: The startup probe configuration
+                      properties:
+                        failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          format: int32
+                          type: integer
+                        maximumLag:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: Lag limit. Used only for `streaming` strategy
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        terminationGracePeriodSeconds:
+                          description: |-
+                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                            The grace period is the duration in seconds after the processes running in the pod are sent
+                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                            Set this value longer than the expected cleanup time for your process.
+                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                            value overrides the value provided by the pod spec.
+                            Value must be non-negative integer. The value zero indicates stop immediately via
+                            the kill signal (no opportunity to shut down).
+                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                          format: int64
+                          type: integer
+                        timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          format: int32
+                          type: integer
+                        type:
+                          description: The probe strategy
+                          enum:
+                            - pg_isready
+                            - streaming
+                            - query
+                          type: string
+                      type: object
+                  type: object
+                projectedVolumeTemplate:
+                  description: |-
+                    Template to be used to define projected volumes, projected volumes will be mounted
+                    under `/projected` base folder
+                  properties:
+                    defaultMode:
+                      description: |-
+                        defaultMode are the mode bits used to set permissions on created files by default.
+                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                        Directories within the path are not affected by this setting.
+                        This might be in conflict with other options that affect the file
+                        mode, like fsGroup, and the result can be other mode bits set.
+                      format: int32
+                      type: integer
+                    sources:
+                      description: |-
+                        sources is the list of volume projections. Each entry in this list
+                        handles one source.
+                      items:
+                        description: |-
+                          Projection that may be projected along with other supported volume types.
+                          Exactly one of these fields must be set.
+                        properties:
+                          clusterTrustBundle:
+                            description: |-
+                              ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                              of ClusterTrustBundle objects in an auto-updating file.
+
+                              Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                              ClusterTrustBundle objects can either be selected by name, or by the
+                              combination of signer name and a label selector.
+
+                              Kubelet performs aggressive normalization of the PEM contents written
+                              into the pod filesystem.  Esoteric PEM features such as inter-block
+                              comments and block headers are stripped.  Certificates are deduplicated.
+                              The ordering of certificates within the file is arbitrary, and Kubelet
+                              may change the order over time.
+                            properties:
+                              labelSelector:
+                                description: |-
+                                  Select all ClusterTrustBundles that match this label selector.  Only has
+                                  effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                  interpreted as "match nothing".  If set but empty, interpreted as "match
+                                  everything".
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              name:
+                                description: |-
+                                  Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                  with signerName and labelSelector.
+                                type: string
+                              optional:
+                                description: |-
+                                  If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                  aren't available.  If using name, then the named ClusterTrustBundle is
+                                  allowed not to exist.  If using signerName, then the combination of
+                                  signerName and labelSelector is allowed to match zero
+                                  ClusterTrustBundles.
+                                type: boolean
+                              path:
+                                description: Relative path from the volume root to write the bundle.
+                                type: string
+                              signerName:
+                                description: |-
+                                  Select all ClusterTrustBundles that match this signer name.
+                                  Mutually-exclusive with name.  The contents of all selected
+                                  ClusterTrustBundles will be unified and deduplicated.
+                                type: string
+                            required:
+                              - path
+                            type: object
+                          configMap:
+                            description: configMap information about the configMap data to project
+                            properties:
+                              items:
+                                description: |-
+                                  items if unspecified, each key-value pair in the Data field of the referenced
+                                  ConfigMap will be projected into the volume as a file whose name is the
+                                  key and content is the value. If specified, the listed keys will be
+                                  projected into the specified paths, and unlisted keys will not be
+                                  present. If a key is specified which is not present in the ConfigMap,
+                                  the volume setup will error unless it is marked optional. Paths must be
+                                  relative and may not contain the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: optional specify whether the ConfigMap or its keys must be defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          downwardAPI:
+                            description: downwardAPI information about the downwardAPI data to project
+                            properties:
+                              items:
+                                description: Items is a list of DownwardAPIVolume file
+                                items:
+                                  description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                  properties:
+                                    fieldRef:
+                                      description: 'Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select in the specified API version.
+                                          type: string
+                                      required:
+                                        - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    mode:
+                                      description: |-
+                                        Optional: mode bits used to set permissions on this file, must be an octal value
+                                        between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                      type: string
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          description: Specifies the output format of the exposed resources, defaults to "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                        - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  required:
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podCertificate:
+                            description: |-
+                              Projects an auto-rotating credential bundle (private key and certificate
+                              chain) that the pod can use either as a TLS client or server.
+
+                              Kubelet generates a private key and uses it to send a
+                              PodCertificateRequest to the named signer.  Once the signer approves the
+                              request and issues a certificate chain, Kubelet writes the key and
+                              certificate chain to the pod filesystem.  The pod does not start until
+                              certificates have been issued for each podCertificate projected volume
+                              source in its spec.
+
+                              Kubelet will begin trying to rotate the certificate at the time indicated
+                              by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                              timestamp.
+
+                              Kubelet can write a single file, indicated by the credentialBundlePath
+                              field, or separate files, indicated by the keyPath and
+                              certificateChainPath fields.
+
+                              The credential bundle is a single file in PEM format.  The first PEM
+                              entry is the private key (in PKCS#8 format), and the remaining PEM
+                              entries are the certificate chain issued by the signer (typically,
+                              signers will return their certificate chain in leaf-to-root order).
+
+                              Prefer using the credential bundle format, since your application code
+                              can read it atomically.  If you use keyPath and certificateChainPath,
+                              your application must make two separate file reads. If these coincide
+                              with a certificate rotation, it is possible that the private key and leaf
+                              certificate you read may not correspond to each other.  Your application
+                              will need to check for this condition, and re-read until they are
+                              consistent.
+
+                              The named signer controls chooses the format of the certificate it
+                              issues; consult the signer implementation's documentation to learn how to
+                              use the certificates it issues.
+                            properties:
+                              certificateChainPath:
+                                description: |-
+                                  Write the certificate chain at this path in the projected volume.
+
+                                  Most applications should use credentialBundlePath.  When using keyPath
+                                  and certificateChainPath, your application needs to check that the key
+                                  and leaf certificate are consistent, because it is possible to read the
+                                  files mid-rotation.
+                                type: string
+                              credentialBundlePath:
+                                description: |-
+                                  Write the credential bundle at this path in the projected volume.
+
+                                  The credential bundle is a single file that contains multiple PEM blocks.
+                                  The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                  key.
+
+                                  The remaining blocks are CERTIFICATE blocks, containing the issued
+                                  certificate chain from the signer (leaf and any intermediates).
+
+                                  Using credentialBundlePath lets your Pod's application code make a single
+                                  atomic read that retrieves a consistent key and certificate chain.  If you
+                                  project them to separate files, your application code will need to
+                                  additionally check that the leaf certificate was issued to the key.
+                                type: string
+                              keyPath:
+                                description: |-
+                                  Write the key at this path in the projected volume.
+
+                                  Most applications should use credentialBundlePath.  When using keyPath
+                                  and certificateChainPath, your application needs to check that the key
+                                  and leaf certificate are consistent, because it is possible to read the
+                                  files mid-rotation.
+                                type: string
+                              keyType:
+                                description: |-
+                                  The type of keypair Kubelet will generate for the pod.
+
+                                  Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                  "ECDSAP521", and "ED25519".
+                                type: string
+                              maxExpirationSeconds:
+                                description: |-
+                                  maxExpirationSeconds is the maximum lifetime permitted for the
+                                  certificate.
+
+                                  Kubelet copies this value verbatim into the PodCertificateRequests it
+                                  generates for this projection.
+
+                                  If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                  will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                  value is 7862400 (91 days).
+
+                                  The signer implementation is then free to issue a certificate with any
+                                  lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                  seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                  `kubernetes.io` signers will never issue certificates with a lifetime
+                                  longer than 24 hours.
+                                format: int32
+                                type: integer
+                              signerName:
+                                description: Kubelet's generated CSRs will be addressed to this signer.
+                                type: string
+                              userAnnotations:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  userAnnotations allow pod authors to pass additional information to
+                                  the signer implementation.  Kubernetes does not restrict or validate this
+                                  metadata in any way.
+
+                                  These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                  the PodCertificateRequest objects that Kubelet creates.
+
+                                  Entries are subject to the same validation as object metadata annotations,
+                                  with the addition that all keys must be domain-prefixed. No restrictions
+                                  are placed on values, except an overall size limitation on the entire field.
+
+                                  Signers should document the keys and values they support. Signers should
+                                  deny requests that contain keys they do not recognize.
+                                type: object
+                            required:
+                              - keyType
+                              - signerName
+                            type: object
+                          secret:
+                            description: secret information about the secret data to project
+                            properties:
+                              items:
+                                description: |-
+                                  items if unspecified, each key-value pair in the Data field of the referenced
+                                  Secret will be projected into the volume as a file whose name is the
+                                  key and content is the value. If specified, the listed keys will be
+                                  projected into the specified paths, and unlisted keys will not be
+                                  present. If a key is specified which is not present in the Secret,
+                                  the volume setup will error unless it is marked optional. Paths must be
+                                  relative and may not contain the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: optional field specify whether the Secret or its key must be defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          serviceAccountToken:
+                            description: serviceAccountToken is information about the serviceAccountToken data to project
+                            properties:
+                              audience:
+                                description: |-
+                                  audience is the intended audience of the token. A recipient of a token
+                                  must identify itself with an identifier specified in the audience of the
+                                  token, and otherwise should reject the token. The audience defaults to the
+                                  identifier of the apiserver.
+                                type: string
+                              expirationSeconds:
+                                description: |-
+                                  expirationSeconds is the requested duration of validity of the service
+                                  account token. As the token approaches expiration, the kubelet volume
+                                  plugin will proactively rotate the service account token. The kubelet will
+                                  start trying to rotate the token if the token is older than 80 percent of
+                                  its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                  and must be at least 10 minutes.
+                                format: int64
+                                type: integer
+                              path:
+                                description: |-
+                                  path is the path relative to the mount point of the file to project the
+                                  token into.
+                                type: string
+                            required:
+                              - path
+                            type: object
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                replica:
+                  description: Replica cluster configuration
+                  properties:
+                    enabled:
+                      description: |-
+                        If replica mode is enabled, this cluster will be a replica of an
+                        existing cluster. Replica cluster can be created from a recovery
+                        object store or via streaming through pg_basebackup.
+                        Refer to the Replica clusters page of the documentation for more information.
+                      type: boolean
+                    minApplyDelay:
+                      description: |-
+                        When replica mode is enabled, this parameter allows you to replay
+                        transactions only when the system time is at least the configured
+                        time past the commit time. This provides an opportunity to correct
+                        data loss errors. Note that when this parameter is set, a promotion
+                        token cannot be used.
+                      type: string
+                    primary:
+                      description: |-
+                        Primary defines which Cluster is defined to be the primary in the distributed PostgreSQL cluster, based on the
+                        topology specified in externalClusters
+                      type: string
+                    promotionToken:
+                      description: |-
+                        A demotion token generated by an external cluster used to
+                        check if the promotion requirements are met.
+                      type: string
+                    self:
+                      description: |-
+                        Self defines the name of this cluster. It is used to determine if this is a primary
+                        or a replica cluster, comparing it with `primary`
+                      type: string
+                    source:
+                      description: The name of the external cluster which is the replication origin
+                      minLength: 1
+                      type: string
+                  required:
+                    - source
+                  type: object
+                replicationSlots:
+                  default:
+                    highAvailability:
+                      enabled: true
+                  description: Replication slots management configuration
+                  properties:
+                    highAvailability:
+                      default:
+                        enabled: true
+                      description: Replication slots for high availability configuration
+                      properties:
+                        enabled:
+                          default: true
+                          description: |-
+                            If enabled (default), the operator will automatically manage replication slots
+                            on the primary instance and use them in streaming replication
+                            connections with all the standby instances that are part of the HA
+                            cluster. If disabled, the operator will not take advantage
+                            of replication slots in streaming connections with the replicas.
+                            This feature also controls replication slots in replica cluster,
+                            from the designated primary to its cascading replicas.
+                          type: boolean
+                        slotPrefix:
+                          default: _cnpg_
+                          description: |-
+                            Prefix for replication slots managed by the operator for HA.
+                            It may only contain lower case letters, numbers, and the underscore character.
+                            This can only be set at creation time. By default set to `_cnpg_`.
+                          pattern: ^[0-9a-z_]*$
+                          type: string
+                        synchronizeLogicalDecoding:
+                          description: |-
+                            When enabled, the operator automatically manages synchronization of logical
+                            decoding (replication) slots across high-availability clusters.
+
+                            Requires one of the following conditions:
+                            - PostgreSQL version 17 or later
+                            - PostgreSQL version < 17 with pg_failover_slots extension enabled
+                          type: boolean
+                      type: object
+                    synchronizeReplicas:
+                      description: Configures the synchronization of the user defined physical replication slots
+                      properties:
+                        enabled:
+                          default: true
+                          description: When set to true, every replication slot that is on the primary is synchronized on each standby
+                          type: boolean
+                        excludePatterns:
+                          description: List of regular expression patterns to match the names of replication slots to be excluded (by default empty)
+                          items:
+                            type: string
+                          type: array
+                      required:
+                        - enabled
+                      type: object
+                    updateInterval:
+                      default: 30
+                      description: |-
+                        Standby will update the status of the local replication slots
+                        every `updateInterval` seconds (default 30).
+                      minimum: 1
+                      type: integer
+                  type: object
+                resources:
+                  description: |-
+                    Resources requirements of every generated Pod. Please refer to
+                    https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    for more information.
+                  properties:
+                    claims:
+                      description: |-
+                        Claims lists the names of resources, defined in spec.resourceClaims,
+                        that are used by this container.
+
+                        This field depends on the
+                        DynamicResourceAllocation feature gate.
+
+                        This field is immutable. It can only be set for containers.
+                      items:
+                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                        properties:
+                          name:
+                            description: |-
+                              Name must match the name of one entry in pod.spec.resourceClaims of
+                              the Pod where this field is used. It makes that resource available
+                              inside a container.
+                            type: string
+                          request:
+                            description: |-
+                              Request is the name chosen for a request in the referenced claim.
+                              If empty, everything from the claim is made available, otherwise
+                              only the result of this request.
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: |-
+                        Limits describes the maximum amount of compute resources allowed.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: |-
+                        Requests describes the minimum amount of compute resources required.
+                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      type: object
+                  type: object
+                schedulerName:
+                  description: |-
+                    If specified, the pod will be dispatched by specified Kubernetes
+                    scheduler. If not specified, the pod will be dispatched by the default
+                    scheduler. More info:
+                    https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+                  type: string
+                seccompProfile:
+                  description: |-
+                    The SeccompProfile applied to every Pod and Container.
+                    Defaults to: `RuntimeDefault`
+                  properties:
+                    localhostProfile:
+                      description: |-
+                        localhostProfile indicates a profile defined in a file on the node should be used.
+                        The profile must be preconfigured on the node to work.
+                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                        Must be set if type is "Localhost". Must NOT be set for any other type.
+                      type: string
+                    type:
+                      description: |-
+                        type indicates which kind of seccomp profile will be applied.
+                        Valid options are:
+
+                        Localhost - a profile defined in a file on the node should be used.
+                        RuntimeDefault - the container runtime default profile should be used.
+                        Unconfined - no profile should be applied.
+                      type: string
+                  required:
+                    - type
+                  type: object
+                securityContext:
+                  description: |-
+                    Override the SecurityContext applied to every Container in the Pod of the cluster.
+                    When set, this overrides the operator's default Container SecurityContext.
+                    If omitted, the operator defaults are used.
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: |-
+                        AllowPrivilegeEscalation controls whether a process can gain more
+                        privileges than its parent process. This bool directly controls if
+                        the no_new_privs flag will be set on the container process.
+                        AllowPrivilegeEscalation is true always when the container is:
+                        1) run as Privileged
+                        2) has CAP_SYS_ADMIN
+                        Note that this field cannot be set when spec.os.name is windows.
+                      type: boolean
+                    appArmorProfile:
+                      description: |-
+                        appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                        overrides the pod's appArmorProfile.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: |-
+                            localhostProfile indicates a profile loaded on the node that should be used.
+                            The profile must be preconfigured on the node to work.
+                            Must match the loaded name of the profile.
+                            Must be set if and only if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of AppArmor profile will be applied.
+                            Valid options are:
+                              Localhost - a profile pre-loaded on the node.
+                              RuntimeDefault - the container runtime's default profile.
+                              Unconfined - no AppArmor enforcement.
+                          type: string
+                      required:
+                        - type
+                      type: object
+                    capabilities:
+                      description: |-
+                        The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the container runtime.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            description: Capability represent POSIX capabilities type
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            description: Capability represent POSIX capabilities type
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    privileged:
+                      description: |-
+                        Run container in privileged mode.
+                        Processes in privileged containers are essentially equivalent to root on the host.
+                        Defaults to false.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      type: boolean
+                    procMount:
+                      description: |-
+                        procMount denotes the type of proc mount to use for the containers.
+                        The default value is Default which uses the container runtime defaults for
+                        readonly paths and masked paths.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: |-
+                        Whether this container has a read-only root filesystem.
+                        Default is false.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      type: boolean
+                    runAsGroup:
+                      description: |-
+                        The GID to run the entrypoint of the container process.
+                        Uses runtime default if unset.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: |-
+                        Indicates that the container must run as a non-root user.
+                        If true, the Kubelet will validate the image at runtime to ensure that it
+                        does not run as UID 0 (root) and fail to start the container if it does.
+                        If unset or false, no such validation will be performed.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: |-
+                        The UID to run the entrypoint of the container process.
+                        Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: |-
+                        The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random SELinux context for each
+                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: |-
+                        The seccomp options to use by this container. If seccomp options are
+                        provided at both the pod & container level, the container options
+                        override the pod options.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: |-
+                            localhostProfile indicates a profile defined in a file on the node should be used.
+                            The profile must be preconfigured on the node to work.
+                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                            Must be set if type is "Localhost". Must NOT be set for any other type.
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied.
+                            Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used.
+                            RuntimeDefault - the container runtime default profile should be used.
+                            Unconfined - no profile should be applied.
+                          type: string
+                      required:
+                        - type
+                      type: object
+                    windowsOptions:
+                      description: |-
+                        The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will be used.
+                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is linux.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: |-
+                            GMSACredentialSpec is where the GMSA admission webhook
+                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                            GMSA credential spec named by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: |-
+                            HostProcess determines if a container should be run as a 'Host Process' container.
+                            All of a Pod's containers must have the same effective HostProcess value
+                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                            In addition, if HostProcess is true then HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: |-
+                            The UserName in Windows to run the entrypoint of the container process.
+                            Defaults to the user specified in image metadata if unspecified.
+                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                serviceAccountName:
+                  description: |-
+                    Name of an existing ServiceAccount in the same namespace to use for the cluster.
+                    When specified, the operator will not create a new ServiceAccount
+                    but will use the provided one. This is useful for sharing a single
+                    ServiceAccount across multiple clusters (e.g., for cloud IAM configurations).
+                    If not specified, a ServiceAccount will be created with the cluster name.
+                    Mutually exclusive with ServiceAccountTemplate.
+                  maxLength: 253
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: serviceAccountName is immutable
+                      rule: self == oldSelf
+                serviceAccountTemplate:
+                  description: Configure the generation of the service account
+                  properties:
+                    metadata:
+                      description: |-
+                        Metadata are the metadata to be used for the generated
+                        service account
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: http://kubernetes.io/docs/user-guide/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: http://kubernetes.io/docs/user-guide/labels
+                          type: object
+                        name:
+                          description: The name of the resource. Only supported for certain types
+                          type: string
+                      type: object
+                  required:
+                    - metadata
+                  type: object
+                smartShutdownTimeout:
+                  default: 180
+                  description: |-
+                    The time in seconds that controls the window of time reserved for the smart shutdown of Postgres to complete.
+                    Make sure you reserve enough time for the operator to request a fast shutdown of Postgres
+                    (that is: `stopDelay` - `smartShutdownTimeout`). Default is 180 seconds.
+                  format: int32
+                  type: integer
+                startDelay:
+                  default: 3600
+                  description: |-
+                    The time in seconds that is allowed for a PostgreSQL instance to
+                    successfully start up (default 3600).
+                    The startup probe failure threshold is derived from this value using the formula:
+                    ceiling(startDelay / 10).
+                  format: int32
+                  type: integer
+                stopDelay:
+                  default: 1800
+                  description: |-
+                    The time in seconds that is allowed for a PostgreSQL instance to
+                    gracefully shutdown (default 1800)
+                  format: int32
+                  type: integer
+                storage:
+                  description: Configuration of the storage of the instances
+                  properties:
+                    pvcTemplate:
+                      description: Template to be used to generate the Persistent Volume Claim
+                      properties:
+                        accessModes:
+                          description: |-
+                            accessModes contains the desired access modes the volume should have.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        dataSource:
+                          description: |-
+                            dataSource field can be used to specify either:
+                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                            * An existing PVC (PersistentVolumeClaim)
+                            If the provisioner or an external controller can support the specified data source,
+                            it will create a new volume based on the contents of the specified data source.
+                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                          properties:
+                            apiGroup:
+                              description: |-
+                                APIGroup is the group for the resource being referenced.
+                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                For any other third-party types, APIGroup is required.
+                              type: string
+                            kind:
+                              description: Kind is the type of resource being referenced
+                              type: string
+                            name:
+                              description: Name is the name of resource being referenced
+                              type: string
+                          required:
+                            - kind
+                            - name
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        dataSourceRef:
+                          description: |-
+                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                            volume is desired. This may be any object from a non-empty API group (non
+                            core object) or a PersistentVolumeClaim object.
+                            When this field is specified, volume binding will only succeed if the type of
+                            the specified object matches some installed volume populator or dynamic
+                            provisioner.
+                            This field will replace the functionality of the dataSource field and as such
+                            if both fields are non-empty, they must have the same value. For backwards
+                            compatibility, when namespace isn't specified in dataSourceRef,
+                            both fields (dataSource and dataSourceRef) will be set to the same
+                            value automatically if one of them is empty and the other is non-empty.
+                            When namespace is specified in dataSourceRef,
+                            dataSource isn't set to the same value and must be empty.
+                            There are three important differences between dataSource and dataSourceRef:
+                            * While dataSource only allows two specific types of objects, dataSourceRef
+                              allows any non-core object, as well as PersistentVolumeClaim objects.
+                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                              preserves all values, and generates an error if a disallowed value is
+                              specified.
+                            * While dataSource only allows local objects, dataSourceRef allows objects
+                              in any namespaces.
+                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                          properties:
+                            apiGroup:
+                              description: |-
+                                APIGroup is the group for the resource being referenced.
+                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                For any other third-party types, APIGroup is required.
+                              type: string
+                            kind:
+                              description: Kind is the type of resource being referenced
+                              type: string
+                            name:
+                              description: Name is the name of resource being referenced
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace is the namespace of resource being referenced
+                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                              type: string
+                          required:
+                            - kind
+                            - name
+                          type: object
+                        resources:
+                          description: |-
+                            resources represents the minimum resources the volume should have.
+                            Users are allowed to specify resource requirements
+                            that are lower than previous value but must still be higher than capacity recorded in the
+                            status field of the claim.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Limits describes the maximum amount of compute resources allowed.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Requests describes the minimum amount of compute resources required.
+                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                          type: object
+                        selector:
+                          description: selector is a label query over volumes to consider for binding.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        storageClassName:
+                          description: |-
+                            storageClassName is the name of the StorageClass required by the claim.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                          type: string
+                        volumeAttributesClassName:
+                          description: |-
+                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                            If specified, the CSI driver will create or update the volume with the attributes defined
+                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                            it can be changed after the claim is created. An empty string or nil value indicates that no
+                            VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                            this field can be reset to its previous value (including nil) to cancel the modification.
+                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                            exists.
+                            More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                          type: string
+                        volumeMode:
+                          description: |-
+                            volumeMode defines what type of volume is required by the claim.
+                            Value of Filesystem is implied when not included in claim spec.
+                          type: string
+                        volumeName:
+                          description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                          type: string
+                      type: object
+                    resizeInUseVolumes:
+                      default: true
+                      description: Resize existent PVCs, defaults to true
+                      type: boolean
+                    size:
+                      description: |-
+                        Size of the storage. Required if not already specified in the PVC template.
+                        Changes to this field are automatically reapplied to the created PVCs.
+                        Size cannot be decreased.
+                      type: string
+                    storageClass:
+                      description: |-
+                        StorageClass to use for PVCs. Applied after
+                        evaluating the PVC template, if available.
+                        If not specified, the generated PVCs will use the
+                        default storage class
+                      type: string
+                  type: object
+                superuserSecret:
+                  description: |-
+                    The secret containing the superuser password. If not defined a new
+                    secret will be created with a randomly generated password
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                switchoverDelay:
+                  default: 3600
+                  description: |-
+                    The time in seconds that is allowed for a primary PostgreSQL instance
+                    to gracefully shutdown during a switchover.
+                    Default value is 3600 seconds (1 hour).
+                  format: int32
+                  type: integer
+                tablespaces:
+                  description: The tablespaces configuration
+                  items:
+                    description: |-
+                      TablespaceConfiguration is the configuration of a tablespace, and includes
+                      the storage specification for the tablespace
+                    properties:
+                      name:
+                        description: The name of the tablespace
+                        type: string
+                      owner:
+                        description: Owner is the PostgreSQL user owning the tablespace
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      storage:
+                        description: The storage configuration for the tablespace
+                        properties:
+                          pvcTemplate:
+                            description: Template to be used to generate the Persistent Volume Claim
+                            properties:
+                              accessModes:
+                                description: |-
+                                  accessModes contains the desired access modes the volume should have.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              dataSource:
+                                description: |-
+                                  dataSource field can be used to specify either:
+                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                  * An existing PVC (PersistentVolumeClaim)
+                                  If the provisioner or an external controller can support the specified data source,
+                                  it will create a new volume based on the contents of the specified data source.
+                                  When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                  and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                  If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                properties:
+                                  apiGroup:
+                                    description: |-
+                                      APIGroup is the group for the resource being referenced.
+                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is required.
+                                    type: string
+                                  kind:
+                                    description: Kind is the type of resource being referenced
+                                    type: string
+                                  name:
+                                    description: Name is the name of resource being referenced
+                                    type: string
+                                required:
+                                  - kind
+                                  - name
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              dataSourceRef:
+                                description: |-
+                                  dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                  volume is desired. This may be any object from a non-empty API group (non
+                                  core object) or a PersistentVolumeClaim object.
+                                  When this field is specified, volume binding will only succeed if the type of
+                                  the specified object matches some installed volume populator or dynamic
+                                  provisioner.
+                                  This field will replace the functionality of the dataSource field and as such
+                                  if both fields are non-empty, they must have the same value. For backwards
+                                  compatibility, when namespace isn't specified in dataSourceRef,
+                                  both fields (dataSource and dataSourceRef) will be set to the same
+                                  value automatically if one of them is empty and the other is non-empty.
+                                  When namespace is specified in dataSourceRef,
+                                  dataSource isn't set to the same value and must be empty.
+                                  There are three important differences between dataSource and dataSourceRef:
+                                  * While dataSource only allows two specific types of objects, dataSourceRef
+                                    allows any non-core object, as well as PersistentVolumeClaim objects.
+                                  * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                    preserves all values, and generates an error if a disallowed value is
+                                    specified.
+                                  * While dataSource only allows local objects, dataSourceRef allows objects
+                                    in any namespaces.
+                                  (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                  (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                properties:
+                                  apiGroup:
+                                    description: |-
+                                      APIGroup is the group for the resource being referenced.
+                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is required.
+                                    type: string
+                                  kind:
+                                    description: Kind is the type of resource being referenced
+                                    type: string
+                                  name:
+                                    description: Name is the name of resource being referenced
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace of resource being referenced
+                                      Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                      (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                    type: string
+                                required:
+                                  - kind
+                                  - name
+                                type: object
+                              resources:
+                                description: |-
+                                  resources represents the minimum resources the volume should have.
+                                  Users are allowed to specify resource requirements
+                                  that are lower than previous value but must still be higher than capacity recorded in the
+                                  status field of the claim.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Requests describes the minimum amount of compute resources required.
+                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                type: object
+                              selector:
+                                description: selector is a label query over volumes to consider for binding.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              storageClassName:
+                                description: |-
+                                  storageClassName is the name of the StorageClass required by the claim.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                type: string
+                              volumeAttributesClassName:
+                                description: |-
+                                  volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                  If specified, the CSI driver will create or update the volume with the attributes defined
+                                  in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                  it can be changed after the claim is created. An empty string or nil value indicates that no
+                                  VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                  this field can be reset to its previous value (including nil) to cancel the modification.
+                                  If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                  set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                  exists.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                type: string
+                              volumeMode:
+                                description: |-
+                                  volumeMode defines what type of volume is required by the claim.
+                                  Value of Filesystem is implied when not included in claim spec.
+                                type: string
+                              volumeName:
+                                description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                type: string
+                            type: object
+                          resizeInUseVolumes:
+                            default: true
+                            description: Resize existent PVCs, defaults to true
+                            type: boolean
+                          size:
+                            description: |-
+                              Size of the storage. Required if not already specified in the PVC template.
+                              Changes to this field are automatically reapplied to the created PVCs.
+                              Size cannot be decreased.
+                            type: string
+                          storageClass:
+                            description: |-
+                              StorageClass to use for PVCs. Applied after
+                              evaluating the PVC template, if available.
+                              If not specified, the generated PVCs will use the
+                              default storage class
+                            type: string
+                        type: object
+                      temporary:
+                        default: false
+                        description: |-
+                          When set to true, the tablespace will be added as a `temp_tablespaces`
+                          entry in PostgreSQL, and will be available to automatically house temp
+                          database objects, or other temporary files. Please refer to PostgreSQL
+                          documentation for more information on the `temp_tablespaces` GUC.
+                        type: boolean
+                    required:
+                      - name
+                      - storage
+                    type: object
+                  type: array
+                topologySpreadConstraints:
+                  description: |-
+                    TopologySpreadConstraints specifies how to spread matching pods among the given topology.
+                    More info:
+                    https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+                  items:
+                    description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                    properties:
+                      labelSelector:
+                        description: |-
+                          LabelSelector is used to find matching pods.
+                          Pods that match this label selector are counted to determine the number of pods
+                          in their corresponding topology domain.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      matchLabelKeys:
+                        description: |-
+                          MatchLabelKeys is a set of pod label keys to select the pods over which
+                          spreading will be calculated. The keys are used to lookup values from the
+                          incoming pod labels, those key-value labels are ANDed with labelSelector
+                          to select the group of existing pods over which spreading will be calculated
+                          for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                          MatchLabelKeys cannot be set when LabelSelector isn't set.
+                          Keys that don't exist in the incoming pod labels will
+                          be ignored. A null or empty list means only match against labelSelector.
+
+                          This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      maxSkew:
+                        description: |-
+                          MaxSkew describes the degree to which pods may be unevenly distributed.
+                          When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                          between the number of matching pods in the target topology and the global minimum.
+                          The global minimum is the minimum number of matching pods in an eligible domain
+                          or zero if the number of eligible domains is less than MinDomains.
+                          For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                          labelSelector spread as 2/2/1:
+                          In this case, the global minimum is 1.
+                          | zone1 | zone2 | zone3 |
+                          |  P P  |  P P  |   P   |
+                          - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                          scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                          violate MaxSkew(1).
+                          - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                          When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                          to topologies that satisfy it.
+                          It's a required field. Default value is 1 and 0 is not allowed.
+                        format: int32
+                        type: integer
+                      minDomains:
+                        description: |-
+                          MinDomains indicates a minimum number of eligible domains.
+                          When the number of eligible domains with matching topology keys is less than minDomains,
+                          Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                          And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                          this value has no effect on scheduling.
+                          As a result, when the number of eligible domains is less than minDomains,
+                          scheduler won't schedule more than maxSkew Pods to those domains.
+                          If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                          Valid values are integers greater than 0.
+                          When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                          For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                          labelSelector spread as 2/2/2:
+                          | zone1 | zone2 | zone3 |
+                          |  P P  |  P P  |  P P  |
+                          The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                          In this situation, new pod with the same labelSelector cannot be scheduled,
+                          because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                          it will violate MaxSkew.
+                        format: int32
+                        type: integer
+                      nodeAffinityPolicy:
+                        description: |-
+                          NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                          when calculating pod topology spread skew. Options are:
+                          - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                          - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                          If this value is nil, the behavior is equivalent to the Honor policy.
+                        type: string
+                      nodeTaintsPolicy:
+                        description: |-
+                          NodeTaintsPolicy indicates how we will treat node taints when calculating
+                          pod topology spread skew. Options are:
+                          - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                          has a toleration, are included.
+                          - Ignore: node taints are ignored. All nodes are included.
+
+                          If this value is nil, the behavior is equivalent to the Ignore policy.
+                        type: string
+                      topologyKey:
+                        description: |-
+                          TopologyKey is the key of node labels. Nodes that have a label with this key
+                          and identical values are considered to be in the same topology.
+                          We consider each <key, value> as a "bucket", and try to put balanced number
+                          of pods into each bucket.
+                          We define a domain as a particular instance of a topology.
+                          Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                          nodeAffinityPolicy and nodeTaintsPolicy.
+                          e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                          And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                          It's a required field.
+                        type: string
+                      whenUnsatisfiable:
+                        description: |-
+                          WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                          the spread constraint.
+                          - DoNotSchedule (default) tells the scheduler not to schedule it.
+                          - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                            but giving higher precedence to topologies that would help reduce the
+                            skew.
+                          A constraint is considered "Unsatisfiable" for an incoming pod
+                          if and only if every possible node assignment for that pod would violate
+                          "MaxSkew" on some topology.
+                          For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                          labelSelector spread as 3/1/1:
+                          | zone1 | zone2 | zone3 |
+                          | P P P |   P   |   P   |
+                          If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                          to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                          MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                          won't make it *more* imbalanced.
+                          It's a required field.
+                        type: string
+                    required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
+                    type: object
+                  type: array
+                walStorage:
+                  description: Configuration of the storage for PostgreSQL WAL (Write-Ahead Log)
+                  properties:
+                    pvcTemplate:
+                      description: Template to be used to generate the Persistent Volume Claim
+                      properties:
+                        accessModes:
+                          description: |-
+                            accessModes contains the desired access modes the volume should have.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        dataSource:
+                          description: |-
+                            dataSource field can be used to specify either:
+                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                            * An existing PVC (PersistentVolumeClaim)
+                            If the provisioner or an external controller can support the specified data source,
+                            it will create a new volume based on the contents of the specified data source.
+                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                          properties:
+                            apiGroup:
+                              description: |-
+                                APIGroup is the group for the resource being referenced.
+                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                For any other third-party types, APIGroup is required.
+                              type: string
+                            kind:
+                              description: Kind is the type of resource being referenced
+                              type: string
+                            name:
+                              description: Name is the name of resource being referenced
+                              type: string
+                          required:
+                            - kind
+                            - name
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        dataSourceRef:
+                          description: |-
+                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                            volume is desired. This may be any object from a non-empty API group (non
+                            core object) or a PersistentVolumeClaim object.
+                            When this field is specified, volume binding will only succeed if the type of
+                            the specified object matches some installed volume populator or dynamic
+                            provisioner.
+                            This field will replace the functionality of the dataSource field and as such
+                            if both fields are non-empty, they must have the same value. For backwards
+                            compatibility, when namespace isn't specified in dataSourceRef,
+                            both fields (dataSource and dataSourceRef) will be set to the same
+                            value automatically if one of them is empty and the other is non-empty.
+                            When namespace is specified in dataSourceRef,
+                            dataSource isn't set to the same value and must be empty.
+                            There are three important differences between dataSource and dataSourceRef:
+                            * While dataSource only allows two specific types of objects, dataSourceRef
+                              allows any non-core object, as well as PersistentVolumeClaim objects.
+                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                              preserves all values, and generates an error if a disallowed value is
+                              specified.
+                            * While dataSource only allows local objects, dataSourceRef allows objects
+                              in any namespaces.
+                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                          properties:
+                            apiGroup:
+                              description: |-
+                                APIGroup is the group for the resource being referenced.
+                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                For any other third-party types, APIGroup is required.
+                              type: string
+                            kind:
+                              description: Kind is the type of resource being referenced
+                              type: string
+                            name:
+                              description: Name is the name of resource being referenced
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace is the namespace of resource being referenced
+                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                              type: string
+                          required:
+                            - kind
+                            - name
+                          type: object
+                        resources:
+                          description: |-
+                            resources represents the minimum resources the volume should have.
+                            Users are allowed to specify resource requirements
+                            that are lower than previous value but must still be higher than capacity recorded in the
+                            status field of the claim.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Limits describes the maximum amount of compute resources allowed.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Requests describes the minimum amount of compute resources required.
+                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                          type: object
+                        selector:
+                          description: selector is a label query over volumes to consider for binding.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        storageClassName:
+                          description: |-
+                            storageClassName is the name of the StorageClass required by the claim.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                          type: string
+                        volumeAttributesClassName:
+                          description: |-
+                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                            If specified, the CSI driver will create or update the volume with the attributes defined
+                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                            it can be changed after the claim is created. An empty string or nil value indicates that no
+                            VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                            this field can be reset to its previous value (including nil) to cancel the modification.
+                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                            exists.
+                            More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                          type: string
+                        volumeMode:
+                          description: |-
+                            volumeMode defines what type of volume is required by the claim.
+                            Value of Filesystem is implied when not included in claim spec.
+                          type: string
+                        volumeName:
+                          description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                          type: string
+                      type: object
+                    resizeInUseVolumes:
+                      default: true
+                      description: Resize existent PVCs, defaults to true
+                      type: boolean
+                    size:
+                      description: |-
+                        Size of the storage. Required if not already specified in the PVC template.
+                        Changes to this field are automatically reapplied to the created PVCs.
+                        Size cannot be decreased.
+                      type: string
+                    storageClass:
+                      description: |-
+                        StorageClass to use for PVCs. Applied after
+                        evaluating the PVC template, if available.
+                        If not specified, the generated PVCs will use the
+                        default storage class
+                      type: string
+                  type: object
+              required:
+                - instances
+              type: object
+              x-kubernetes-validations:
+                - message: imageName and imageCatalogRef are mutually exclusive
+                  rule: '!(has(self.imageCatalogRef) && has(self.imageName))'
+            status:
+              description: |-
+                Most recently observed status of the cluster. This data may not be up
+                to date. Populated by the system. Read-only.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                availableArchitectures:
+                  description: AvailableArchitectures reports the available architectures of a cluster
+                  items:
+                    description: AvailableArchitecture represents the state of a cluster's architecture
+                    properties:
+                      goArch:
+                        description: GoArch is the name of the executable architecture
+                        type: string
+                      hash:
+                        description: Hash is the hash of the executable
+                        type: string
+                    required:
+                      - goArch
+                      - hash
+                    type: object
+                  type: array
+                certificates:
+                  description: The configuration for the CA and related certificates, initialized with defaults.
+                  properties:
+                    clientCASecret:
+                      description: |-
+                        The secret containing the Client CA certificate. If not defined, a new secret will be created
+                        with a self-signed CA and will be used to generate all the client certificates.<br />
+                        <br />
+                        Contains:<br />
+                        <br />
+                        - `ca.crt`: CA that should be used to validate the client certificates,
+                        used as `ssl_ca_file` of all the instances.<br />
+                        - `ca.key`: key used to generate client certificates, if ReplicationTLSSecret is provided,
+                        this can be omitted.<br />
+                      type: string
+                    expirations:
+                      additionalProperties:
+                        type: string
+                      description: Expiration dates for all certificates.
+                      type: object
+                    replicationTLSSecret:
+                      description: |-
+                        The secret of type kubernetes.io/tls containing the client certificate to authenticate as
+                        the `streaming_replica` user.
+                        If not defined, ClientCASecret must provide also `ca.key`, and a new secret will be
+                        created using the provided CA.
+                      type: string
+                    serverAltDNSNames:
+                      description: The list of the server alternative DNS names to be added to the generated server TLS certificates, when required.
+                      items:
+                        type: string
+                      type: array
+                    serverCASecret:
+                      description: |-
+                        The secret containing the Server CA certificate. If not defined, a new secret will be created
+                        with a self-signed CA and will be used to generate the TLS certificate ServerTLSSecret.<br />
+                        <br />
+                        Contains:<br />
+                        <br />
+                        - `ca.crt`: CA that should be used to validate the server certificate,
+                        used as `sslrootcert` in client connection strings.<br />
+                        - `ca.key`: key used to generate Server SSL certs, if ServerTLSSecret is provided,
+                        this can be omitted.<br />
+                      type: string
+                    serverTLSSecret:
+                      description: |-
+                        The secret of type kubernetes.io/tls containing the server TLS certificate and key that will be set as
+                        `ssl_cert_file` and `ssl_key_file` so that clients can connect to postgres securely.
+                        If not defined, ServerCASecret must provide also `ca.key` and a new secret will be
+                        created using the provided CA.
+                      type: string
+                  type: object
+                cloudNativePGCommitHash:
+                  description: The commit hash number of which this operator running
+                  type: string
+                cloudNativePGOperatorHash:
+                  description: The hash of the binary of the operator
+                  type: string
+                conditions:
+                  description: Conditions for cluster object
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                configMapResourceVersion:
+                  description: |-
+                    The list of resource versions of the configmaps,
+                    managed by the operator. Every change here is done in the
+                    interest of the instance manager, which will refresh the
+                    configmap data
+                  properties:
+                    metrics:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        A map with the versions of all the config maps used to pass metrics.
+                        Map keys are the config map names, map values are the versions
+                      type: object
+                  type: object
+                currentPrimary:
+                  description: Current primary instance
+                  type: string
+                currentPrimaryFailingSinceTimestamp:
+                  description: |-
+                    The timestamp when the primary was detected to be unhealthy
+                    This field is reported when `.spec.failoverDelay` is populated or during online upgrades
+                  type: string
+                currentPrimaryTimestamp:
+                  description: The timestamp when the last actual promotion to primary has occurred
+                  type: string
+                danglingPVC:
+                  description: |-
+                    List of all the PVCs created by this cluster and still available
+                    which are not attached to a Pod
+                  items:
+                    type: string
+                  type: array
+                demotionToken:
+                  description: |-
+                    DemotionToken is a JSON token containing the information
+                    from pg_controldata such as Database system identifier, Latest checkpoint's
+                    TimeLineID, Latest checkpoint's REDO location, Latest checkpoint's REDO
+                    WAL file, and Time of latest checkpoint
+                  type: string
+                firstRecoverabilityPoint:
+                  description: |-
+                    The first recoverability point, stored as a date in RFC3339 format.
+                    This field is calculated from the content of FirstRecoverabilityPointByMethod.
+
+                    Deprecated: the field is not set for backup plugins.
+                  type: string
+                firstRecoverabilityPointByMethod:
+                  additionalProperties:
+                    format: date-time
+                    type: string
+                  description: |-
+                    The first recoverability point, stored as a date in RFC3339 format, per backup method type.
+
+                    Deprecated: the field is not set for backup plugins.
+                  type: object
+                healthyPVC:
+                  description: List of all the PVCs not dangling nor initializing
+                  items:
+                    type: string
+                  type: array
+                image:
+                  description: Image contains the image name used by the pods
+                  type: string
+                initializingPVC:
+                  description: List of all the PVCs that are being initialized by this cluster
+                  items:
+                    type: string
+                  type: array
+                instanceNames:
+                  description: List of instance names in the cluster
+                  items:
+                    type: string
+                  type: array
+                instances:
+                  description: The total number of PVC Groups detected in the cluster. It may differ from the number of existing instance pods.
+                  type: integer
+                instancesReportedState:
+                  additionalProperties:
+                    description: InstanceReportedState describes the last reported state of an instance during a reconciliation loop
+                    properties:
+                      ip:
+                        description: IP address of the instance
+                        type: string
+                      isPrimary:
+                        description: indicates if an instance is the primary one
+                        type: boolean
+                      timeLineID:
+                        description: indicates on which TimelineId the instance is
+                        type: integer
+                    required:
+                      - isPrimary
+                    type: object
+                  description: The reported state of the instances during the last reconciliation loop
+                  type: object
+                instancesStatus:
+                  additionalProperties:
+                    items:
+                      type: string
+                    type: array
+                  description: InstancesStatus indicates in which status the instances are
+                  type: object
+                jobCount:
+                  description: How many Jobs have been created by this cluster
+                  format: int32
+                  type: integer
+                lastFailedBackup:
+                  description: |-
+                    Last failed backup, stored as a date in RFC3339 format.
+
+                    Deprecated: the field is not set for backup plugins.
+                  type: string
+                lastPromotionToken:
+                  description: |-
+                    LastPromotionToken is the last verified promotion token that
+                    was used to promote a replica cluster
+                  type: string
+                lastSuccessfulBackup:
+                  description: |-
+                    Last successful backup, stored as a date in RFC3339 format.
+                    This field is calculated from the content of LastSuccessfulBackupByMethod.
+
+                    Deprecated: the field is not set for backup plugins.
+                  type: string
+                lastSuccessfulBackupByMethod:
+                  additionalProperties:
+                    format: date-time
+                    type: string
+                  description: |-
+                    Last successful backup, stored as a date in RFC3339 format, per backup method type.
+
+                    Deprecated: the field is not set for backup plugins.
+                  type: object
+                latestGeneratedNode:
+                  description: ID of the latest generated node (used to avoid node name clashing)
+                  type: integer
+                managedRolesStatus:
+                  description: ManagedRolesStatus reports the state of the managed roles in the cluster
+                  properties:
+                    byStatus:
+                      additionalProperties:
+                        items:
+                          type: string
+                        type: array
+                      description: ByStatus gives the list of roles in each state
+                      type: object
+                    cannotReconcile:
+                      additionalProperties:
+                        items:
+                          type: string
+                        type: array
+                      description: |-
+                        CannotReconcile lists roles that cannot be reconciled in PostgreSQL,
+                        with an explanation of the cause
+                      type: object
+                    passwordStatus:
+                      additionalProperties:
+                        description: PasswordState represents the state of the password of a managed RoleConfiguration
+                        properties:
+                          resourceVersion:
+                            description: the resource version of the password secret
+                            type: string
+                          transactionID:
+                            description: the last transaction ID to affect the role definition in PostgreSQL
+                            format: int64
+                            type: integer
+                        type: object
+                      description: PasswordStatus gives the last transaction id and password secret version for each managed role
+                      type: object
+                  type: object
+                onlineUpdateEnabled:
+                  description: OnlineUpdateEnabled shows if the online upgrade is enabled inside the cluster
+                  type: boolean
+                pgDataImageInfo:
+                  description: PGDataImageInfo contains the details of the latest image that has run on the current data directory.
+                  properties:
+                    extensions:
+                      description: Extensions contains the container image extensions available for the current Image
+                      items:
+                        description: |-
+                          ExtensionConfiguration is the configuration used to add
+                          PostgreSQL extensions to the Cluster.
+                        properties:
+                          bin_path:
+                            description: |-
+                              A list of directories within the image to be appended to the
+                              PostgreSQL process's `PATH` environment variable.
+                            items:
+                              type: string
+                            type: array
+                          dynamic_library_path:
+                            description: |-
+                              The list of directories inside the image which should be added to dynamic_library_path.
+                              If not defined, defaults to "/lib".
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: |-
+                              Env is a list of custom environment variables to be set in the
+                              PostgreSQL process for this extension. It is the responsibility of the
+                              cluster administrator to ensure the variables are correct for the
+                              specific extension. Note that changes to these variables require
+                              a manual cluster restart to take effect.
+                            items:
+                              description: |-
+                                ExtensionEnvVar defines an environment variable for a specific extension
+                                image volume.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable to be injected into the
+                                    PostgreSQL process.
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value of the environment variable. CloudNativePG performs a direct
+                                    replacement of this value, with support for placeholder expansion.
+                                    The ${`image_root`} placeholder resolves to the absolute mount path
+                                    of the extension's volume (e.g., `/extensions/my-extension`). This
+                                    is particularly useful for allowing applications or libraries to
+                                    locate specific directories within the mounted image.
+                                    Unrecognized placeholders are rejected. To include a literal ${...}
+                                    in the value, escape it as $${...}.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
+                          extension_control_path:
+                            description: |-
+                              The list of directories inside the image which should be added to extension_control_path.
+                              If not defined, defaults to "/share".
+                            items:
+                              type: string
+                            type: array
+                          image:
+                            description: The image containing the extension.
+                            properties:
+                              pullPolicy:
+                                description: |-
+                                  Policy for pulling OCI objects. Possible values are:
+                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                type: string
+                              reference:
+                                description: |-
+                                  Required: Image or artifact reference to be used.
+                                  Behaves in the same way as pod.spec.containers[*].image.
+                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                            type: object
+                          ld_library_path:
+                            description: The list of directories inside the image which should be added to ld_library_path.
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            description: The name of the extension, required
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    image:
+                      description: Image is the image name
+                      type: string
+                    majorVersion:
+                      description: MajorVersion is the major version of the image
+                      type: integer
+                  required:
+                    - image
+                    - majorVersion
+                  type: object
+                phase:
+                  description: Current phase of the cluster
+                  type: string
+                phaseReason:
+                  description: Reason for the current phase
+                  type: string
+                pluginStatus:
+                  description: PluginStatus is the status of the loaded plugins
+                  items:
+                    description: PluginStatus is the status of a loaded plugin
+                    properties:
+                      backupCapabilities:
+                        description: |-
+                          BackupCapabilities are the list of capabilities of the
+                          plugin regarding the Backup management
+                        items:
+                          type: string
+                        type: array
+                      capabilities:
+                        description: |-
+                          Capabilities are the list of capabilities of the
+                          plugin
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: Name is the name of the plugin
+                        type: string
+                      operatorCapabilities:
+                        description: |-
+                          OperatorCapabilities are the list of capabilities of the
+                          plugin regarding the reconciler
+                        items:
+                          type: string
+                        type: array
+                      restoreJobHookCapabilities:
+                        description: |-
+                          RestoreJobHookCapabilities are the list of capabilities of the
+                          plugin regarding the RestoreJobHook management
+                        items:
+                          type: string
+                        type: array
+                      status:
+                        description: Status contain the status reported by the plugin through the SetStatusInCluster interface
+                        type: string
+                      version:
+                        description: |-
+                          Version is the version of the plugin loaded by the
+                          latest reconciliation loop
+                        type: string
+                      walCapabilities:
+                        description: |-
+                          WALCapabilities are the list of capabilities of the
+                          plugin regarding the WAL management
+                        items:
+                          type: string
+                        type: array
+                    required:
+                      - name
+                      - version
+                    type: object
+                  type: array
+                podSelectorRefs:
+                  description: |-
+                    PodSelectorRefs contains the resolved pod IPs for each named selector
+                    defined in spec.podSelectorRefs.
+                  items:
+                    description: PodSelectorRefStatus contains the resolved pod IPs for a named selector.
+                    properties:
+                      ips:
+                        description: |-
+                          IPs is the list of pod IPs matching the selector.
+                          Each IP is a single address (no CIDR notation).
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: Name corresponds to the name in the spec's PodSelectorRef.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                poolerIntegrations:
+                  description: The integration needed by poolers referencing the cluster
+                  properties:
+                    pgBouncerIntegration:
+                      description: PgBouncerIntegrationStatus encapsulates the needed integration for the pgbouncer poolers referencing the cluster
+                      properties:
+                        secrets:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                  type: object
+                pvcCount:
+                  description: How many PVCs have been created by this cluster
+                  format: int32
+                  type: integer
+                readService:
+                  description: Current list of read pods
+                  type: string
+                readyInstances:
+                  description: The total number of ready instances in the cluster. It is equal to the number of ready instance pods.
+                  type: integer
+                resizingPVC:
+                  description: List of all the PVCs that have ResizingPVC condition.
+                  items:
+                    type: string
+                  type: array
+                secretsResourceVersion:
+                  description: |-
+                    The list of resource versions of the secrets
+                    managed by the operator. Every change here is done in the
+                    interest of the instance manager, which will refresh the
+                    secret data
+                  properties:
+                    applicationSecretVersion:
+                      description: The resource version of the "app" user secret
+                      type: string
+                    barmanEndpointCA:
+                      description: The resource version of the Barman Endpoint CA if provided
+                      type: string
+                    caSecretVersion:
+                      description: Unused. Retained for compatibility with old versions.
+                      type: string
+                    clientCaSecretVersion:
+                      description: The resource version of the PostgreSQL client-side CA secret version
+                      type: string
+                    externalClusterSecretVersion:
+                      additionalProperties:
+                        type: string
+                      description: The resource versions of the external cluster secrets
+                      type: object
+                    managedRoleSecretVersion:
+                      additionalProperties:
+                        type: string
+                      description: The resource versions of the managed roles secrets
+                      type: object
+                    metrics:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        A map with the versions of all the secrets used to pass metrics.
+                        Map keys are the secret names, map values are the versions
+                      type: object
+                    replicationSecretVersion:
+                      description: The resource version of the "streaming_replica" user secret
+                      type: string
+                    serverCaSecretVersion:
+                      description: The resource version of the PostgreSQL server-side CA secret version
+                      type: string
+                    serverSecretVersion:
+                      description: The resource version of the PostgreSQL server-side secret version
+                      type: string
+                    superuserSecretVersion:
+                      description: The resource version of the "postgres" user secret
+                      type: string
+                  type: object
+                switchReplicaClusterStatus:
+                  description: SwitchReplicaClusterStatus is the status of the switch to replica cluster
+                  properties:
+                    inProgress:
+                      description: InProgress indicates if there is an ongoing procedure of switching a cluster to a replica cluster.
+                      type: boolean
+                  type: object
+                systemID:
+                  description: SystemID is the latest detected PostgreSQL SystemID
+                  type: string
+                tablespacesStatus:
+                  description: TablespacesStatus reports the state of the declarative tablespaces in the cluster
+                  items:
+                    description: TablespaceState represents the state of a tablespace in a cluster
+                    properties:
+                      error:
+                        description: Error is the reconciliation error, if any
+                        type: string
+                      name:
+                        description: Name is the name of the tablespace
+                        type: string
+                      owner:
+                        description: Owner is the PostgreSQL user owning the tablespace
+                        type: string
+                      state:
+                        description: State is the latest reconciliation state
+                        type: string
+                    required:
+                      - name
+                      - state
+                    type: object
+                  type: array
+                targetPrimary:
+                  description: |-
+                    Target primary instance, this is different from the previous one
+                    during a switchover or a failover
+                  type: string
+                targetPrimaryTimestamp:
+                  description: The timestamp when the last request for a new primary has occurred
+                  type: string
+                timelineID:
+                  description: The timeline of the Postgres cluster
+                  type: integer
+                topology:
+                  description: Instances topology.
+                  properties:
+                    instances:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        description: PodTopologyLabels represent the topology of a Pod. map[labelName]labelValue
+                        type: object
+                      description: Instances contains the pod topology of the instances
+                      type: object
+                    nodesUsed:
+                      description: |-
+                        NodesUsed represents the count of distinct nodes accommodating the instances.
+                        A value of '1' suggests that all instances are hosted on a single node,
+                        implying the absence of High Availability (HA). Ideally, this value should
+                        be the same as the number of instances in the Postgres HA cluster, implying
+                        shared nothing architecture on the compute side.
+                      format: int32
+                      type: integer
+                    successfullyExtracted:
+                      description: |-
+                        SuccessfullyExtracted indicates if the topology data was extract. It is useful to enact fallback behaviors
+                        in synchronous replica election in case of failures
+                      type: boolean
+                  type: object
+                unusablePVC:
+                  description: List of all the PVCs that are unusable because another PVC is missing
+                  items:
+                    type: string
+                  type: array
+                writeService:
+                  description: Current write pod
+                  type: string
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        scale:
+          specReplicasPath: .spec.instances
+          statusReplicasPath: .status.instances
+        status: {}

--- a/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-databases-postgresql-cnpg-io.yaml
+++ b/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-databases-postgresql-cnpg-io.yaml
@@ -1,0 +1,579 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+    helm.sh/resource-policy: keep
+  name: databases.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: Database
+    listKind: DatabaseList
+    plural: databases
+    singular: database
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.cluster.name
+          name: Cluster
+          type: string
+        - jsonPath: .spec.name
+          name: PG Name
+          type: string
+        - jsonPath: .status.applied
+          name: Applied
+          type: boolean
+        - description: Latest reconciliation message
+          jsonPath: .status.message
+          name: Message
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: Database is the Schema for the databases API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Specification of the desired Database.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                allowConnections:
+                  description: |-
+                    Maps to the `ALLOW_CONNECTIONS` parameter of `CREATE DATABASE` and
+                    `ALTER DATABASE`. If false then no one can connect to this database.
+                  type: boolean
+                builtinLocale:
+                  description: |-
+                    Maps to the `BUILTIN_LOCALE` parameter of `CREATE DATABASE`. This
+                    setting cannot be changed. Specifies the locale name when the
+                    builtin provider is used. This option requires `localeProvider` to
+                    be set to `builtin`. Available from PostgreSQL 17.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: builtinLocale is immutable
+                      rule: self == oldSelf
+                cluster:
+                  description: The name of the PostgreSQL cluster hosting the database.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                collationVersion:
+                  description: |-
+                    Maps to the `COLLATION_VERSION` parameter of `CREATE DATABASE`. This
+                    setting cannot be changed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: collationVersion is immutable
+                      rule: self == oldSelf
+                connectionLimit:
+                  description: |-
+                    Maps to the `CONNECTION LIMIT` clause of `CREATE DATABASE` and
+                    `ALTER DATABASE`. How many concurrent connections can be made to
+                    this database. -1 (the default) means no limit.
+                  type: integer
+                databaseReclaimPolicy:
+                  default: retain
+                  description: The policy for end-of-life maintenance of this database.
+                  enum:
+                    - delete
+                    - retain
+                  type: string
+                encoding:
+                  description: |-
+                    Maps to the `ENCODING` parameter of `CREATE DATABASE`. This setting
+                    cannot be changed. Character set encoding to use in the database.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: encoding is immutable
+                      rule: self == oldSelf
+                ensure:
+                  default: present
+                  description: Ensure the PostgreSQL database is `present` or `absent` - defaults to "present".
+                  enum:
+                    - present
+                    - absent
+                  type: string
+                extensions:
+                  description: The list of extensions to be managed in the database
+                  items:
+                    description: ExtensionSpec configures an extension in a database
+                    properties:
+                      ensure:
+                        default: present
+                        description: |-
+                          Specifies whether an object (e.g schema) should be present or absent
+                          in the database. If set to `present`, the object will be created if
+                          it does not exist. If set to `absent`, the extension/schema will be
+                          removed if it exists.
+                        enum:
+                          - present
+                          - absent
+                        type: string
+                      name:
+                        description: Name of the object (extension, schema, FDW, server)
+                        type: string
+                      schema:
+                        description: |-
+                          The name of the schema in which to install the extension's objects,
+                          in case the extension allows its contents to be relocated. If not
+                          specified (default), and the extension's control file does not
+                          specify a schema either, the current default object creation schema
+                          is used.
+                        type: string
+                      version:
+                        description: |-
+                          The version of the extension to install. If empty, the operator will
+                          install the default version (whatever is specified in the
+                          extension's control file)
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                fdws:
+                  description: The list of foreign data wrappers to be managed in the database
+                  items:
+                    description: FDWSpec configures an Foreign Data Wrapper in a database
+                    properties:
+                      ensure:
+                        default: present
+                        description: |-
+                          Specifies whether an object (e.g schema) should be present or absent
+                          in the database. If set to `present`, the object will be created if
+                          it does not exist. If set to `absent`, the extension/schema will be
+                          removed if it exists.
+                        enum:
+                          - present
+                          - absent
+                        type: string
+                      handler:
+                        description: |-
+                          Name of the handler function (e.g., "postgres_fdw_handler").
+                          This will be empty if no handler is specified. In that case,
+                          the default handler is registered when the FDW extension is created.
+                        type: string
+                      name:
+                        description: Name of the object (extension, schema, FDW, server)
+                        type: string
+                      options:
+                        description: Options specifies the configuration options for the FDW.
+                        items:
+                          description: OptionSpec holds the name, value and the ensure field for an option
+                          properties:
+                            ensure:
+                              default: present
+                              description: |-
+                                Specifies whether an option should be present or absent in
+                                the database. If set to `present`, the option will be
+                                created if it does not exist. If set to `absent`, the
+                                option will be removed if it exists.
+                              enum:
+                                - present
+                                - absent
+                              type: string
+                            name:
+                              description: Name of the option
+                              type: string
+                            value:
+                              description: Value of the option
+                              type: string
+                          required:
+                            - name
+                            - value
+                          type: object
+                        type: array
+                      owner:
+                        description: |-
+                          Owner specifies the database role that will own the Foreign Data Wrapper.
+                          The role must have superuser privileges in the target database.
+                        type: string
+                      usage:
+                        description: List of roles for which `USAGE` privileges on the FDW are granted or revoked.
+                        items:
+                          description: UsageSpec configures a usage for a foreign data wrapper
+                          properties:
+                            name:
+                              description: Name of the usage
+                              type: string
+                              x-kubernetes-validations:
+                                - message: name is required
+                                  rule: self != ''
+                            type:
+                              default: grant
+                              description: The type of usage
+                              enum:
+                                - grant
+                                - revoke
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                      validator:
+                        description: |-
+                          Name of the validator function (e.g., "postgres_fdw_validator").
+                          This will be empty if no validator is specified. In that case,
+                          the default validator is registered when the FDW extension is created.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                icuLocale:
+                  description: |-
+                    Maps to the `ICU_LOCALE` parameter of `CREATE DATABASE`. This
+                    setting cannot be changed. Specifies the ICU locale when the ICU
+                    provider is used. This option requires `localeProvider` to be set to
+                    `icu`. Available from PostgreSQL 15.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: icuLocale is immutable
+                      rule: self == oldSelf
+                icuRules:
+                  description: |-
+                    Maps to the `ICU_RULES` parameter of `CREATE DATABASE`. This setting
+                    cannot be changed. Specifies additional collation rules to customize
+                    the behavior of the default collation. This option requires
+                    `localeProvider` to be set to `icu`. Available from PostgreSQL 16.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: icuRules is immutable
+                      rule: self == oldSelf
+                isTemplate:
+                  description: |-
+                    Maps to the `IS_TEMPLATE` parameter of `CREATE DATABASE` and `ALTER
+                    DATABASE`. If true, this database is considered a template and can
+                    be cloned by any user with `CREATEDB` privileges.
+                  type: boolean
+                locale:
+                  description: |-
+                    Maps to the `LOCALE` parameter of `CREATE DATABASE`. This setting
+                    cannot be changed. Sets the default collation order and character
+                    classification in the new database.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: locale is immutable
+                      rule: self == oldSelf
+                localeCType:
+                  description: |-
+                    Maps to the `LC_CTYPE` parameter of `CREATE DATABASE`. This setting
+                    cannot be changed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: localeCType is immutable
+                      rule: self == oldSelf
+                localeCollate:
+                  description: |-
+                    Maps to the `LC_COLLATE` parameter of `CREATE DATABASE`. This
+                    setting cannot be changed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: localeCollate is immutable
+                      rule: self == oldSelf
+                localeProvider:
+                  description: |-
+                    Maps to the `LOCALE_PROVIDER` parameter of `CREATE DATABASE`. This
+                    setting cannot be changed. This option sets the locale provider for
+                    databases created in the new cluster. Available from PostgreSQL 16.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: localeProvider is immutable
+                      rule: self == oldSelf
+                name:
+                  description: The name of the database to create inside PostgreSQL. This setting cannot be changed.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: name is immutable
+                      rule: self == oldSelf
+                    - message: the name postgres is reserved
+                      rule: self != 'postgres'
+                    - message: the name template0 is reserved
+                      rule: self != 'template0'
+                    - message: the name template1 is reserved
+                      rule: self != 'template1'
+                owner:
+                  description: |-
+                    Maps to the `OWNER` parameter of `CREATE DATABASE`.
+                    Maps to the `OWNER TO` command of `ALTER DATABASE`.
+                    The role name of the user who owns the database inside PostgreSQL.
+                  type: string
+                schemas:
+                  description: The list of schemas to be managed in the database
+                  items:
+                    description: SchemaSpec configures a schema in a database
+                    properties:
+                      ensure:
+                        default: present
+                        description: |-
+                          Specifies whether an object (e.g schema) should be present or absent
+                          in the database. If set to `present`, the object will be created if
+                          it does not exist. If set to `absent`, the extension/schema will be
+                          removed if it exists.
+                        enum:
+                          - present
+                          - absent
+                        type: string
+                      name:
+                        description: Name of the object (extension, schema, FDW, server)
+                        type: string
+                      owner:
+                        description: |-
+                          The role name of the user who owns the schema inside PostgreSQL.
+                          It maps to the `AUTHORIZATION` parameter of `CREATE SCHEMA` and the
+                          `OWNER TO` command of `ALTER SCHEMA`.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                servers:
+                  description: The list of foreign servers to be managed in the database
+                  items:
+                    description: ServerSpec configures a server of a foreign data wrapper
+                    properties:
+                      ensure:
+                        default: present
+                        description: |-
+                          Specifies whether an object (e.g schema) should be present or absent
+                          in the database. If set to `present`, the object will be created if
+                          it does not exist. If set to `absent`, the extension/schema will be
+                          removed if it exists.
+                        enum:
+                          - present
+                          - absent
+                        type: string
+                      fdw:
+                        description: The name of the Foreign Data Wrapper (FDW)
+                        type: string
+                        x-kubernetes-validations:
+                          - message: fdw is required
+                            rule: self != ''
+                      name:
+                        description: Name of the object (extension, schema, FDW, server)
+                        type: string
+                      options:
+                        description: |-
+                          Options specifies the configuration options for the server
+                          (key is the option name, value is the option value).
+                        items:
+                          description: OptionSpec holds the name, value and the ensure field for an option
+                          properties:
+                            ensure:
+                              default: present
+                              description: |-
+                                Specifies whether an option should be present or absent in
+                                the database. If set to `present`, the option will be
+                                created if it does not exist. If set to `absent`, the
+                                option will be removed if it exists.
+                              enum:
+                                - present
+                                - absent
+                              type: string
+                            name:
+                              description: Name of the option
+                              type: string
+                            value:
+                              description: Value of the option
+                              type: string
+                          required:
+                            - name
+                            - value
+                          type: object
+                        type: array
+                      usage:
+                        description: List of roles for which `USAGE` privileges on the server are granted or revoked.
+                        items:
+                          description: UsageSpec configures a usage for a foreign data wrapper
+                          properties:
+                            name:
+                              description: Name of the usage
+                              type: string
+                              x-kubernetes-validations:
+                                - message: name is required
+                                  rule: self != ''
+                            type:
+                              default: grant
+                              description: The type of usage
+                              enum:
+                                - grant
+                                - revoke
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                    required:
+                      - fdw
+                      - name
+                    type: object
+                  type: array
+                tablespace:
+                  description: |-
+                    Maps to the `TABLESPACE` parameter of `CREATE DATABASE`.
+                    Maps to the `SET TABLESPACE` command of `ALTER DATABASE`.
+                    The name of the tablespace (in PostgreSQL) that will be associated
+                    with the new database. This tablespace will be the default
+                    tablespace used for objects created in this database.
+                  type: string
+                template:
+                  description: |-
+                    Maps to the `TEMPLATE` parameter of `CREATE DATABASE`. This setting
+                    cannot be changed. The name of the template from which to create
+                    this database.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: template is immutable
+                      rule: self == oldSelf
+              required:
+                - cluster
+                - name
+                - owner
+              type: object
+              x-kubernetes-validations:
+                - message: builtinLocale is only available when localeProvider is set to `builtin`
+                  rule: '!has(self.builtinLocale) || self.localeProvider == ''builtin'''
+                - message: icuLocale is only available when localeProvider is set to `icu`
+                  rule: '!has(self.icuLocale) || self.localeProvider == ''icu'''
+                - message: icuRules is only available when localeProvider is set to `icu`
+                  rule: '!has(self.icuRules) || self.localeProvider == ''icu'''
+            status:
+              description: |-
+                Most recently observed status of the Database. This data may not be up to
+                date. Populated by the system. Read-only.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                applied:
+                  description: Applied is true if the database was reconciled correctly
+                  type: boolean
+                extensions:
+                  description: Extensions is the status of the managed extensions
+                  items:
+                    description: DatabaseObjectStatus is the status of the managed database objects
+                    properties:
+                      applied:
+                        description: |-
+                          True of the object has been installed successfully in
+                          the database
+                        type: boolean
+                      message:
+                        description: Message is the object reconciliation message
+                        type: string
+                      name:
+                        description: The name of the object
+                        type: string
+                    required:
+                      - applied
+                      - name
+                    type: object
+                  type: array
+                fdws:
+                  description: FDWs is the status of the managed FDWs
+                  items:
+                    description: DatabaseObjectStatus is the status of the managed database objects
+                    properties:
+                      applied:
+                        description: |-
+                          True of the object has been installed successfully in
+                          the database
+                        type: boolean
+                      message:
+                        description: Message is the object reconciliation message
+                        type: string
+                      name:
+                        description: The name of the object
+                        type: string
+                    required:
+                      - applied
+                      - name
+                    type: object
+                  type: array
+                message:
+                  description: Message is the reconciliation output message
+                  type: string
+                observedGeneration:
+                  description: |-
+                    A sequence number representing the latest
+                    desired state that was synchronized
+                  format: int64
+                  type: integer
+                schemas:
+                  description: Schemas is the status of the managed schemas
+                  items:
+                    description: DatabaseObjectStatus is the status of the managed database objects
+                    properties:
+                      applied:
+                        description: |-
+                          True of the object has been installed successfully in
+                          the database
+                        type: boolean
+                      message:
+                        description: Message is the object reconciliation message
+                        type: string
+                      name:
+                        description: The name of the object
+                        type: string
+                    required:
+                      - applied
+                      - name
+                    type: object
+                  type: array
+                servers:
+                  description: Servers is the status of the managed servers
+                  items:
+                    description: DatabaseObjectStatus is the status of the managed database objects
+                    properties:
+                      applied:
+                        description: |-
+                          True of the object has been installed successfully in
+                          the database
+                        type: boolean
+                      message:
+                        description: Message is the object reconciliation message
+                        type: string
+                      name:
+                        description: The name of the object
+                        type: string
+                    required:
+                      - applied
+                      - name
+                    type: object
+                  type: array
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-failoverquorums-postgresql-cnpg-io.yaml
+++ b/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-failoverquorums-postgresql-cnpg-io.yaml
@@ -1,0 +1,77 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+    helm.sh/resource-policy: keep
+  name: failoverquorums.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: FailoverQuorum
+    listKind: FailoverQuorumList
+    plural: failoverquorums
+    singular: failoverquorum
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            FailoverQuorum contains the information about the current failover
+            quorum status of a PG cluster. It is updated by the instance manager
+            of the primary node and reset to zero by the operator to trigger
+            an update.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            status:
+              description: Most recently observed status of the failover quorum.
+              properties:
+                method:
+                  description: Contains the latest reported Method value.
+                  type: string
+                primary:
+                  description: |-
+                    Primary is the name of the primary instance that updated
+                    this object the latest time.
+                  type: string
+                standbyNames:
+                  description: |-
+                    StandbyNames is the list of potentially synchronous
+                    instance names.
+                  items:
+                    type: string
+                  type: array
+                standbyNumber:
+                  description: |-
+                    StandbyNumber is the number of synchronous standbys that transactions
+                    need to wait for replies from.
+                  type: integer
+              type: object
+          required:
+            - metadata
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-imagecatalogs-postgresql-cnpg-io.yaml
+++ b/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-imagecatalogs-postgresql-cnpg-io.yaml
@@ -1,0 +1,184 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+    helm.sh/resource-policy: keep
+  name: imagecatalogs.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: ImageCatalog
+    listKind: ImageCatalogList
+    plural: imagecatalogs
+    singular: imagecatalog
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ImageCatalog is the Schema for the imagecatalogs API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Specification of the desired behavior of the ImageCatalog.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                images:
+                  description: List of CatalogImages available in the catalog
+                  items:
+                    description: CatalogImage defines the image and major version
+                    properties:
+                      extensions:
+                        description: The configuration of the extensions to be added
+                        items:
+                          description: |-
+                            ExtensionConfiguration is the configuration used to add
+                            PostgreSQL extensions to the Cluster.
+                          properties:
+                            bin_path:
+                              description: |-
+                                A list of directories within the image to be appended to the
+                                PostgreSQL process's `PATH` environment variable.
+                              items:
+                                type: string
+                              type: array
+                            dynamic_library_path:
+                              description: |-
+                                The list of directories inside the image which should be added to dynamic_library_path.
+                                If not defined, defaults to "/lib".
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: |-
+                                Env is a list of custom environment variables to be set in the
+                                PostgreSQL process for this extension. It is the responsibility of the
+                                cluster administrator to ensure the variables are correct for the
+                                specific extension. Note that changes to these variables require
+                                a manual cluster restart to take effect.
+                              items:
+                                description: |-
+                                  ExtensionEnvVar defines an environment variable for a specific extension
+                                  image volume.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the environment variable to be injected into the
+                                      PostgreSQL process.
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value of the environment variable. CloudNativePG performs a direct
+                                      replacement of this value, with support for placeholder expansion.
+                                      The ${`image_root`} placeholder resolves to the absolute mount path
+                                      of the extension's volume (e.g., `/extensions/my-extension`). This
+                                      is particularly useful for allowing applications or libraries to
+                                      locate specific directories within the mounted image.
+                                      Unrecognized placeholders are rejected. To include a literal ${...}
+                                      in the value, escape it as $${...}.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            extension_control_path:
+                              description: |-
+                                The list of directories inside the image which should be added to extension_control_path.
+                                If not defined, defaults to "/share".
+                              items:
+                                type: string
+                              type: array
+                            image:
+                              description: The image containing the extension.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                              type: object
+                            ld_library_path:
+                              description: The list of directories inside the image which should be added to ld_library_path.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the extension, required
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
+                      image:
+                        description: The image reference
+                        type: string
+                      major:
+                        description: The PostgreSQL major version of the image. Must be unique within the catalog.
+                        minimum: 10
+                        type: integer
+                    required:
+                      - image
+                      - major
+                    type: object
+                  maxItems: 8
+                  minItems: 1
+                  type: array
+                  x-kubernetes-validations:
+                    - message: Images must have unique major versions
+                      rule: self.all(e, self.filter(f, f.major==e.major).size() == 1)
+              required:
+                - images
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-poolers-postgresql-cnpg-io.yaml
+++ b/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-poolers-postgresql-cnpg-io.yaml
@@ -1,0 +1,8976 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+    helm.sh/resource-policy: keep
+  name: poolers.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: Pooler
+    listKind: PoolerList
+    plural: poolers
+    singular: pooler
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.cluster.name
+          name: Cluster
+          type: string
+        - jsonPath: .spec.type
+          name: Type
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: Pooler is the Schema for the poolers API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Specification of the desired behavior of the Pooler.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                cluster:
+                  description: |-
+                    This is the cluster reference on which the Pooler will work.
+                    Pooler name should never match with any cluster name within the same namespace.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                deploymentStrategy:
+                  description: The deployment strategy to use for pgbouncer to replace existing pods with new ones
+                  properties:
+                    rollingUpdate:
+                      description: |-
+                        Rolling update config params. Present only if DeploymentStrategyType =
+                        RollingUpdate.
+                      properties:
+                        maxSurge:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: |-
+                            The maximum number of pods that can be scheduled above the desired number of
+                            pods.
+                            Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                            This can not be 0 if MaxUnavailable is 0.
+                            Absolute number is calculated from percentage by rounding up.
+                            Defaults to 25%.
+                            Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                            the rolling update starts, such that the total number of old and new pods do not exceed
+                            130% of desired pods. Once old pods have been killed,
+                            new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                            at any time during the update is at most 130% of desired pods.
+                          x-kubernetes-int-or-string: true
+                        maxUnavailable:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: |-
+                            The maximum number of pods that can be unavailable during the update.
+                            Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                            Absolute number is calculated from percentage by rounding down.
+                            This can not be 0 if MaxSurge is 0.
+                            Defaults to 25%.
+                            Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                            immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                            can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                            that the total number of pods available at all times during the update is at
+                            least 70% of desired pods.
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    type:
+                      description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                      type: string
+                  type: object
+                instances:
+                  default: 1
+                  description: 'The number of replicas we want. Default: 1.'
+                  format: int32
+                  type: integer
+                monitoring:
+                  description: |-
+                    The configuration of the monitoring infrastructure of this pooler.
+
+                    Deprecated: This feature will be removed in an upcoming release. If
+                    you need this functionality, you can create a PodMonitor manually.
+                  properties:
+                    enablePodMonitor:
+                      default: false
+                      description: Enable or disable the `PodMonitor`
+                      type: boolean
+                    podMonitorMetricRelabelings:
+                      description: The list of metric relabelings for the `PodMonitor`. Applied to samples before ingestion.
+                      items:
+                        description: |-
+                          RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                          scraped samples and remote write samples.
+
+                          More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                        properties:
+                          action:
+                            default: replace
+                            description: |-
+                              action to perform based on the regex matching.
+
+                              `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                              `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                              Default: "Replace"
+                            enum:
+                              - replace
+                              - Replace
+                              - keep
+                              - Keep
+                              - drop
+                              - Drop
+                              - hashmod
+                              - HashMod
+                              - labelmap
+                              - LabelMap
+                              - labeldrop
+                              - LabelDrop
+                              - labelkeep
+                              - LabelKeep
+                              - lowercase
+                              - Lowercase
+                              - uppercase
+                              - Uppercase
+                              - keepequal
+                              - KeepEqual
+                              - dropequal
+                              - DropEqual
+                            type: string
+                          modulus:
+                            description: |-
+                              modulus to take of the hash of the source label values.
+
+                              Only applicable when the action is `HashMod`.
+                            format: int64
+                            type: integer
+                          regex:
+                            description: regex defines the regular expression against which the extracted value is matched.
+                            type: string
+                          replacement:
+                            description: |-
+                              replacement value against which a Replace action is performed if the
+                              regular expression matches.
+
+                              Regex capture groups are available.
+                            type: string
+                          separator:
+                            description: separator defines the string between concatenated SourceLabels.
+                            type: string
+                          sourceLabels:
+                            description: |-
+                              sourceLabels defines the source labels select values from existing labels. Their content is
+                              concatenated using the configured Separator and matched against the
+                              configured regular expression.
+                            items:
+                              description: |-
+                                LabelName is a valid Prometheus label name.
+                                For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                                For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
+                              type: string
+                            type: array
+                          targetLabel:
+                            description: |-
+                              targetLabel defines the label to which the resulting string is written in a replacement.
+
+                              It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                              `KeepEqual` and `DropEqual` actions.
+
+                              Regex capture groups are available.
+                            type: string
+                        type: object
+                      type: array
+                    podMonitorRelabelings:
+                      description: The list of relabelings for the `PodMonitor`. Applied to samples before scraping.
+                      items:
+                        description: |-
+                          RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                          scraped samples and remote write samples.
+
+                          More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                        properties:
+                          action:
+                            default: replace
+                            description: |-
+                              action to perform based on the regex matching.
+
+                              `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                              `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                              Default: "Replace"
+                            enum:
+                              - replace
+                              - Replace
+                              - keep
+                              - Keep
+                              - drop
+                              - Drop
+                              - hashmod
+                              - HashMod
+                              - labelmap
+                              - LabelMap
+                              - labeldrop
+                              - LabelDrop
+                              - labelkeep
+                              - LabelKeep
+                              - lowercase
+                              - Lowercase
+                              - uppercase
+                              - Uppercase
+                              - keepequal
+                              - KeepEqual
+                              - dropequal
+                              - DropEqual
+                            type: string
+                          modulus:
+                            description: |-
+                              modulus to take of the hash of the source label values.
+
+                              Only applicable when the action is `HashMod`.
+                            format: int64
+                            type: integer
+                          regex:
+                            description: regex defines the regular expression against which the extracted value is matched.
+                            type: string
+                          replacement:
+                            description: |-
+                              replacement value against which a Replace action is performed if the
+                              regular expression matches.
+
+                              Regex capture groups are available.
+                            type: string
+                          separator:
+                            description: separator defines the string between concatenated SourceLabels.
+                            type: string
+                          sourceLabels:
+                            description: |-
+                              sourceLabels defines the source labels select values from existing labels. Their content is
+                              concatenated using the configured Separator and matched against the
+                              configured regular expression.
+                            items:
+                              description: |-
+                                LabelName is a valid Prometheus label name.
+                                For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                                For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
+                              type: string
+                            type: array
+                          targetLabel:
+                            description: |-
+                              targetLabel defines the label to which the resulting string is written in a replacement.
+
+                              It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                              `KeepEqual` and `DropEqual` actions.
+
+                              Regex capture groups are available.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                pgbouncer:
+                  description: The PgBouncer configuration
+                  properties:
+                    authQuery:
+                      description: |-
+                        The query that will be used to download the hash of the password
+                        of a certain user. Default: "SELECT usename, passwd FROM public.user_search($1)".
+                        In case it is specified, also an AuthQuerySecret has to be specified and
+                        no automatic CNPG Cluster integration will be triggered.
+                      type: string
+                    authQuerySecret:
+                      description: |-
+                        The credentials of the user that need to be used for the authentication
+                        query. In case it is specified, also an AuthQuery
+                        (e.g. "SELECT usename, passwd FROM pg_catalog.pg_shadow WHERE usename=$1")
+                        has to be specified and no automatic CNPG Cluster integration will be triggered.
+
+                        Deprecated.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    clientCASecret:
+                      description: |-
+                        ClientCASecret provides PgBouncer’s client_tls_ca_file, the root
+                        CA for validating client certificates
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    clientTLSSecret:
+                      description: |-
+                        ClientTLSSecret provides PgBouncer’s client_tls_key_file (private key)
+                        and client_tls_cert_file (certificate) used to accept client connections
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    parameters:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Additional parameters to be passed to PgBouncer - please check
+                        the CNPG documentation for a list of options you can configure
+                      type: object
+                    paused:
+                      default: false
+                      description: |-
+                        When set to `true`, PgBouncer will disconnect from the PostgreSQL
+                        server, first waiting for all queries to complete, and pause all new
+                        client connections until this value is set to `false` (default). Internally,
+                        the operator calls PgBouncer's `PAUSE` and `RESUME` commands.
+                      type: boolean
+                    pg_hba:
+                      description: |-
+                        PostgreSQL Host Based Authentication rules (lines to be appended
+                        to the pg_hba.conf file)
+                      items:
+                        type: string
+                      type: array
+                    poolMode:
+                      default: session
+                      description: 'The pool mode. Default: `session`.'
+                      enum:
+                        - session
+                        - transaction
+                      type: string
+                    serverCASecret:
+                      description: |-
+                        ServerCASecret provides PgBouncer’s server_tls_ca_file, the root
+                        CA for validating PostgreSQL certificates
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    serverTLSSecret:
+                      description: |-
+                        ServerTLSSecret, when pointing to a TLS secret, provides pgbouncer's
+                        `server_tls_key_file` and `server_tls_cert_file`, used when
+                        authenticating against PostgreSQL.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                  type: object
+                serviceAccountName:
+                  description: |-
+                    Name of an existing ServiceAccount in the same namespace to use for the pooler.
+                    When specified, the operator will not create a new ServiceAccount
+                    but will use the provided one. This is useful for sharing a single
+                    ServiceAccount across multiple poolers (e.g., for cloud IAM configurations).
+                    If not specified, a ServiceAccount will be created with the pooler name.
+                  maxLength: 253
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: serviceAccountName is immutable
+                      rule: self == oldSelf
+                serviceTemplate:
+                  description: Template for the Service to be created
+                  properties:
+                    metadata:
+                      description: |-
+                        Standard object's metadata.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: http://kubernetes.io/docs/user-guide/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: http://kubernetes.io/docs/user-guide/labels
+                          type: object
+                        name:
+                          description: The name of the resource. Only supported for certain types
+                          type: string
+                      type: object
+                    spec:
+                      description: |-
+                        Specification of the desired behavior of the service.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                      properties:
+                        allocateLoadBalancerNodePorts:
+                          description: |-
+                            allocateLoadBalancerNodePorts defines if NodePorts will be automatically
+                            allocated for services with type LoadBalancer.  Default is "true". It
+                            may be set to "false" if the cluster load-balancer does not rely on
+                            NodePorts.  If the caller requests specific NodePorts (by specifying a
+                            value), those requests will be respected, regardless of this field.
+                            This field may only be set for services with type LoadBalancer and will
+                            be cleared if the type is changed to any other type.
+                          type: boolean
+                        clusterIP:
+                          description: |-
+                            clusterIP is the IP address of the service and is usually assigned
+                            randomly. If an address is specified manually, is in-range (as per
+                            system configuration), and is not in use, it will be allocated to the
+                            service; otherwise creation of the service will fail. This field may not
+                            be changed through updates unless the type field is also being changed
+                            to ExternalName (which requires this field to be blank) or the type
+                            field is being changed from ExternalName (in which case this field may
+                            optionally be specified, as describe above).  Valid values are "None",
+                            empty string (""), or a valid IP address. Setting this to "None" makes a
+                            "headless service" (no virtual IP), which is useful when direct endpoint
+                            connections are preferred and proxying is not required.  Only applies to
+                            types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+                            when creating a Service of type ExternalName, creation will fail. This
+                            field will be wiped when updating a Service to type ExternalName.
+                            More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                          type: string
+                        clusterIPs:
+                          description: |-
+                            ClusterIPs is a list of IP addresses assigned to this service, and are
+                            usually assigned randomly.  If an address is specified manually, is
+                            in-range (as per system configuration), and is not in use, it will be
+                            allocated to the service; otherwise creation of the service will fail.
+                            This field may not be changed through updates unless the type field is
+                            also being changed to ExternalName (which requires this field to be
+                            empty) or the type field is being changed from ExternalName (in which
+                            case this field may optionally be specified, as describe above).  Valid
+                            values are "None", empty string (""), or a valid IP address.  Setting
+                            this to "None" makes a "headless service" (no virtual IP), which is
+                            useful when direct endpoint connections are preferred and proxying is
+                            not required.  Only applies to types ClusterIP, NodePort, and
+                            LoadBalancer. If this field is specified when creating a Service of type
+                            ExternalName, creation will fail. This field will be wiped when updating
+                            a Service to type ExternalName.  If this field is not specified, it will
+                            be initialized from the clusterIP field.  If this field is specified,
+                            clients must ensure that clusterIPs[0] and clusterIP have the same
+                            value.
+
+                            This field may hold a maximum of two entries (dual-stack IPs, in either order).
+                            These IPs must correspond to the values of the ipFamilies field. Both
+                            clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+                            More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        externalIPs:
+                          description: |-
+                            externalIPs is a list of IP addresses for which nodes in the cluster
+                            will also accept traffic for this service.  These IPs are not managed by
+                            Kubernetes.  The user is responsible for ensuring that traffic arrives
+                            at a node with this IP.  A common example is external load-balancers
+                            that are not part of the Kubernetes system.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        externalName:
+                          description: |-
+                            externalName is the external reference that discovery mechanisms will
+                            return as an alias for this service (e.g. a DNS CNAME record). No
+                            proxying will be involved.  Must be a lowercase RFC-1123 hostname
+                            (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+                          type: string
+                        externalTrafficPolicy:
+                          description: |-
+                            externalTrafficPolicy describes how nodes distribute service traffic they
+                            receive on one of the Service's "externally-facing" addresses (NodePorts,
+                            ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure
+                            the service in a way that assumes that external load balancers will take care
+                            of balancing the service traffic between nodes, and so each node will deliver
+                            traffic only to the node-local endpoints of the service, without masquerading
+                            the client source IP. (Traffic mistakenly sent to a node with no endpoints will
+                            be dropped.) The default value, "Cluster", uses the standard behavior of
+                            routing to all endpoints evenly (possibly modified by topology and other
+                            features). Note that traffic sent to an External IP or LoadBalancer IP from
+                            within the cluster will always get "Cluster" semantics, but clients sending to
+                            a NodePort from within the cluster may need to take traffic policy into account
+                            when picking a node.
+                          type: string
+                        healthCheckNodePort:
+                          description: |-
+                            healthCheckNodePort specifies the healthcheck nodePort for the service.
+                            This only applies when type is set to LoadBalancer and
+                            externalTrafficPolicy is set to Local. If a value is specified, is
+                            in-range, and is not in use, it will be used.  If not specified, a value
+                            will be automatically allocated.  External systems (e.g. load-balancers)
+                            can use this port to determine if a given node holds endpoints for this
+                            service or not.  If this field is specified when creating a Service
+                            which does not need it, creation will fail. This field will be wiped
+                            when updating a Service to no longer need it (e.g. changing type).
+                            This field cannot be updated once set.
+                          format: int32
+                          type: integer
+                        internalTrafficPolicy:
+                          description: |-
+                            InternalTrafficPolicy describes how nodes distribute service traffic they
+                            receive on the ClusterIP. If set to "Local", the proxy will assume that pods
+                            only want to talk to endpoints of the service on the same node as the pod,
+                            dropping the traffic if there are no local endpoints. The default value,
+                            "Cluster", uses the standard behavior of routing to all endpoints evenly
+                            (possibly modified by topology and other features).
+                          type: string
+                        ipFamilies:
+                          description: |-
+                            IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this
+                            service. This field is usually assigned automatically based on cluster
+                            configuration and the ipFamilyPolicy field. If this field is specified
+                            manually, the requested family is available in the cluster,
+                            and ipFamilyPolicy allows it, it will be used; otherwise creation of
+                            the service will fail. This field is conditionally mutable: it allows
+                            for adding or removing a secondary IP family, but it does not allow
+                            changing the primary IP family of the Service. Valid values are "IPv4"
+                            and "IPv6".  This field only applies to Services of types ClusterIP,
+                            NodePort, and LoadBalancer, and does apply to "headless" services.
+                            This field will be wiped when updating a Service to type ExternalName.
+
+                            This field may hold a maximum of two entries (dual-stack families, in
+                            either order).  These families must correspond to the values of the
+                            clusterIPs field, if specified. Both clusterIPs and ipFamilies are
+                            governed by the ipFamilyPolicy field.
+                          items:
+                            description: |-
+                              IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                              to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ipFamilyPolicy:
+                          description: |-
+                            IPFamilyPolicy represents the dual-stack-ness requested or required by
+                            this Service. If there is no value provided, then this field will be set
+                            to SingleStack. Services can be "SingleStack" (a single IP family),
+                            "PreferDualStack" (two IP families on dual-stack configured clusters or
+                            a single IP family on single-stack clusters), or "RequireDualStack"
+                            (two IP families on dual-stack configured clusters, otherwise fail). The
+                            ipFamilies and clusterIPs fields depend on the value of this field. This
+                            field will be wiped when updating a service to type ExternalName.
+                          type: string
+                        loadBalancerClass:
+                          description: |-
+                            loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                            If specified, the value of this field must be a label-style identifier, with an optional prefix,
+                            e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+                            This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
+                            balancer implementation is used, today this is typically done through the cloud provider integration,
+                            but should apply for any default implementation. If set, it is assumed that a load balancer
+                            implementation is watching for Services with a matching class. Any default load balancer
+                            implementation (e.g. cloud providers) should ignore Services that set this field.
+                            This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+                            Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+                          type: string
+                        loadBalancerIP:
+                          description: |-
+                            Only applies to Service Type: LoadBalancer.
+                            This feature depends on whether the underlying cloud-provider supports specifying
+                            the loadBalancerIP when a load balancer is created.
+                            This field will be ignored if the cloud-provider does not support the feature.
+                            Deprecated: This field was under-specified and its meaning varies across implementations.
+                            Using it is non-portable and it may not support dual-stack.
+                            Users are encouraged to use implementation-specific annotations when available.
+                          type: string
+                        loadBalancerSourceRanges:
+                          description: |-
+                            If specified and supported by the platform, this will restrict traffic through the cloud-provider
+                            load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+                            cloud-provider does not support the feature."
+                            More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ports:
+                          description: |-
+                            The list of ports that are exposed by this service.
+                            More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                          items:
+                            description: ServicePort contains information on service's port.
+                            properties:
+                              appProtocol:
+                                description: |-
+                                  The application protocol for this port.
+                                  This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                  This field follows standard Kubernetes label syntax.
+                                  Valid values are either:
+
+                                  * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                  RFC-6335 and https://www.iana.org/assignments/service-names).
+
+                                  * Kubernetes-defined prefixed names:
+                                    * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                                    * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                                    * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+
+                                  * Other protocols should use implementation-defined prefixed names such as
+                                  mycompany.com/my-custom-protocol.
+                                type: string
+                              name:
+                                description: |-
+                                  The name of this port within the service. This must be a DNS_LABEL.
+                                  All ports within a ServiceSpec must have unique names. When considering
+                                  the endpoints for a Service, this must match the 'name' field in the
+                                  EndpointPort.
+                                  Optional if only one ServicePort is defined on this service.
+                                type: string
+                              nodePort:
+                                description: |-
+                                  The port on each node on which this service is exposed when type is
+                                  NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                                  specified, in-range, and not in use it will be used, otherwise the
+                                  operation will fail.  If not specified, a port will be allocated if this
+                                  Service requires one.  If this field is specified when creating a
+                                  Service which does not need it, creation will fail. This field will be
+                                  wiped when updating a Service to no longer need it (e.g. changing type
+                                  from NodePort to ClusterIP).
+                                  More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+                                format: int32
+                                type: integer
+                              port:
+                                description: The port that will be exposed by this service.
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                  Default is TCP.
+                                type: string
+                              targetPort:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: |-
+                                  Number or name of the port to access on the pods targeted by the service.
+                                  Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  If this is a string, it will be looked up as a named port in the
+                                  target Pod's container ports. If this is not specified, the value
+                                  of the 'port' field is used (an identity map).
+                                  This field is ignored for services with clusterIP=None, and should be
+                                  omitted or set equal to the 'port' field.
+                                  More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
+                                x-kubernetes-int-or-string: true
+                            required:
+                              - port
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - port
+                            - protocol
+                          x-kubernetes-list-type: map
+                        publishNotReadyAddresses:
+                          description: |-
+                            publishNotReadyAddresses indicates that any agent which deals with endpoints for this
+                            Service should disregard any indications of ready/not-ready.
+                            The primary use case for setting this field is for a StatefulSet's Headless Service to
+                            propagate SRV DNS records for its Pods for the purpose of peer discovery.
+                            The Kubernetes controllers that generate Endpoints and EndpointSlice resources for
+                            Services interpret this to mean that all endpoints are considered "ready" even if the
+                            Pods themselves are not. Agents which consume only Kubernetes generated endpoints
+                            through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                          type: boolean
+                        selector:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Route service traffic to pods with label keys and values matching this
+                            selector. If empty or not present, the service is assumed to have an
+                            external process managing its endpoints, which Kubernetes will not
+                            modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+                            Ignored if type is ExternalName.
+                            More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        sessionAffinity:
+                          description: |-
+                            Supports "ClientIP" and "None". Used to maintain session affinity.
+                            Enable client IP based session affinity.
+                            Must be ClientIP or None.
+                            Defaults to None.
+                            More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                          type: string
+                        sessionAffinityConfig:
+                          description: sessionAffinityConfig contains the configurations of session affinity.
+                          properties:
+                            clientIP:
+                              description: clientIP contains the configurations of Client IP based session affinity.
+                              properties:
+                                timeoutSeconds:
+                                  description: |-
+                                    timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                                    The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                                    Default value is 10800(for 3 hours).
+                                  format: int32
+                                  type: integer
+                              type: object
+                          type: object
+                        trafficDistribution:
+                          description: |-
+                            TrafficDistribution offers a way to express preferences for how traffic
+                            is distributed to Service endpoints. Implementations can use this field
+                            as a hint, but are not required to guarantee strict adherence. If the
+                            field is not set, the implementation will apply its default routing
+                            strategy. If set to "PreferClose", implementations should prioritize
+                            endpoints that are in the same zone.
+                          type: string
+                        type:
+                          description: |-
+                            type determines how the Service is exposed. Defaults to ClusterIP. Valid
+                            options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+                            "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                            to endpoints. Endpoints are determined by the selector or if that is not
+                            specified, by manual construction of an Endpoints object or
+                            EndpointSlice objects. If clusterIP is "None", no virtual IP is
+                            allocated and the endpoints are published as a set of endpoints rather
+                            than a virtual IP.
+                            "NodePort" builds on ClusterIP and allocates a port on every node which
+                            routes to the same endpoints as the clusterIP.
+                            "LoadBalancer" builds on NodePort and creates an external load-balancer
+                            (if supported in the current cloud) which routes to the same endpoints
+                            as the clusterIP.
+                            "ExternalName" aliases this service to the specified externalName.
+                            Several other fields do not apply to ExternalName services.
+                            More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+                          type: string
+                      type: object
+                  type: object
+                template:
+                  description: The template of the Pod to be created
+                  properties:
+                    metadata:
+                      description: |-
+                        Standard object's metadata.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: http://kubernetes.io/docs/user-guide/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: http://kubernetes.io/docs/user-guide/labels
+                          type: object
+                        name:
+                          description: The name of the resource. Only supported for certain types
+                          type: string
+                      type: object
+                    spec:
+                      description: |-
+                        Specification of the desired behavior of the pod.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                      properties:
+                        activeDeadlineSeconds:
+                          description: |-
+                            Optional duration in seconds the pod may be active on the node relative to
+                            StartTime before the system will actively try to mark it failed and kill associated containers.
+                            Value must be a positive integer.
+                          format: int64
+                          type: integer
+                        affinity:
+                          description: If specified, the pod's scheduling constraints
+                          properties:
+                            nodeAffinity:
+                              description: Describes node affinity scheduling rules for the pod.
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  description: |-
+                                    The scheduler will prefer to schedule pods to nodes that satisfy
+                                    the affinity expressions specified by this field, but it may choose
+                                    a node that violates one or more of the expressions. The node that is
+                                    most preferred is the one with the greatest sum of weights, i.e.
+                                    for each node that meets all of the scheduling requirements (resource
+                                    request, requiredDuringScheduling affinity expressions, etc.),
+                                    compute a sum by iterating through the elements of this field and adding
+                                    "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                    node(s) with the highest sum are the most preferred.
+                                  items:
+                                    description: |-
+                                      An empty preferred scheduling term matches all objects with implicit weight 0
+                                      (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                    properties:
+                                      preference:
+                                        description: A node selector term, associated with the corresponding weight.
+                                        properties:
+                                          matchExpressions:
+                                            description: A list of node selector requirements by node's labels.
+                                            items:
+                                              description: |-
+                                                A node selector requirement is a selector that contains values, a key, and an operator
+                                                that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    An array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                                    array must have a single element, which will be interpreted as an integer.
+                                                    This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchFields:
+                                            description: A list of node selector requirements by node's fields.
+                                            items:
+                                              description: |-
+                                                A node selector requirement is a selector that contains values, a key, and an operator
+                                                that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    An array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                                    array must have a single element, which will be interpreted as an integer.
+                                                    This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      weight:
+                                        description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                      - preference
+                                      - weight
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  description: |-
+                                    If the affinity requirements specified by this field are not met at
+                                    scheduling time, the pod will not be scheduled onto the node.
+                                    If the affinity requirements specified by this field cease to be met
+                                    at some point during pod execution (e.g. due to an update), the system
+                                    may or may not try to eventually evict the pod from its node.
+                                  properties:
+                                    nodeSelectorTerms:
+                                      description: Required. A list of node selector terms. The terms are ORed.
+                                      items:
+                                        description: |-
+                                          A null or empty node selector term matches no objects. The requirements of
+                                          them are ANDed.
+                                          The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                        properties:
+                                          matchExpressions:
+                                            description: A list of node selector requirements by node's labels.
+                                            items:
+                                              description: |-
+                                                A node selector requirement is a selector that contains values, a key, and an operator
+                                                that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    An array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                                    array must have a single element, which will be interpreted as an integer.
+                                                    This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchFields:
+                                            description: A list of node selector requirements by node's fields.
+                                            items:
+                                              description: |-
+                                                A node selector requirement is a selector that contains values, a key, and an operator
+                                                that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    An array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                                    array must have a single element, which will be interpreted as an integer.
+                                                    This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - nodeSelectorTerms
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            podAffinity:
+                              description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  description: |-
+                                    The scheduler will prefer to schedule pods to nodes that satisfy
+                                    the affinity expressions specified by this field, but it may choose
+                                    a node that violates one or more of the expressions. The node that is
+                                    most preferred is the one with the greatest sum of weights, i.e.
+                                    for each node that meets all of the scheduling requirements (resource
+                                    request, requiredDuringScheduling affinity expressions, etc.),
+                                    compute a sum by iterating through the elements of this field and adding
+                                    "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                    node(s) with the highest sum are the most preferred.
+                                  items:
+                                    description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                    properties:
+                                      podAffinityTerm:
+                                        description: Required. A pod affinity term, associated with the corresponding weight.
+                                        properties:
+                                          labelSelector:
+                                            description: |-
+                                              A label query over a set of resources, in this case pods.
+                                              If it's null, this PodAffinityTerm matches with no Pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            description: |-
+                                              MatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                              Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            description: |-
+                                              MismatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                              Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          namespaceSelector:
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          namespaces:
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          topologyKey:
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                          - topologyKey
+                                        type: object
+                                      weight:
+                                        description: |-
+                                          weight associated with matching the corresponding podAffinityTerm,
+                                          in the range 1-100.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                      - podAffinityTerm
+                                      - weight
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  description: |-
+                                    If the affinity requirements specified by this field are not met at
+                                    scheduling time, the pod will not be scheduled onto the node.
+                                    If the affinity requirements specified by this field cease to be met
+                                    at some point during pod execution (e.g. due to a pod label update), the
+                                    system may or may not try to eventually evict the pod from its node.
+                                    When there are multiple elements, the lists of nodes corresponding to each
+                                    podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                  items:
+                                    description: |-
+                                      Defines a set of pods (namely those matching the labelSelector
+                                      relative to the given namespace(s)) that this pod should be
+                                      co-located (affinity) or not co-located (anti-affinity) with,
+                                      where co-located is defined as running on a node whose value of
+                                      the label with key <topologyKey> matches that of any node on which
+                                      a pod of the set of pods is running
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          A label query over a set of resources, in this case pods.
+                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: |-
+                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: |-
+                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      namespaceSelector:
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      topologyKey:
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            podAntiAffinity:
+                              description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  description: |-
+                                    The scheduler will prefer to schedule pods to nodes that satisfy
+                                    the anti-affinity expressions specified by this field, but it may choose
+                                    a node that violates one or more of the expressions. The node that is
+                                    most preferred is the one with the greatest sum of weights, i.e.
+                                    for each node that meets all of the scheduling requirements (resource
+                                    request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                    compute a sum by iterating through the elements of this field and subtracting
+                                    "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                    node(s) with the highest sum are the most preferred.
+                                  items:
+                                    description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                    properties:
+                                      podAffinityTerm:
+                                        description: Required. A pod affinity term, associated with the corresponding weight.
+                                        properties:
+                                          labelSelector:
+                                            description: |-
+                                              A label query over a set of resources, in this case pods.
+                                              If it's null, this PodAffinityTerm matches with no Pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            description: |-
+                                              MatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                              Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            description: |-
+                                              MismatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                              Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          namespaceSelector:
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          namespaces:
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          topologyKey:
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                          - topologyKey
+                                        type: object
+                                      weight:
+                                        description: |-
+                                          weight associated with matching the corresponding podAffinityTerm,
+                                          in the range 1-100.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                      - podAffinityTerm
+                                      - weight
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  description: |-
+                                    If the anti-affinity requirements specified by this field are not met at
+                                    scheduling time, the pod will not be scheduled onto the node.
+                                    If the anti-affinity requirements specified by this field cease to be met
+                                    at some point during pod execution (e.g. due to a pod label update), the
+                                    system may or may not try to eventually evict the pod from its node.
+                                    When there are multiple elements, the lists of nodes corresponding to each
+                                    podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                  items:
+                                    description: |-
+                                      Defines a set of pods (namely those matching the labelSelector
+                                      relative to the given namespace(s)) that this pod should be
+                                      co-located (affinity) or not co-located (anti-affinity) with,
+                                      where co-located is defined as running on a node whose value of
+                                      the label with key <topologyKey> matches that of any node on which
+                                      a pod of the set of pods is running
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          A label query over a set of resources, in this case pods.
+                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: |-
+                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: |-
+                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      namespaceSelector:
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      topologyKey:
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                          type: object
+                        automountServiceAccountToken:
+                          description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+                          type: boolean
+                        containers:
+                          description: |-
+                            List of containers belonging to the pod.
+                            Containers cannot currently be added or removed.
+                            There must be at least one container in a Pod.
+                            Cannot be updated.
+                          items:
+                            description: A single application container that you want to run within a pod.
+                            properties:
+                              args:
+                                description: |-
+                                  Arguments to the entrypoint.
+                                  The container image's CMD is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              command:
+                                description: |-
+                                  Entrypoint array. Not executed within a shell.
+                                  The container image's ENTRYPOINT is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              env:
+                                description: |-
+                                  List of environment variables to set in the container.
+                                  Cannot be updated.
+                                items:
+                                  description: EnvVar represents an environment variable present in a Container.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the environment variable.
+                                        May consist of any printable ASCII characters except '='.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap or its key must be defined
+                                              type: boolean
+                                          required:
+                                            - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: |-
+                                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select in the specified API version.
+                                              type: string
+                                          required:
+                                            - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fileKeyRef:
+                                          description: |-
+                                            FileKeyRef selects a key of the env file.
+                                            Requires the EnvFiles feature gate to be enabled.
+                                          properties:
+                                            key:
+                                              description: |-
+                                                The key within the env file. An invalid key will prevent the pod from starting.
+                                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                              type: string
+                                            optional:
+                                              default: false
+                                              description: |-
+                                                Specify whether the file or its key must be defined. If the file or key
+                                                does not exist, then the env var is not published.
+                                                If optional is set to true and the specified key does not exist,
+                                                the environment variable will not be set in the Pod's containers.
+
+                                                If optional is set to false and the specified key does not exist,
+                                                an error will be returned during Pod creation.
+                                              type: boolean
+                                            path:
+                                              description: |-
+                                                The path within the volume from which to select the file.
+                                                Must be relative and may not contain the '..' path or start with '..'.
+                                              type: string
+                                            volumeName:
+                                              description: The name of the volume mount containing the env file.
+                                              type: string
+                                          required:
+                                            - key
+                                            - path
+                                            - volumeName
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              description: Specifies the output format of the exposed resources, defaults to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to select'
+                                              type: string
+                                          required:
+                                            - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to select from.  Must be a valid secret key.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret or its key must be defined
+                                              type: boolean
+                                          required:
+                                            - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
+                              envFrom:
+                                description: |-
+                                  List of sources to populate environment variables in the container.
+                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                  When a key exists in multiple
+                                  sources, the value associated with the last source will take precedence.
+                                  Values defined by an Env with a duplicate key will take precedence.
+                                  Cannot be updated.
+                                items:
+                                  description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
+                                  properties:
+                                    configMapRef:
+                                      description: The ConfigMap to select from
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    prefix:
+                                      description: |-
+                                        Optional text to prepend to the name of each environment variable.
+                                        May consist of any printable ASCII characters except '='.
+                                      type: string
+                                    secretRef:
+                                      description: The Secret to select from
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              image:
+                                description: |-
+                                  Container image name.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                              imagePullPolicy:
+                                description: |-
+                                  Image pull policy.
+                                  One of Always, Never, IfNotPresent.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                type: string
+                              lifecycle:
+                                description: |-
+                                  Actions that the management system should take in response to container lifecycle events.
+                                  Cannot be updated.
+                                properties:
+                                  postStart:
+                                    description: |-
+                                      PostStart is called immediately after a container is created. If the handler fails,
+                                      the container is terminated and restarted according to its restart policy.
+                                      Other management of the container blocks until the hook completes.
+                                      More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                    properties:
+                                      exec:
+                                        description: Exec specifies a command to execute in the container.
+                                        properties:
+                                          command:
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies an HTTP GET request to perform.
+                                        properties:
+                                          host:
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                                - name
+                                                - value
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          path:
+                                            description: Path to access on the HTTP server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
+                                            type: string
+                                        required:
+                                          - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents a duration that the container should sleep.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                          - seconds
+                                        type: object
+                                      tcpSocket:
+                                        description: |-
+                                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                          for backward compatibility. There is no validation of this field and
+                                          lifecycle hooks will fail at runtime when it is specified.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                          - port
+                                        type: object
+                                    type: object
+                                  preStop:
+                                    description: |-
+                                      PreStop is called immediately before a container is terminated due to an
+                                      API request or management event such as liveness/startup probe failure,
+                                      preemption, resource contention, etc. The handler is not called if the
+                                      container crashes or exits. The Pod's termination grace period countdown begins before the
+                                      PreStop hook is executed. Regardless of the outcome of the handler, the
+                                      container will eventually terminate within the Pod's termination grace
+                                      period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                      or until the termination grace period is reached.
+                                      More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                    properties:
+                                      exec:
+                                        description: Exec specifies a command to execute in the container.
+                                        properties:
+                                          command:
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies an HTTP GET request to perform.
+                                        properties:
+                                          host:
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                                - name
+                                                - value
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          path:
+                                            description: Path to access on the HTTP server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
+                                            type: string
+                                        required:
+                                          - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents a duration that the container should sleep.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                          - seconds
+                                        type: object
+                                      tcpSocket:
+                                        description: |-
+                                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                          for backward compatibility. There is no validation of this field and
+                                          lifecycle hooks will fail at runtime when it is specified.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                          - port
+                                        type: object
+                                    type: object
+                                  stopSignal:
+                                    description: |-
+                                      StopSignal defines which signal will be sent to a container when it is being stopped.
+                                      If not specified, the default is defined by the container runtime in use.
+                                      StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                    type: string
+                                type: object
+                              livenessProbe:
+                                description: |-
+                                  Periodic probe of container liveness.
+                                  Container will be restarted if the probe fails.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  grpc:
+                                    description: GRPC specifies a GRPC HealthCheckRequest.
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        default: ""
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
+                                      Default to 10 seconds. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: TCPSocket specifies a connection to a TCP port.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: |-
+                                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after the processes running in the pod are sent
+                                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                      Set this value longer than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                      value overrides the value provided by the pod spec.
+                                      Value must be non-negative integer. The value zero indicates stop immediately via
+                                      the kill signal (no opportunity to shut down).
+                                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                type: object
+                              name:
+                                description: |-
+                                  Name of the container specified as a DNS_LABEL.
+                                  Each container in a pod must have a unique name (DNS_LABEL).
+                                  Cannot be updated.
+                                type: string
+                              ports:
+                                description: |-
+                                  List of ports to expose from the container. Not specifying a port here
+                                  DOES NOT prevent that port from being exposed. Any port which is
+                                  listening on the default "0.0.0.0" address inside a container will be
+                                  accessible from the network.
+                                  Modifying this array with strategic merge patch may corrupt the data.
+                                  For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                  Cannot be updated.
+                                items:
+                                  description: ContainerPort represents a network port in a single container.
+                                  properties:
+                                    containerPort:
+                                      description: |-
+                                        Number of port to expose on the pod's IP address.
+                                        This must be a valid port number, 0 < x < 65536.
+                                      format: int32
+                                      type: integer
+                                    hostIP:
+                                      description: What host IP to bind the external port to.
+                                      type: string
+                                    hostPort:
+                                      description: |-
+                                        Number of port to expose on the host.
+                                        If specified, this must be a valid port number, 0 < x < 65536.
+                                        If HostNetwork is specified, this must match ContainerPort.
+                                        Most containers do not need this.
+                                      format: int32
+                                      type: integer
+                                    name:
+                                      description: |-
+                                        If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                        named port in a pod must have a unique name. Name for the port that can be
+                                        referred to by services.
+                                      type: string
+                                    protocol:
+                                      default: TCP
+                                      description: |-
+                                        Protocol for port. Must be UDP, TCP, or SCTP.
+                                        Defaults to "TCP".
+                                      type: string
+                                  required:
+                                    - containerPort
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - containerPort
+                                  - protocol
+                                x-kubernetes-list-type: map
+                              readinessProbe:
+                                description: |-
+                                  Periodic probe of container service readiness.
+                                  Container will be removed from service endpoints if the probe fails.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  grpc:
+                                    description: GRPC specifies a GRPC HealthCheckRequest.
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        default: ""
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
+                                      Default to 10 seconds. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: TCPSocket specifies a connection to a TCP port.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: |-
+                                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after the processes running in the pod are sent
+                                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                      Set this value longer than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                      value overrides the value provided by the pod spec.
+                                      Value must be non-negative integer. The value zero indicates stop immediately via
+                                      the kill signal (no opportunity to shut down).
+                                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                type: object
+                              resizePolicy:
+                                description: |-
+                                  Resources resize policy for the container.
+                                  This field cannot be set on ephemeral containers.
+                                items:
+                                  description: ContainerResizePolicy represents resource resize policy for the container.
+                                  properties:
+                                    resourceName:
+                                      description: |-
+                                        Name of the resource to which this resource resize policy applies.
+                                        Supported values: cpu, memory.
+                                      type: string
+                                    restartPolicy:
+                                      description: |-
+                                        Restart policy to apply when specified resource is resized.
+                                        If not specified, it defaults to NotRequired.
+                                      type: string
+                                  required:
+                                    - resourceName
+                                    - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              resources:
+                                description: |-
+                                  Compute Resources required by this container.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                properties:
+                                  claims:
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
+
+                                      This field depends on the
+                                      DynamicResourceAllocation feature gate.
+
+                                      This field is immutable. It can only be set for containers.
+                                    items:
+                                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes that resource available
+                                            inside a container.
+                                          type: string
+                                        request:
+                                          description: |-
+                                            Request is the name chosen for a request in the referenced claim.
+                                            If empty, everything from the claim is made available, otherwise
+                                            only the result of this request.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Requests describes the minimum amount of compute resources required.
+                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                type: object
+                              restartPolicy:
+                                description: |-
+                                  RestartPolicy defines the restart behavior of individual containers in a pod.
+                                  This overrides the pod-level restart policy. When this field is not specified,
+                                  the restart behavior is defined by the Pod's restart policy and the container type.
+                                  Additionally, setting the RestartPolicy as "Always" for the init container will
+                                  have the following effect:
+                                  this init container will be continually restarted on
+                                  exit until all regular containers have terminated. Once all regular
+                                  containers have completed, all init containers with restartPolicy "Always"
+                                  will be shut down. This lifecycle differs from normal init containers and
+                                  is often referred to as a "sidecar" container. Although this init
+                                  container still starts in the init container sequence, it does not wait
+                                  for the container to complete before proceeding to the next init
+                                  container. Instead, the next init container starts immediately after this
+                                  init container is started, or after any startupProbe has successfully
+                                  completed.
+                                type: string
+                              restartPolicyRules:
+                                description: |-
+                                  Represents a list of rules to be checked to determine if the
+                                  container should be restarted on exit. The rules are evaluated in
+                                  order. Once a rule matches a container exit condition, the remaining
+                                  rules are ignored. If no rule matches the container exit condition,
+                                  the Container-level restart policy determines the whether the container
+                                  is restarted or not. Constraints on the rules:
+                                  - At most 20 rules are allowed.
+                                  - Rules can have the same action.
+                                  - Identical rules are not forbidden in validations.
+                                  When rules are specified, container MUST set RestartPolicy explicitly
+                                  even it if matches the Pod's RestartPolicy.
+                                items:
+                                  description: ContainerRestartRule describes how a container exit is handled.
+                                  properties:
+                                    action:
+                                      description: |-
+                                        Specifies the action taken on a container exit if the requirements
+                                        are satisfied. The only possible value is "Restart" to restart the
+                                        container.
+                                      type: string
+                                    exitCodes:
+                                      description: Represents the exit codes to check on container exits.
+                                      properties:
+                                        operator:
+                                          description: |-
+                                            Represents the relationship between the container exit code(s) and the
+                                            specified values. Possible values are:
+                                            - In: the requirement is satisfied if the container exit code is in the
+                                              set of specified values.
+                                            - NotIn: the requirement is satisfied if the container exit code is
+                                              not in the set of specified values.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            Specifies the set of values to check for container exit codes.
+                                            At most 255 elements are allowed.
+                                          items:
+                                            format: int32
+                                            type: integer
+                                          type: array
+                                          x-kubernetes-list-type: set
+                                      required:
+                                        - operator
+                                      type: object
+                                  required:
+                                    - action
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              securityContext:
+                                description: |-
+                                  SecurityContext defines the security options the container should be run with.
+                                  If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                  More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                                properties:
+                                  allowPrivilegeEscalation:
+                                    description: |-
+                                      AllowPrivilegeEscalation controls whether a process can gain more
+                                      privileges than its parent process. This bool directly controls if
+                                      the no_new_privs flag will be set on the container process.
+                                      AllowPrivilegeEscalation is true always when the container is:
+                                      1) run as Privileged
+                                      2) has CAP_SYS_ADMIN
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  appArmorProfile:
+                                    description: |-
+                                      appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                      overrides the pod's appArmorProfile.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile loaded on the node that should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must match the loaded name of the profile.
+                                          Must be set if and only if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of AppArmor profile will be applied.
+                                          Valid options are:
+                                            Localhost - a profile pre-loaded on the node.
+                                            RuntimeDefault - the container runtime's default profile.
+                                            Unconfined - no AppArmor enforcement.
+                                        type: string
+                                    required:
+                                      - type
+                                    type: object
+                                  capabilities:
+                                    description: |-
+                                      The capabilities to add/drop when running containers.
+                                      Defaults to the default set of capabilities granted by the container runtime.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      add:
+                                        description: Added capabilities
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      drop:
+                                        description: Removed capabilities
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  privileged:
+                                    description: |-
+                                      Run container in privileged mode.
+                                      Processes in privileged containers are essentially equivalent to root on the host.
+                                      Defaults to false.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  procMount:
+                                    description: |-
+                                      procMount denotes the type of proc mount to use for the containers.
+                                      The default value is Default which uses the container runtime defaults for
+                                      readonly paths and masked paths.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: string
+                                  readOnlyRootFilesystem:
+                                    description: |-
+                                      Whether this container has a read-only root filesystem.
+                                      Default is false.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  runAsGroup:
+                                    description: |-
+                                      The GID to run the entrypoint of the container process.
+                                      Uses runtime default if unset.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    description: |-
+                                      Indicates that the container must run as a non-root user.
+                                      If true, the Kubelet will validate the image at runtime to ensure that it
+                                      does not run as UID 0 (root) and fail to start the container if it does.
+                                      If unset or false, no such validation will be performed.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: |-
+                                      The UID to run the entrypoint of the container process.
+                                      Defaults to user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    description: |-
+                                      The SELinux context to be applied to the container.
+                                      If unspecified, the container runtime will allocate a random SELinux context for each
+                                      container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      level:
+                                        description: Level is SELinux level label that applies to the container.
+                                        type: string
+                                      role:
+                                        description: Role is a SELinux role label that applies to the container.
+                                        type: string
+                                      type:
+                                        description: Type is a SELinux type label that applies to the container.
+                                        type: string
+                                      user:
+                                        description: User is a SELinux user label that applies to the container.
+                                        type: string
+                                    type: object
+                                  seccompProfile:
+                                    description: |-
+                                      The seccomp options to use by this container. If seccomp options are
+                                      provided at both the pod & container level, the container options
+                                      override the pod options.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile defined in a file on the node should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                          Must be set if type is "Localhost". Must NOT be set for any other type.
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of seccomp profile will be applied.
+                                          Valid options are:
+
+                                          Localhost - a profile defined in a file on the node should be used.
+                                          RuntimeDefault - the container runtime default profile should be used.
+                                          Unconfined - no profile should be applied.
+                                        type: string
+                                    required:
+                                      - type
+                                    type: object
+                                  windowsOptions:
+                                    description: |-
+                                      The Windows specific settings applied to all containers.
+                                      If unspecified, the options from the PodSecurityContext will be used.
+                                      If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is linux.
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        description: |-
+                                          GMSACredentialSpec is where the GMSA admission webhook
+                                          (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                          GMSA credential spec named by the GMSACredentialSpecName field.
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                        type: string
+                                      hostProcess:
+                                        description: |-
+                                          HostProcess determines if a container should be run as a 'Host Process' container.
+                                          All of a Pod's containers must have the same effective HostProcess value
+                                          (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                          In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                        type: boolean
+                                      runAsUserName:
+                                        description: |-
+                                          The UserName in Windows to run the entrypoint of the container process.
+                                          Defaults to the user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext. If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        type: string
+                                    type: object
+                                type: object
+                              startupProbe:
+                                description: |-
+                                  StartupProbe indicates that the Pod has successfully initialized.
+                                  If specified, no other probes are executed until this completes successfully.
+                                  If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                  This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                  when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                  This cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  grpc:
+                                    description: GRPC specifies a GRPC HealthCheckRequest.
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        default: ""
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
+                                      Default to 10 seconds. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: TCPSocket specifies a connection to a TCP port.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: |-
+                                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after the processes running in the pod are sent
+                                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                      Set this value longer than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                      value overrides the value provided by the pod spec.
+                                      Value must be non-negative integer. The value zero indicates stop immediately via
+                                      the kill signal (no opportunity to shut down).
+                                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                type: object
+                              stdin:
+                                description: |-
+                                  Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                  is not set, reads from stdin in the container will always result in EOF.
+                                  Default is false.
+                                type: boolean
+                              stdinOnce:
+                                description: |-
+                                  Whether the container runtime should close the stdin channel after it has been opened by
+                                  a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                  sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                  first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                  at which time stdin is closed and remains closed until the container is restarted. If this
+                                  flag is false, a container processes that reads from stdin will never receive an EOF.
+                                  Default is false
+                                type: boolean
+                              terminationMessagePath:
+                                description: |-
+                                  Optional: Path at which the file to which the container's termination message
+                                  will be written is mounted into the container's filesystem.
+                                  Message written is intended to be brief final status, such as an assertion failure message.
+                                  Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                  all containers will be limited to 12kb.
+                                  Defaults to /dev/termination-log.
+                                  Cannot be updated.
+                                type: string
+                              terminationMessagePolicy:
+                                description: |-
+                                  Indicate how the termination message should be populated. File will use the contents of
+                                  terminationMessagePath to populate the container status message on both success and failure.
+                                  FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                  message file is empty and the container exited with an error.
+                                  The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                  Defaults to File.
+                                  Cannot be updated.
+                                type: string
+                              tty:
+                                description: |-
+                                  Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                  Default is false.
+                                type: boolean
+                              volumeDevices:
+                                description: volumeDevices is the list of block devices to be used by the container.
+                                items:
+                                  description: volumeDevice describes a mapping of a raw block device within a container.
+                                  properties:
+                                    devicePath:
+                                      description: devicePath is the path inside of the container that the device will be mapped to.
+                                      type: string
+                                    name:
+                                      description: name must match the name of a persistentVolumeClaim in the pod
+                                      type: string
+                                  required:
+                                    - devicePath
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - devicePath
+                                x-kubernetes-list-type: map
+                              volumeMounts:
+                                description: |-
+                                  Pod volumes to mount into the container's filesystem.
+                                  Cannot be updated.
+                                items:
+                                  description: VolumeMount describes a mounting of a Volume within a container.
+                                  properties:
+                                    mountPath:
+                                      description: |-
+                                        Path within the container at which the volume should be mounted.  Must
+                                        not contain ':'.
+                                      type: string
+                                    mountPropagation:
+                                      description: |-
+                                        mountPropagation determines how mounts are propagated from the host
+                                        to container and the other way around.
+                                        When not set, MountPropagationNone is used.
+                                        This field is beta in 1.10.
+                                        When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                        (which defaults to None).
+                                      type: string
+                                    name:
+                                      description: This must match the Name of a Volume.
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                                        Defaults to false.
+                                      type: boolean
+                                    recursiveReadOnly:
+                                      description: |-
+                                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                                        recursively.
+
+                                        If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                        If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                        recursively read-only.  If this field is set to IfPossible, the mount is made
+                                        recursively read-only, if it is supported by the container runtime.  If this
+                                        field is set to Enabled, the mount is made recursively read-only if it is
+                                        supported by the container runtime, otherwise the pod will not be started and
+                                        an error will be generated to indicate the reason.
+
+                                        If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                        None (or be unspecified, which defaults to None).
+
+                                        If this field is not specified, it is treated as an equivalent of Disabled.
+                                      type: string
+                                    subPath:
+                                      description: |-
+                                        Path within the volume from which the container's volume should be mounted.
+                                        Defaults to "" (volume's root).
+                                      type: string
+                                    subPathExpr:
+                                      description: |-
+                                        Expanded path within the volume from which the container's volume should be mounted.
+                                        Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                        Defaults to "" (volume's root).
+                                        SubPathExpr and SubPath are mutually exclusive.
+                                      type: string
+                                  required:
+                                    - mountPath
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - mountPath
+                                x-kubernetes-list-type: map
+                              workingDir:
+                                description: |-
+                                  Container's working directory.
+                                  If not specified, the container runtime's default will be used, which
+                                  might be configured in the container image.
+                                  Cannot be updated.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        dnsConfig:
+                          description: |-
+                            Specifies the DNS parameters of a pod.
+                            Parameters specified here will be merged to the generated DNS
+                            configuration based on DNSPolicy.
+                          properties:
+                            nameservers:
+                              description: |-
+                                A list of DNS name server IP addresses.
+                                This will be appended to the base nameservers generated from DNSPolicy.
+                                Duplicated nameservers will be removed.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            options:
+                              description: |-
+                                A list of DNS resolver options.
+                                This will be merged with the base options generated from DNSPolicy.
+                                Duplicated entries will be removed. Resolution options given in Options
+                                will override those that appear in the base DNSPolicy.
+                              items:
+                                description: PodDNSConfigOption defines DNS resolver options of a pod.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name is this DNS resolver option's name.
+                                      Required.
+                                    type: string
+                                  value:
+                                    description: Value is this DNS resolver option's value.
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            searches:
+                              description: |-
+                                A list of DNS search domains for host-name lookup.
+                                This will be appended to the base search paths generated from DNSPolicy.
+                                Duplicated search paths will be removed.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        dnsPolicy:
+                          description: |-
+                            Set DNS policy for the pod.
+                            Defaults to "ClusterFirst".
+                            Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                            DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                            To have DNS options set along with hostNetwork, you have to specify DNS policy
+                            explicitly to 'ClusterFirstWithHostNet'.
+                          type: string
+                        enableServiceLinks:
+                          description: |-
+                            EnableServiceLinks indicates whether information about services should be injected into pod's
+                            environment variables, matching the syntax of Docker links.
+                            Optional: Defaults to true.
+                          type: boolean
+                        ephemeralContainers:
+                          description: |-
+                            List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
+                            pod to perform user-initiated actions such as debugging. This list cannot be specified when
+                            creating a pod, and it cannot be modified by updating the pod spec. In order to add an
+                            ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
+                          items:
+                            description: |-
+                              An EphemeralContainer is a temporary container that you may add to an existing Pod for
+                              user-initiated activities such as debugging. Ephemeral containers have no resource or
+                              scheduling guarantees, and they will not be restarted when they exit or when a Pod is
+                              removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
+                              Pod to exceed its resource allocation.
+
+                              To add an ephemeral container, use the ephemeralcontainers subresource of an existing
+                              Pod. Ephemeral containers may not be removed or restarted.
+                            properties:
+                              args:
+                                description: |-
+                                  Arguments to the entrypoint.
+                                  The image's CMD is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              command:
+                                description: |-
+                                  Entrypoint array. Not executed within a shell.
+                                  The image's ENTRYPOINT is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              env:
+                                description: |-
+                                  List of environment variables to set in the container.
+                                  Cannot be updated.
+                                items:
+                                  description: EnvVar represents an environment variable present in a Container.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the environment variable.
+                                        May consist of any printable ASCII characters except '='.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap or its key must be defined
+                                              type: boolean
+                                          required:
+                                            - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: |-
+                                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select in the specified API version.
+                                              type: string
+                                          required:
+                                            - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fileKeyRef:
+                                          description: |-
+                                            FileKeyRef selects a key of the env file.
+                                            Requires the EnvFiles feature gate to be enabled.
+                                          properties:
+                                            key:
+                                              description: |-
+                                                The key within the env file. An invalid key will prevent the pod from starting.
+                                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                              type: string
+                                            optional:
+                                              default: false
+                                              description: |-
+                                                Specify whether the file or its key must be defined. If the file or key
+                                                does not exist, then the env var is not published.
+                                                If optional is set to true and the specified key does not exist,
+                                                the environment variable will not be set in the Pod's containers.
+
+                                                If optional is set to false and the specified key does not exist,
+                                                an error will be returned during Pod creation.
+                                              type: boolean
+                                            path:
+                                              description: |-
+                                                The path within the volume from which to select the file.
+                                                Must be relative and may not contain the '..' path or start with '..'.
+                                              type: string
+                                            volumeName:
+                                              description: The name of the volume mount containing the env file.
+                                              type: string
+                                          required:
+                                            - key
+                                            - path
+                                            - volumeName
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              description: Specifies the output format of the exposed resources, defaults to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to select'
+                                              type: string
+                                          required:
+                                            - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to select from.  Must be a valid secret key.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret or its key must be defined
+                                              type: boolean
+                                          required:
+                                            - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
+                              envFrom:
+                                description: |-
+                                  List of sources to populate environment variables in the container.
+                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                  When a key exists in multiple
+                                  sources, the value associated with the last source will take precedence.
+                                  Values defined by an Env with a duplicate key will take precedence.
+                                  Cannot be updated.
+                                items:
+                                  description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
+                                  properties:
+                                    configMapRef:
+                                      description: The ConfigMap to select from
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    prefix:
+                                      description: |-
+                                        Optional text to prepend to the name of each environment variable.
+                                        May consist of any printable ASCII characters except '='.
+                                      type: string
+                                    secretRef:
+                                      description: The Secret to select from
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              image:
+                                description: |-
+                                  Container image name.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                type: string
+                              imagePullPolicy:
+                                description: |-
+                                  Image pull policy.
+                                  One of Always, Never, IfNotPresent.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                type: string
+                              lifecycle:
+                                description: Lifecycle is not allowed for ephemeral containers.
+                                properties:
+                                  postStart:
+                                    description: |-
+                                      PostStart is called immediately after a container is created. If the handler fails,
+                                      the container is terminated and restarted according to its restart policy.
+                                      Other management of the container blocks until the hook completes.
+                                      More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                    properties:
+                                      exec:
+                                        description: Exec specifies a command to execute in the container.
+                                        properties:
+                                          command:
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies an HTTP GET request to perform.
+                                        properties:
+                                          host:
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                                - name
+                                                - value
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          path:
+                                            description: Path to access on the HTTP server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
+                                            type: string
+                                        required:
+                                          - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents a duration that the container should sleep.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                          - seconds
+                                        type: object
+                                      tcpSocket:
+                                        description: |-
+                                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                          for backward compatibility. There is no validation of this field and
+                                          lifecycle hooks will fail at runtime when it is specified.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                          - port
+                                        type: object
+                                    type: object
+                                  preStop:
+                                    description: |-
+                                      PreStop is called immediately before a container is terminated due to an
+                                      API request or management event such as liveness/startup probe failure,
+                                      preemption, resource contention, etc. The handler is not called if the
+                                      container crashes or exits. The Pod's termination grace period countdown begins before the
+                                      PreStop hook is executed. Regardless of the outcome of the handler, the
+                                      container will eventually terminate within the Pod's termination grace
+                                      period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                      or until the termination grace period is reached.
+                                      More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                    properties:
+                                      exec:
+                                        description: Exec specifies a command to execute in the container.
+                                        properties:
+                                          command:
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies an HTTP GET request to perform.
+                                        properties:
+                                          host:
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                                - name
+                                                - value
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          path:
+                                            description: Path to access on the HTTP server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
+                                            type: string
+                                        required:
+                                          - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents a duration that the container should sleep.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                          - seconds
+                                        type: object
+                                      tcpSocket:
+                                        description: |-
+                                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                          for backward compatibility. There is no validation of this field and
+                                          lifecycle hooks will fail at runtime when it is specified.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                          - port
+                                        type: object
+                                    type: object
+                                  stopSignal:
+                                    description: |-
+                                      StopSignal defines which signal will be sent to a container when it is being stopped.
+                                      If not specified, the default is defined by the container runtime in use.
+                                      StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                    type: string
+                                type: object
+                              livenessProbe:
+                                description: Probes are not allowed for ephemeral containers.
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  grpc:
+                                    description: GRPC specifies a GRPC HealthCheckRequest.
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        default: ""
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
+                                      Default to 10 seconds. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: TCPSocket specifies a connection to a TCP port.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: |-
+                                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after the processes running in the pod are sent
+                                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                      Set this value longer than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                      value overrides the value provided by the pod spec.
+                                      Value must be non-negative integer. The value zero indicates stop immediately via
+                                      the kill signal (no opportunity to shut down).
+                                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                type: object
+                              name:
+                                description: |-
+                                  Name of the ephemeral container specified as a DNS_LABEL.
+                                  This name must be unique among all containers, init containers and ephemeral containers.
+                                type: string
+                              ports:
+                                description: Ports are not allowed for ephemeral containers.
+                                items:
+                                  description: ContainerPort represents a network port in a single container.
+                                  properties:
+                                    containerPort:
+                                      description: |-
+                                        Number of port to expose on the pod's IP address.
+                                        This must be a valid port number, 0 < x < 65536.
+                                      format: int32
+                                      type: integer
+                                    hostIP:
+                                      description: What host IP to bind the external port to.
+                                      type: string
+                                    hostPort:
+                                      description: |-
+                                        Number of port to expose on the host.
+                                        If specified, this must be a valid port number, 0 < x < 65536.
+                                        If HostNetwork is specified, this must match ContainerPort.
+                                        Most containers do not need this.
+                                      format: int32
+                                      type: integer
+                                    name:
+                                      description: |-
+                                        If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                        named port in a pod must have a unique name. Name for the port that can be
+                                        referred to by services.
+                                      type: string
+                                    protocol:
+                                      default: TCP
+                                      description: |-
+                                        Protocol for port. Must be UDP, TCP, or SCTP.
+                                        Defaults to "TCP".
+                                      type: string
+                                  required:
+                                    - containerPort
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - containerPort
+                                  - protocol
+                                x-kubernetes-list-type: map
+                              readinessProbe:
+                                description: Probes are not allowed for ephemeral containers.
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  grpc:
+                                    description: GRPC specifies a GRPC HealthCheckRequest.
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        default: ""
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
+                                      Default to 10 seconds. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: TCPSocket specifies a connection to a TCP port.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: |-
+                                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after the processes running in the pod are sent
+                                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                      Set this value longer than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                      value overrides the value provided by the pod spec.
+                                      Value must be non-negative integer. The value zero indicates stop immediately via
+                                      the kill signal (no opportunity to shut down).
+                                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                type: object
+                              resizePolicy:
+                                description: Resources resize policy for the container.
+                                items:
+                                  description: ContainerResizePolicy represents resource resize policy for the container.
+                                  properties:
+                                    resourceName:
+                                      description: |-
+                                        Name of the resource to which this resource resize policy applies.
+                                        Supported values: cpu, memory.
+                                      type: string
+                                    restartPolicy:
+                                      description: |-
+                                        Restart policy to apply when specified resource is resized.
+                                        If not specified, it defaults to NotRequired.
+                                      type: string
+                                  required:
+                                    - resourceName
+                                    - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              resources:
+                                description: |-
+                                  Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
+                                  already allocated to the pod.
+                                properties:
+                                  claims:
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
+
+                                      This field depends on the
+                                      DynamicResourceAllocation feature gate.
+
+                                      This field is immutable. It can only be set for containers.
+                                    items:
+                                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes that resource available
+                                            inside a container.
+                                          type: string
+                                        request:
+                                          description: |-
+                                            Request is the name chosen for a request in the referenced claim.
+                                            If empty, everything from the claim is made available, otherwise
+                                            only the result of this request.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Requests describes the minimum amount of compute resources required.
+                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                type: object
+                              restartPolicy:
+                                description: |-
+                                  Restart policy for the container to manage the restart behavior of each
+                                  container within a pod.
+                                  You cannot set this field on ephemeral containers.
+                                type: string
+                              restartPolicyRules:
+                                description: |-
+                                  Represents a list of rules to be checked to determine if the
+                                  container should be restarted on exit. You cannot set this field on
+                                  ephemeral containers.
+                                items:
+                                  description: ContainerRestartRule describes how a container exit is handled.
+                                  properties:
+                                    action:
+                                      description: |-
+                                        Specifies the action taken on a container exit if the requirements
+                                        are satisfied. The only possible value is "Restart" to restart the
+                                        container.
+                                      type: string
+                                    exitCodes:
+                                      description: Represents the exit codes to check on container exits.
+                                      properties:
+                                        operator:
+                                          description: |-
+                                            Represents the relationship between the container exit code(s) and the
+                                            specified values. Possible values are:
+                                            - In: the requirement is satisfied if the container exit code is in the
+                                              set of specified values.
+                                            - NotIn: the requirement is satisfied if the container exit code is
+                                              not in the set of specified values.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            Specifies the set of values to check for container exit codes.
+                                            At most 255 elements are allowed.
+                                          items:
+                                            format: int32
+                                            type: integer
+                                          type: array
+                                          x-kubernetes-list-type: set
+                                      required:
+                                        - operator
+                                      type: object
+                                  required:
+                                    - action
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              securityContext:
+                                description: |-
+                                  Optional: SecurityContext defines the security options the ephemeral container should be run with.
+                                  If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                properties:
+                                  allowPrivilegeEscalation:
+                                    description: |-
+                                      AllowPrivilegeEscalation controls whether a process can gain more
+                                      privileges than its parent process. This bool directly controls if
+                                      the no_new_privs flag will be set on the container process.
+                                      AllowPrivilegeEscalation is true always when the container is:
+                                      1) run as Privileged
+                                      2) has CAP_SYS_ADMIN
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  appArmorProfile:
+                                    description: |-
+                                      appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                      overrides the pod's appArmorProfile.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile loaded on the node that should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must match the loaded name of the profile.
+                                          Must be set if and only if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of AppArmor profile will be applied.
+                                          Valid options are:
+                                            Localhost - a profile pre-loaded on the node.
+                                            RuntimeDefault - the container runtime's default profile.
+                                            Unconfined - no AppArmor enforcement.
+                                        type: string
+                                    required:
+                                      - type
+                                    type: object
+                                  capabilities:
+                                    description: |-
+                                      The capabilities to add/drop when running containers.
+                                      Defaults to the default set of capabilities granted by the container runtime.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      add:
+                                        description: Added capabilities
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      drop:
+                                        description: Removed capabilities
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  privileged:
+                                    description: |-
+                                      Run container in privileged mode.
+                                      Processes in privileged containers are essentially equivalent to root on the host.
+                                      Defaults to false.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  procMount:
+                                    description: |-
+                                      procMount denotes the type of proc mount to use for the containers.
+                                      The default value is Default which uses the container runtime defaults for
+                                      readonly paths and masked paths.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: string
+                                  readOnlyRootFilesystem:
+                                    description: |-
+                                      Whether this container has a read-only root filesystem.
+                                      Default is false.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  runAsGroup:
+                                    description: |-
+                                      The GID to run the entrypoint of the container process.
+                                      Uses runtime default if unset.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    description: |-
+                                      Indicates that the container must run as a non-root user.
+                                      If true, the Kubelet will validate the image at runtime to ensure that it
+                                      does not run as UID 0 (root) and fail to start the container if it does.
+                                      If unset or false, no such validation will be performed.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: |-
+                                      The UID to run the entrypoint of the container process.
+                                      Defaults to user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    description: |-
+                                      The SELinux context to be applied to the container.
+                                      If unspecified, the container runtime will allocate a random SELinux context for each
+                                      container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      level:
+                                        description: Level is SELinux level label that applies to the container.
+                                        type: string
+                                      role:
+                                        description: Role is a SELinux role label that applies to the container.
+                                        type: string
+                                      type:
+                                        description: Type is a SELinux type label that applies to the container.
+                                        type: string
+                                      user:
+                                        description: User is a SELinux user label that applies to the container.
+                                        type: string
+                                    type: object
+                                  seccompProfile:
+                                    description: |-
+                                      The seccomp options to use by this container. If seccomp options are
+                                      provided at both the pod & container level, the container options
+                                      override the pod options.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile defined in a file on the node should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                          Must be set if type is "Localhost". Must NOT be set for any other type.
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of seccomp profile will be applied.
+                                          Valid options are:
+
+                                          Localhost - a profile defined in a file on the node should be used.
+                                          RuntimeDefault - the container runtime default profile should be used.
+                                          Unconfined - no profile should be applied.
+                                        type: string
+                                    required:
+                                      - type
+                                    type: object
+                                  windowsOptions:
+                                    description: |-
+                                      The Windows specific settings applied to all containers.
+                                      If unspecified, the options from the PodSecurityContext will be used.
+                                      If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is linux.
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        description: |-
+                                          GMSACredentialSpec is where the GMSA admission webhook
+                                          (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                          GMSA credential spec named by the GMSACredentialSpecName field.
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                        type: string
+                                      hostProcess:
+                                        description: |-
+                                          HostProcess determines if a container should be run as a 'Host Process' container.
+                                          All of a Pod's containers must have the same effective HostProcess value
+                                          (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                          In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                        type: boolean
+                                      runAsUserName:
+                                        description: |-
+                                          The UserName in Windows to run the entrypoint of the container process.
+                                          Defaults to the user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext. If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        type: string
+                                    type: object
+                                type: object
+                              startupProbe:
+                                description: Probes are not allowed for ephemeral containers.
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  grpc:
+                                    description: GRPC specifies a GRPC HealthCheckRequest.
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        default: ""
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
+                                      Default to 10 seconds. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: TCPSocket specifies a connection to a TCP port.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: |-
+                                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after the processes running in the pod are sent
+                                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                      Set this value longer than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                      value overrides the value provided by the pod spec.
+                                      Value must be non-negative integer. The value zero indicates stop immediately via
+                                      the kill signal (no opportunity to shut down).
+                                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                type: object
+                              stdin:
+                                description: |-
+                                  Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                  is not set, reads from stdin in the container will always result in EOF.
+                                  Default is false.
+                                type: boolean
+                              stdinOnce:
+                                description: |-
+                                  Whether the container runtime should close the stdin channel after it has been opened by
+                                  a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                  sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                  first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                  at which time stdin is closed and remains closed until the container is restarted. If this
+                                  flag is false, a container processes that reads from stdin will never receive an EOF.
+                                  Default is false
+                                type: boolean
+                              targetContainerName:
+                                description: |-
+                                  If set, the name of the container from PodSpec that this ephemeral container targets.
+                                  The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+                                  If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                                  The container runtime must implement support for this feature. If the runtime does not
+                                  support namespace targeting then the result of setting this field is undefined.
+                                type: string
+                              terminationMessagePath:
+                                description: |-
+                                  Optional: Path at which the file to which the container's termination message
+                                  will be written is mounted into the container's filesystem.
+                                  Message written is intended to be brief final status, such as an assertion failure message.
+                                  Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                  all containers will be limited to 12kb.
+                                  Defaults to /dev/termination-log.
+                                  Cannot be updated.
+                                type: string
+                              terminationMessagePolicy:
+                                description: |-
+                                  Indicate how the termination message should be populated. File will use the contents of
+                                  terminationMessagePath to populate the container status message on both success and failure.
+                                  FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                  message file is empty and the container exited with an error.
+                                  The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                  Defaults to File.
+                                  Cannot be updated.
+                                type: string
+                              tty:
+                                description: |-
+                                  Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                  Default is false.
+                                type: boolean
+                              volumeDevices:
+                                description: volumeDevices is the list of block devices to be used by the container.
+                                items:
+                                  description: volumeDevice describes a mapping of a raw block device within a container.
+                                  properties:
+                                    devicePath:
+                                      description: devicePath is the path inside of the container that the device will be mapped to.
+                                      type: string
+                                    name:
+                                      description: name must match the name of a persistentVolumeClaim in the pod
+                                      type: string
+                                  required:
+                                    - devicePath
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - devicePath
+                                x-kubernetes-list-type: map
+                              volumeMounts:
+                                description: |-
+                                  Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
+                                  Cannot be updated.
+                                items:
+                                  description: VolumeMount describes a mounting of a Volume within a container.
+                                  properties:
+                                    mountPath:
+                                      description: |-
+                                        Path within the container at which the volume should be mounted.  Must
+                                        not contain ':'.
+                                      type: string
+                                    mountPropagation:
+                                      description: |-
+                                        mountPropagation determines how mounts are propagated from the host
+                                        to container and the other way around.
+                                        When not set, MountPropagationNone is used.
+                                        This field is beta in 1.10.
+                                        When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                        (which defaults to None).
+                                      type: string
+                                    name:
+                                      description: This must match the Name of a Volume.
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                                        Defaults to false.
+                                      type: boolean
+                                    recursiveReadOnly:
+                                      description: |-
+                                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                                        recursively.
+
+                                        If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                        If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                        recursively read-only.  If this field is set to IfPossible, the mount is made
+                                        recursively read-only, if it is supported by the container runtime.  If this
+                                        field is set to Enabled, the mount is made recursively read-only if it is
+                                        supported by the container runtime, otherwise the pod will not be started and
+                                        an error will be generated to indicate the reason.
+
+                                        If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                        None (or be unspecified, which defaults to None).
+
+                                        If this field is not specified, it is treated as an equivalent of Disabled.
+                                      type: string
+                                    subPath:
+                                      description: |-
+                                        Path within the volume from which the container's volume should be mounted.
+                                        Defaults to "" (volume's root).
+                                      type: string
+                                    subPathExpr:
+                                      description: |-
+                                        Expanded path within the volume from which the container's volume should be mounted.
+                                        Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                        Defaults to "" (volume's root).
+                                        SubPathExpr and SubPath are mutually exclusive.
+                                      type: string
+                                  required:
+                                    - mountPath
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - mountPath
+                                x-kubernetes-list-type: map
+                              workingDir:
+                                description: |-
+                                  Container's working directory.
+                                  If not specified, the container runtime's default will be used, which
+                                  might be configured in the container image.
+                                  Cannot be updated.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        hostAliases:
+                          description: |-
+                            HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                            file if specified.
+                          items:
+                            description: |-
+                              HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                              pod's hosts file.
+                            properties:
+                              hostnames:
+                                description: Hostnames for the above IP address.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ip:
+                                description: IP address of the host file entry.
+                                type: string
+                            required:
+                              - ip
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - ip
+                          x-kubernetes-list-type: map
+                        hostIPC:
+                          description: |-
+                            Use the host's ipc namespace.
+                            Optional: Default to false.
+                          type: boolean
+                        hostNetwork:
+                          description: |-
+                            Host networking requested for this pod. Use the host's network namespace.
+                            When using HostNetwork you should specify ports so the scheduler is aware.
+                            When `hostNetwork` is true, specified `hostPort` fields in port definitions must match `containerPort`,
+                            and unspecified `hostPort` fields in port definitions are defaulted to match `containerPort`.
+                            Default to false.
+                          type: boolean
+                        hostPID:
+                          description: |-
+                            Use the host's pid namespace.
+                            Optional: Default to false.
+                          type: boolean
+                        hostUsers:
+                          description: |-
+                            Use the host's user namespace.
+                            Optional: Default to true.
+                            If set to true or not present, the pod will be run in the host user namespace, useful
+                            for when the pod needs a feature only available to the host user namespace, such as
+                            loading a kernel module with CAP_SYS_MODULE.
+                            When set to false, a new userns is created for the pod. Setting false is useful for
+                            mitigating container breakout vulnerabilities even allowing users to run their
+                            containers as root without actually having root privileges on the host.
+                          type: boolean
+                        hostname:
+                          description: |-
+                            Specifies the hostname of the Pod
+                            If not specified, the pod's hostname will be set to a system-defined value.
+                          type: string
+                        hostnameOverride:
+                          description: |-
+                            HostnameOverride specifies an explicit override for the pod's hostname as perceived by the pod.
+                            This field only specifies the pod's hostname and does not affect its DNS records.
+                            When this field is set to a non-empty string:
+                            - It takes precedence over the values set in `hostname` and `subdomain`.
+                            - The Pod's hostname will be set to this value.
+                            - `setHostnameAsFQDN` must be nil or set to false.
+                            - `hostNetwork` must be set to false.
+
+                            This field must be a valid DNS subdomain as defined in RFC 1123 and contain at most 64 characters.
+                            Requires the HostnameOverride feature gate to be enabled.
+                          type: string
+                        imagePullSecrets:
+                          description: |-
+                            ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                            If specified, these secrets will be passed to individual puller implementations for them to use.
+                            More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                          items:
+                            description: |-
+                              LocalObjectReference contains enough information to let you locate the
+                              referenced object inside the same namespace.
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        initContainers:
+                          description: |-
+                            List of initialization containers belonging to the pod.
+                            Init containers are executed in order prior to containers being started. If any
+                            init container fails, the pod is considered to have failed and is handled according
+                            to its restartPolicy. The name for an init container or normal container must be
+                            unique among all containers.
+                            Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                            The resourceRequirements of an init container are taken into account during scheduling
+                            by finding the highest request/limit for each resource type, and then using the max of
+                            that value or the sum of the normal containers. Limits are applied to init containers
+                            in a similar fashion.
+                            Init containers cannot currently be added or removed.
+                            Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+                          items:
+                            description: A single application container that you want to run within a pod.
+                            properties:
+                              args:
+                                description: |-
+                                  Arguments to the entrypoint.
+                                  The container image's CMD is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              command:
+                                description: |-
+                                  Entrypoint array. Not executed within a shell.
+                                  The container image's ENTRYPOINT is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              env:
+                                description: |-
+                                  List of environment variables to set in the container.
+                                  Cannot be updated.
+                                items:
+                                  description: EnvVar represents an environment variable present in a Container.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the environment variable.
+                                        May consist of any printable ASCII characters except '='.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap or its key must be defined
+                                              type: boolean
+                                          required:
+                                            - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: |-
+                                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select in the specified API version.
+                                              type: string
+                                          required:
+                                            - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fileKeyRef:
+                                          description: |-
+                                            FileKeyRef selects a key of the env file.
+                                            Requires the EnvFiles feature gate to be enabled.
+                                          properties:
+                                            key:
+                                              description: |-
+                                                The key within the env file. An invalid key will prevent the pod from starting.
+                                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                              type: string
+                                            optional:
+                                              default: false
+                                              description: |-
+                                                Specify whether the file or its key must be defined. If the file or key
+                                                does not exist, then the env var is not published.
+                                                If optional is set to true and the specified key does not exist,
+                                                the environment variable will not be set in the Pod's containers.
+
+                                                If optional is set to false and the specified key does not exist,
+                                                an error will be returned during Pod creation.
+                                              type: boolean
+                                            path:
+                                              description: |-
+                                                The path within the volume from which to select the file.
+                                                Must be relative and may not contain the '..' path or start with '..'.
+                                              type: string
+                                            volumeName:
+                                              description: The name of the volume mount containing the env file.
+                                              type: string
+                                          required:
+                                            - key
+                                            - path
+                                            - volumeName
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              description: Specifies the output format of the exposed resources, defaults to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to select'
+                                              type: string
+                                          required:
+                                            - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to select from.  Must be a valid secret key.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret or its key must be defined
+                                              type: boolean
+                                          required:
+                                            - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
+                              envFrom:
+                                description: |-
+                                  List of sources to populate environment variables in the container.
+                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                  When a key exists in multiple
+                                  sources, the value associated with the last source will take precedence.
+                                  Values defined by an Env with a duplicate key will take precedence.
+                                  Cannot be updated.
+                                items:
+                                  description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
+                                  properties:
+                                    configMapRef:
+                                      description: The ConfigMap to select from
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    prefix:
+                                      description: |-
+                                        Optional text to prepend to the name of each environment variable.
+                                        May consist of any printable ASCII characters except '='.
+                                      type: string
+                                    secretRef:
+                                      description: The Secret to select from
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              image:
+                                description: |-
+                                  Container image name.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                              imagePullPolicy:
+                                description: |-
+                                  Image pull policy.
+                                  One of Always, Never, IfNotPresent.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                type: string
+                              lifecycle:
+                                description: |-
+                                  Actions that the management system should take in response to container lifecycle events.
+                                  Cannot be updated.
+                                properties:
+                                  postStart:
+                                    description: |-
+                                      PostStart is called immediately after a container is created. If the handler fails,
+                                      the container is terminated and restarted according to its restart policy.
+                                      Other management of the container blocks until the hook completes.
+                                      More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                    properties:
+                                      exec:
+                                        description: Exec specifies a command to execute in the container.
+                                        properties:
+                                          command:
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies an HTTP GET request to perform.
+                                        properties:
+                                          host:
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                                - name
+                                                - value
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          path:
+                                            description: Path to access on the HTTP server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
+                                            type: string
+                                        required:
+                                          - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents a duration that the container should sleep.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                          - seconds
+                                        type: object
+                                      tcpSocket:
+                                        description: |-
+                                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                          for backward compatibility. There is no validation of this field and
+                                          lifecycle hooks will fail at runtime when it is specified.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                          - port
+                                        type: object
+                                    type: object
+                                  preStop:
+                                    description: |-
+                                      PreStop is called immediately before a container is terminated due to an
+                                      API request or management event such as liveness/startup probe failure,
+                                      preemption, resource contention, etc. The handler is not called if the
+                                      container crashes or exits. The Pod's termination grace period countdown begins before the
+                                      PreStop hook is executed. Regardless of the outcome of the handler, the
+                                      container will eventually terminate within the Pod's termination grace
+                                      period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                      or until the termination grace period is reached.
+                                      More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                    properties:
+                                      exec:
+                                        description: Exec specifies a command to execute in the container.
+                                        properties:
+                                          command:
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies an HTTP GET request to perform.
+                                        properties:
+                                          host:
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                                - name
+                                                - value
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          path:
+                                            description: Path to access on the HTTP server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
+                                            type: string
+                                        required:
+                                          - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents a duration that the container should sleep.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                          - seconds
+                                        type: object
+                                      tcpSocket:
+                                        description: |-
+                                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                          for backward compatibility. There is no validation of this field and
+                                          lifecycle hooks will fail at runtime when it is specified.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                          - port
+                                        type: object
+                                    type: object
+                                  stopSignal:
+                                    description: |-
+                                      StopSignal defines which signal will be sent to a container when it is being stopped.
+                                      If not specified, the default is defined by the container runtime in use.
+                                      StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                    type: string
+                                type: object
+                              livenessProbe:
+                                description: |-
+                                  Periodic probe of container liveness.
+                                  Container will be restarted if the probe fails.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  grpc:
+                                    description: GRPC specifies a GRPC HealthCheckRequest.
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        default: ""
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
+                                      Default to 10 seconds. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: TCPSocket specifies a connection to a TCP port.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: |-
+                                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after the processes running in the pod are sent
+                                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                      Set this value longer than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                      value overrides the value provided by the pod spec.
+                                      Value must be non-negative integer. The value zero indicates stop immediately via
+                                      the kill signal (no opportunity to shut down).
+                                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                type: object
+                              name:
+                                description: |-
+                                  Name of the container specified as a DNS_LABEL.
+                                  Each container in a pod must have a unique name (DNS_LABEL).
+                                  Cannot be updated.
+                                type: string
+                              ports:
+                                description: |-
+                                  List of ports to expose from the container. Not specifying a port here
+                                  DOES NOT prevent that port from being exposed. Any port which is
+                                  listening on the default "0.0.0.0" address inside a container will be
+                                  accessible from the network.
+                                  Modifying this array with strategic merge patch may corrupt the data.
+                                  For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                  Cannot be updated.
+                                items:
+                                  description: ContainerPort represents a network port in a single container.
+                                  properties:
+                                    containerPort:
+                                      description: |-
+                                        Number of port to expose on the pod's IP address.
+                                        This must be a valid port number, 0 < x < 65536.
+                                      format: int32
+                                      type: integer
+                                    hostIP:
+                                      description: What host IP to bind the external port to.
+                                      type: string
+                                    hostPort:
+                                      description: |-
+                                        Number of port to expose on the host.
+                                        If specified, this must be a valid port number, 0 < x < 65536.
+                                        If HostNetwork is specified, this must match ContainerPort.
+                                        Most containers do not need this.
+                                      format: int32
+                                      type: integer
+                                    name:
+                                      description: |-
+                                        If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                        named port in a pod must have a unique name. Name for the port that can be
+                                        referred to by services.
+                                      type: string
+                                    protocol:
+                                      default: TCP
+                                      description: |-
+                                        Protocol for port. Must be UDP, TCP, or SCTP.
+                                        Defaults to "TCP".
+                                      type: string
+                                  required:
+                                    - containerPort
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - containerPort
+                                  - protocol
+                                x-kubernetes-list-type: map
+                              readinessProbe:
+                                description: |-
+                                  Periodic probe of container service readiness.
+                                  Container will be removed from service endpoints if the probe fails.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  grpc:
+                                    description: GRPC specifies a GRPC HealthCheckRequest.
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        default: ""
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
+                                      Default to 10 seconds. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: TCPSocket specifies a connection to a TCP port.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: |-
+                                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after the processes running in the pod are sent
+                                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                      Set this value longer than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                      value overrides the value provided by the pod spec.
+                                      Value must be non-negative integer. The value zero indicates stop immediately via
+                                      the kill signal (no opportunity to shut down).
+                                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                type: object
+                              resizePolicy:
+                                description: |-
+                                  Resources resize policy for the container.
+                                  This field cannot be set on ephemeral containers.
+                                items:
+                                  description: ContainerResizePolicy represents resource resize policy for the container.
+                                  properties:
+                                    resourceName:
+                                      description: |-
+                                        Name of the resource to which this resource resize policy applies.
+                                        Supported values: cpu, memory.
+                                      type: string
+                                    restartPolicy:
+                                      description: |-
+                                        Restart policy to apply when specified resource is resized.
+                                        If not specified, it defaults to NotRequired.
+                                      type: string
+                                  required:
+                                    - resourceName
+                                    - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              resources:
+                                description: |-
+                                  Compute Resources required by this container.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                properties:
+                                  claims:
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
+
+                                      This field depends on the
+                                      DynamicResourceAllocation feature gate.
+
+                                      This field is immutable. It can only be set for containers.
+                                    items:
+                                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes that resource available
+                                            inside a container.
+                                          type: string
+                                        request:
+                                          description: |-
+                                            Request is the name chosen for a request in the referenced claim.
+                                            If empty, everything from the claim is made available, otherwise
+                                            only the result of this request.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Requests describes the minimum amount of compute resources required.
+                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                type: object
+                              restartPolicy:
+                                description: |-
+                                  RestartPolicy defines the restart behavior of individual containers in a pod.
+                                  This overrides the pod-level restart policy. When this field is not specified,
+                                  the restart behavior is defined by the Pod's restart policy and the container type.
+                                  Additionally, setting the RestartPolicy as "Always" for the init container will
+                                  have the following effect:
+                                  this init container will be continually restarted on
+                                  exit until all regular containers have terminated. Once all regular
+                                  containers have completed, all init containers with restartPolicy "Always"
+                                  will be shut down. This lifecycle differs from normal init containers and
+                                  is often referred to as a "sidecar" container. Although this init
+                                  container still starts in the init container sequence, it does not wait
+                                  for the container to complete before proceeding to the next init
+                                  container. Instead, the next init container starts immediately after this
+                                  init container is started, or after any startupProbe has successfully
+                                  completed.
+                                type: string
+                              restartPolicyRules:
+                                description: |-
+                                  Represents a list of rules to be checked to determine if the
+                                  container should be restarted on exit. The rules are evaluated in
+                                  order. Once a rule matches a container exit condition, the remaining
+                                  rules are ignored. If no rule matches the container exit condition,
+                                  the Container-level restart policy determines the whether the container
+                                  is restarted or not. Constraints on the rules:
+                                  - At most 20 rules are allowed.
+                                  - Rules can have the same action.
+                                  - Identical rules are not forbidden in validations.
+                                  When rules are specified, container MUST set RestartPolicy explicitly
+                                  even it if matches the Pod's RestartPolicy.
+                                items:
+                                  description: ContainerRestartRule describes how a container exit is handled.
+                                  properties:
+                                    action:
+                                      description: |-
+                                        Specifies the action taken on a container exit if the requirements
+                                        are satisfied. The only possible value is "Restart" to restart the
+                                        container.
+                                      type: string
+                                    exitCodes:
+                                      description: Represents the exit codes to check on container exits.
+                                      properties:
+                                        operator:
+                                          description: |-
+                                            Represents the relationship between the container exit code(s) and the
+                                            specified values. Possible values are:
+                                            - In: the requirement is satisfied if the container exit code is in the
+                                              set of specified values.
+                                            - NotIn: the requirement is satisfied if the container exit code is
+                                              not in the set of specified values.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            Specifies the set of values to check for container exit codes.
+                                            At most 255 elements are allowed.
+                                          items:
+                                            format: int32
+                                            type: integer
+                                          type: array
+                                          x-kubernetes-list-type: set
+                                      required:
+                                        - operator
+                                      type: object
+                                  required:
+                                    - action
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              securityContext:
+                                description: |-
+                                  SecurityContext defines the security options the container should be run with.
+                                  If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                  More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                                properties:
+                                  allowPrivilegeEscalation:
+                                    description: |-
+                                      AllowPrivilegeEscalation controls whether a process can gain more
+                                      privileges than its parent process. This bool directly controls if
+                                      the no_new_privs flag will be set on the container process.
+                                      AllowPrivilegeEscalation is true always when the container is:
+                                      1) run as Privileged
+                                      2) has CAP_SYS_ADMIN
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  appArmorProfile:
+                                    description: |-
+                                      appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                      overrides the pod's appArmorProfile.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile loaded on the node that should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must match the loaded name of the profile.
+                                          Must be set if and only if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of AppArmor profile will be applied.
+                                          Valid options are:
+                                            Localhost - a profile pre-loaded on the node.
+                                            RuntimeDefault - the container runtime's default profile.
+                                            Unconfined - no AppArmor enforcement.
+                                        type: string
+                                    required:
+                                      - type
+                                    type: object
+                                  capabilities:
+                                    description: |-
+                                      The capabilities to add/drop when running containers.
+                                      Defaults to the default set of capabilities granted by the container runtime.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      add:
+                                        description: Added capabilities
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      drop:
+                                        description: Removed capabilities
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  privileged:
+                                    description: |-
+                                      Run container in privileged mode.
+                                      Processes in privileged containers are essentially equivalent to root on the host.
+                                      Defaults to false.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  procMount:
+                                    description: |-
+                                      procMount denotes the type of proc mount to use for the containers.
+                                      The default value is Default which uses the container runtime defaults for
+                                      readonly paths and masked paths.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: string
+                                  readOnlyRootFilesystem:
+                                    description: |-
+                                      Whether this container has a read-only root filesystem.
+                                      Default is false.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  runAsGroup:
+                                    description: |-
+                                      The GID to run the entrypoint of the container process.
+                                      Uses runtime default if unset.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    description: |-
+                                      Indicates that the container must run as a non-root user.
+                                      If true, the Kubelet will validate the image at runtime to ensure that it
+                                      does not run as UID 0 (root) and fail to start the container if it does.
+                                      If unset or false, no such validation will be performed.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: |-
+                                      The UID to run the entrypoint of the container process.
+                                      Defaults to user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    description: |-
+                                      The SELinux context to be applied to the container.
+                                      If unspecified, the container runtime will allocate a random SELinux context for each
+                                      container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      level:
+                                        description: Level is SELinux level label that applies to the container.
+                                        type: string
+                                      role:
+                                        description: Role is a SELinux role label that applies to the container.
+                                        type: string
+                                      type:
+                                        description: Type is a SELinux type label that applies to the container.
+                                        type: string
+                                      user:
+                                        description: User is a SELinux user label that applies to the container.
+                                        type: string
+                                    type: object
+                                  seccompProfile:
+                                    description: |-
+                                      The seccomp options to use by this container. If seccomp options are
+                                      provided at both the pod & container level, the container options
+                                      override the pod options.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile defined in a file on the node should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                          Must be set if type is "Localhost". Must NOT be set for any other type.
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of seccomp profile will be applied.
+                                          Valid options are:
+
+                                          Localhost - a profile defined in a file on the node should be used.
+                                          RuntimeDefault - the container runtime default profile should be used.
+                                          Unconfined - no profile should be applied.
+                                        type: string
+                                    required:
+                                      - type
+                                    type: object
+                                  windowsOptions:
+                                    description: |-
+                                      The Windows specific settings applied to all containers.
+                                      If unspecified, the options from the PodSecurityContext will be used.
+                                      If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is linux.
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        description: |-
+                                          GMSACredentialSpec is where the GMSA admission webhook
+                                          (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                          GMSA credential spec named by the GMSACredentialSpecName field.
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                        type: string
+                                      hostProcess:
+                                        description: |-
+                                          HostProcess determines if a container should be run as a 'Host Process' container.
+                                          All of a Pod's containers must have the same effective HostProcess value
+                                          (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                          In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                        type: boolean
+                                      runAsUserName:
+                                        description: |-
+                                          The UserName in Windows to run the entrypoint of the container process.
+                                          Defaults to the user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext. If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        type: string
+                                    type: object
+                                type: object
+                              startupProbe:
+                                description: |-
+                                  StartupProbe indicates that the Pod has successfully initialized.
+                                  If specified, no other probes are executed until this completes successfully.
+                                  If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                  This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                  when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                  This cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  grpc:
+                                    description: GRPC specifies a GRPC HealthCheckRequest.
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        default: ""
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
+                                      Default to 10 seconds. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: TCPSocket specifies a connection to a TCP port.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: |-
+                                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after the processes running in the pod are sent
+                                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                      Set this value longer than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                      value overrides the value provided by the pod spec.
+                                      Value must be non-negative integer. The value zero indicates stop immediately via
+                                      the kill signal (no opportunity to shut down).
+                                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                type: object
+                              stdin:
+                                description: |-
+                                  Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                  is not set, reads from stdin in the container will always result in EOF.
+                                  Default is false.
+                                type: boolean
+                              stdinOnce:
+                                description: |-
+                                  Whether the container runtime should close the stdin channel after it has been opened by
+                                  a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                  sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                  first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                  at which time stdin is closed and remains closed until the container is restarted. If this
+                                  flag is false, a container processes that reads from stdin will never receive an EOF.
+                                  Default is false
+                                type: boolean
+                              terminationMessagePath:
+                                description: |-
+                                  Optional: Path at which the file to which the container's termination message
+                                  will be written is mounted into the container's filesystem.
+                                  Message written is intended to be brief final status, such as an assertion failure message.
+                                  Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                  all containers will be limited to 12kb.
+                                  Defaults to /dev/termination-log.
+                                  Cannot be updated.
+                                type: string
+                              terminationMessagePolicy:
+                                description: |-
+                                  Indicate how the termination message should be populated. File will use the contents of
+                                  terminationMessagePath to populate the container status message on both success and failure.
+                                  FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                  message file is empty and the container exited with an error.
+                                  The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                  Defaults to File.
+                                  Cannot be updated.
+                                type: string
+                              tty:
+                                description: |-
+                                  Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                  Default is false.
+                                type: boolean
+                              volumeDevices:
+                                description: volumeDevices is the list of block devices to be used by the container.
+                                items:
+                                  description: volumeDevice describes a mapping of a raw block device within a container.
+                                  properties:
+                                    devicePath:
+                                      description: devicePath is the path inside of the container that the device will be mapped to.
+                                      type: string
+                                    name:
+                                      description: name must match the name of a persistentVolumeClaim in the pod
+                                      type: string
+                                  required:
+                                    - devicePath
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - devicePath
+                                x-kubernetes-list-type: map
+                              volumeMounts:
+                                description: |-
+                                  Pod volumes to mount into the container's filesystem.
+                                  Cannot be updated.
+                                items:
+                                  description: VolumeMount describes a mounting of a Volume within a container.
+                                  properties:
+                                    mountPath:
+                                      description: |-
+                                        Path within the container at which the volume should be mounted.  Must
+                                        not contain ':'.
+                                      type: string
+                                    mountPropagation:
+                                      description: |-
+                                        mountPropagation determines how mounts are propagated from the host
+                                        to container and the other way around.
+                                        When not set, MountPropagationNone is used.
+                                        This field is beta in 1.10.
+                                        When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                        (which defaults to None).
+                                      type: string
+                                    name:
+                                      description: This must match the Name of a Volume.
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                                        Defaults to false.
+                                      type: boolean
+                                    recursiveReadOnly:
+                                      description: |-
+                                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                                        recursively.
+
+                                        If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                        If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                        recursively read-only.  If this field is set to IfPossible, the mount is made
+                                        recursively read-only, if it is supported by the container runtime.  If this
+                                        field is set to Enabled, the mount is made recursively read-only if it is
+                                        supported by the container runtime, otherwise the pod will not be started and
+                                        an error will be generated to indicate the reason.
+
+                                        If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                        None (or be unspecified, which defaults to None).
+
+                                        If this field is not specified, it is treated as an equivalent of Disabled.
+                                      type: string
+                                    subPath:
+                                      description: |-
+                                        Path within the volume from which the container's volume should be mounted.
+                                        Defaults to "" (volume's root).
+                                      type: string
+                                    subPathExpr:
+                                      description: |-
+                                        Expanded path within the volume from which the container's volume should be mounted.
+                                        Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                        Defaults to "" (volume's root).
+                                        SubPathExpr and SubPath are mutually exclusive.
+                                      type: string
+                                  required:
+                                    - mountPath
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - mountPath
+                                x-kubernetes-list-type: map
+                              workingDir:
+                                description: |-
+                                  Container's working directory.
+                                  If not specified, the container runtime's default will be used, which
+                                  might be configured in the container image.
+                                  Cannot be updated.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        nodeName:
+                          description: |-
+                            NodeName indicates in which node this pod is scheduled.
+                            If empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName.
+                            Once this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod.
+                            This field should not be used to express a desire for the pod to be scheduled on a specific node.
+                            https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename
+                          type: string
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            NodeSelector is a selector which must be true for the pod to fit on a node.
+                            Selector which must match a node's labels for the pod to be scheduled on that node.
+                            More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        os:
+                          description: |-
+                            Specifies the OS of the containers in the pod.
+                            Some pod and container fields are restricted if this is set.
+
+                            If the OS field is set to linux, the following fields must be unset:
+                            -securityContext.windowsOptions
+
+                            If the OS field is set to windows, following fields must be unset:
+                            - spec.hostPID
+                            - spec.hostIPC
+                            - spec.hostUsers
+                            - spec.resources
+                            - spec.securityContext.appArmorProfile
+                            - spec.securityContext.seLinuxOptions
+                            - spec.securityContext.seccompProfile
+                            - spec.securityContext.fsGroup
+                            - spec.securityContext.fsGroupChangePolicy
+                            - spec.securityContext.sysctls
+                            - spec.shareProcessNamespace
+                            - spec.securityContext.runAsUser
+                            - spec.securityContext.runAsGroup
+                            - spec.securityContext.supplementalGroups
+                            - spec.securityContext.supplementalGroupsPolicy
+                            - spec.containers[*].securityContext.appArmorProfile
+                            - spec.containers[*].securityContext.seLinuxOptions
+                            - spec.containers[*].securityContext.seccompProfile
+                            - spec.containers[*].securityContext.capabilities
+                            - spec.containers[*].securityContext.readOnlyRootFilesystem
+                            - spec.containers[*].securityContext.privileged
+                            - spec.containers[*].securityContext.allowPrivilegeEscalation
+                            - spec.containers[*].securityContext.procMount
+                            - spec.containers[*].securityContext.runAsUser
+                            - spec.containers[*].securityContext.runAsGroup
+                          properties:
+                            name:
+                              description: |-
+                                Name is the name of the operating system. The currently supported values are linux and windows.
+                                Additional value may be defined in future and can be one of:
+                                https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                Clients should expect to handle additional values and treat unrecognized values in this field as os: null
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        overhead:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                            This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+                            the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+                            The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+                            set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value
+                            defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero.
+                            More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
+                          type: object
+                        preemptionPolicy:
+                          description: |-
+                            PreemptionPolicy is the Policy for preempting pods with lower priority.
+                            One of Never, PreemptLowerPriority.
+                            Defaults to PreemptLowerPriority if unset.
+                          type: string
+                        priority:
+                          description: |-
+                            The priority value. Various system components use this field to find the
+                            priority of the pod. When Priority Admission Controller is enabled, it
+                            prevents users from setting this field. The admission controller populates
+                            this field from PriorityClassName.
+                            The higher the value, the higher the priority.
+                          format: int32
+                          type: integer
+                        priorityClassName:
+                          description: |-
+                            If specified, indicates the pod's priority. "system-node-critical" and
+                            "system-cluster-critical" are two special keywords which indicate the
+                            highest priorities with the former being the highest priority. Any other
+                            name must be defined by creating a PriorityClass object with that name.
+                            If not specified, the pod priority will be default or zero if there is no
+                            default.
+                          type: string
+                        readinessGates:
+                          description: |-
+                            If specified, all readiness gates will be evaluated for pod readiness.
+                            A pod is ready when all its containers are ready AND
+                            all conditions specified in the readiness gates have status equal to "True"
+                            More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
+                          items:
+                            description: PodReadinessGate contains the reference to a pod condition
+                            properties:
+                              conditionType:
+                                description: ConditionType refers to a condition in the pod's condition list with matching type.
+                                type: string
+                            required:
+                              - conditionType
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        resourceClaims:
+                          description: |-
+                            ResourceClaims defines which ResourceClaims must be allocated
+                            and reserved before the Pod is allowed to start. The resources
+                            will be made available to those containers which consume them
+                            by name.
+
+                            This is a stable field but requires that the
+                            DynamicResourceAllocation feature gate is enabled.
+
+                            This field is immutable.
+                          items:
+                            description: |-
+                              PodResourceClaim references exactly one ResourceClaim, either directly
+                              or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
+                              for the pod.
+
+                              It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                              Containers that need access to the ResourceClaim reference it with this name.
+
+                              When the DRAWorkloadResourceClaims feature gate is enabled and this Pod
+                              belongs to a PodGroup, a PodResourceClaim is matched to a
+                              PodGroupResourceClaim if all of their fields are equal (Name,
+                              ResourceClaimName, and ResourceClaimTemplateName). A matched claim references
+                              a single ResourceClaim shared across all Pods in the PodGroup, reserved for
+                              the PodGroup in ResourceClaimStatus.ReservedFor rather than for individual
+                              Pods.
+                            properties:
+                              name:
+                                description: |-
+                                  Name uniquely identifies this resource claim inside the pod.
+                                  This must be a DNS_LABEL.
+                                type: string
+                              resourceClaimName:
+                                description: |-
+                                  ResourceClaimName is the name of a ResourceClaim object in the same
+                                  namespace as this pod.
+
+                                  Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                                  be set.
+                                type: string
+                              resourceClaimTemplateName:
+                                description: |-
+                                  ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                                  object in the same namespace as this pod.
+
+                                  The template will be used to create a new ResourceClaim, which will
+                                  be bound to this pod. When this pod is deleted, the ResourceClaim
+                                  will also be deleted. The pod name and resource name, along with a
+                                  generated component, will be used to form a unique name for the
+                                  ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                  When the DRAWorkloadResourceClaims feature gate is enabled and the pod
+                                  belongs to a PodGroup that defines a PodGroupResourceClaim with the same
+                                  Name and ResourceClaimTemplateName, this PodResourceClaim resolves to the
+                                  ResourceClaim generated for the PodGroup. All pods in the group that
+                                  define an equivalent PodResourceClaim matching the
+                                  PodGroupResourceClaim's Name and ResourceClaimTemplateName share the same
+                                  generated ResourceClaim. ResourceClaims generated for a PodGroup are
+                                  owned by the PodGroup and their lifecycles are tied to the PodGroup
+                                  instead of any individual pod.
+
+                                  This field is immutable and no changes will be made to the
+                                  corresponding ResourceClaim by the control plane after creating the
+                                  ResourceClaim.
+
+                                  Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                                  be set.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        resources:
+                          description: |-
+                            Resources is the total amount of CPU and Memory resources required by all
+                            containers in the pod. It supports specifying Requests and Limits for
+                            "cpu", "memory" and "hugepages-" resource names only. ResourceClaims are not supported.
+
+                            This field enables fine-grained control over resource allocation for the
+                            entire pod, allowing resource sharing among containers in a pod.
+
+                            This is an alpha field and requires enabling the PodLevelResources feature
+                            gate.
+                          properties:
+                            claims:
+                              description: |-
+                                Claims lists the names of resources, defined in spec.resourceClaims,
+                                that are used by this container.
+
+                                This field depends on the
+                                DynamicResourceAllocation feature gate.
+
+                                This field is immutable. It can only be set for containers.
+                              items:
+                                description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name must match the name of one entry in pod.spec.resourceClaims of
+                                      the Pod where this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                  request:
+                                    description: |-
+                                      Request is the name chosen for a request in the referenced claim.
+                                      If empty, everything from the claim is made available, otherwise
+                                      only the result of this request.
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Limits describes the maximum amount of compute resources allowed.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Requests describes the minimum amount of compute resources required.
+                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                          type: object
+                        restartPolicy:
+                          description: |-
+                            Restart policy for all containers within the pod.
+                            One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted.
+                            Default to Always.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+                          type: string
+                        runtimeClassName:
+                          description: |-
+                            RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+                            to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
+                            If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+                            empty definition that uses the default runtime handler.
+                            More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
+                          type: string
+                        schedulerName:
+                          description: |-
+                            If specified, the pod will be dispatched by specified scheduler.
+                            If not specified, the pod will be dispatched by default scheduler.
+                          type: string
+                        schedulingGates:
+                          description: |-
+                            SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
+                            If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
+                            scheduler will not attempt to schedule the pod.
+
+                            SchedulingGates can only be set at pod creation time, and be removed only afterwards.
+                          items:
+                            description: PodSchedulingGate is associated to a Pod to guard its scheduling.
+                            properties:
+                              name:
+                                description: |-
+                                  Name of the scheduling gate.
+                                  Each scheduling gate must have a unique name field.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        schedulingGroup:
+                          description: |-
+                            SchedulingGroup provides a reference to the immediate scheduling runtime
+                            grouping object that this Pod belongs to.
+                            This field is used by the scheduler to identify the group and apply the
+                            correct group scheduling policies. The association with a group also
+                            impacts other lifecycle aspects of a Pod that are relevant in a wider context
+                            of scheduling like preemption, resource attachment, etc. If not specified,
+                            the Pod is treated as a single unit in all of these aspects.
+                            The group object referenced by this field may not exist at the time the
+                            Pod is created.
+                            This field is immutable, but a group object with the same name may be
+                            recreated with different policies. Doing this during pod scheduling
+                            may result in the placement not conforming to the expected policies.
+                          properties:
+                            podGroupName:
+                              description: |-
+                                PodGroupName specifies the name of the standalone PodGroup object
+                                that represents the runtime instance of this group.
+                                Must be a DNS subdomain.
+                              type: string
+                          type: object
+                        securityContext:
+                          description: |-
+                            SecurityContext holds pod-level security attributes and common container settings.
+                            Optional: Defaults to empty.  See type description for default values of each field.
+                          properties:
+                            appArmorProfile:
+                              description: |-
+                                appArmorProfile is the AppArmor options to use by the containers in this pod.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: |-
+                                    localhostProfile indicates a profile loaded on the node that should be used.
+                                    The profile must be preconfigured on the node to work.
+                                    Must match the loaded name of the profile.
+                                    Must be set if and only if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of AppArmor profile will be applied.
+                                    Valid options are:
+                                      Localhost - a profile pre-loaded on the node.
+                                      RuntimeDefault - the container runtime's default profile.
+                                      Unconfined - no AppArmor enforcement.
+                                  type: string
+                              required:
+                                - type
+                              type: object
+                            fsGroup:
+                              description: |-
+                                A special supplemental group that applies to all containers in a pod.
+                                Some volume types allow the Kubelet to change the ownership of that volume
+                                to be owned by the pod:
+
+                                1. The owning GID will be the FSGroup
+                                2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                3. The permission bits are OR'd with rw-rw----
+
+                                If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            fsGroupChangePolicy:
+                              description: |-
+                                fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                before being exposed inside Pod. This field will only apply to
+                                volume types which support fsGroup based ownership(and permissions).
+                                It will have no effect on ephemeral volume types such as: secret, configmaps
+                                and emptydir.
+                                Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: string
+                            runAsGroup:
+                              description: |-
+                                The GID to run the entrypoint of the container process.
+                                Uses runtime default if unset.
+                                May also be set in SecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence
+                                for that container.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: |-
+                                Indicates that the container must run as a non-root user.
+                                If true, the Kubelet will validate the image at runtime to ensure that it
+                                does not run as UID 0 (root) and fail to start the container if it does.
+                                If unset or false, no such validation will be performed.
+                                May also be set in SecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: |-
+                                The UID to run the entrypoint of the container process.
+                                Defaults to user specified in image metadata if unspecified.
+                                May also be set in SecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence
+                                for that container.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            seLinuxChangePolicy:
+                              description: |-
+                                seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                                It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                                Valid values are "MountOption" and "Recursive".
+
+                                "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                                This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                                "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                                This requires all Pods that share the same volume to use the same SELinux label.
+                                It is not possible to share the same volume among privileged and unprivileged Pods.
+                                Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                                whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                                CSIDriver instance. Other volumes are always re-labelled recursively.
+                                "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                                If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                                If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                                and "Recursive" for all other volumes.
+
+                                This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                                All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: string
+                            seLinuxOptions:
+                              description: |-
+                                The SELinux context to be applied to all containers.
+                                If unspecified, the container runtime will allocate a random SELinux context for each
+                                container.  May also be set in SecurityContext.  If set in
+                                both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence for that container.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: |-
+                                The seccomp options to use by the containers in this pod.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: |-
+                                    localhostProfile indicates a profile defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node to work.
+                                    Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                    Must be set if type is "Localhost". Must NOT be set for any other type.
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied.
+                                    Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used.
+                                    RuntimeDefault - the container runtime default profile should be used.
+                                    Unconfined - no profile should be applied.
+                                  type: string
+                              required:
+                                - type
+                              type: object
+                            supplementalGroups:
+                              description: |-
+                                A list of groups applied to the first process run in each container, in
+                                addition to the container's primary GID and fsGroup (if specified).  If
+                                the SupplementalGroupsPolicy feature is enabled, the
+                                supplementalGroupsPolicy field determines whether these are in addition
+                                to or instead of any group memberships defined in the container image.
+                                If unspecified, no additional groups are added, though group memberships
+                                defined in the container image may still be used, depending on the
+                                supplementalGroupsPolicy field.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              items:
+                                format: int64
+                                type: integer
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            supplementalGroupsPolicy:
+                              description: |-
+                                Defines how supplemental groups of the first container processes are calculated.
+                                Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                                (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                                and the container runtime must implement support for this feature.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: string
+                            sysctls:
+                              description: |-
+                                Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                sysctls (by the container runtime) might fail to launch.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              items:
+                                description: Sysctl defines a kernel parameter to be set
+                                properties:
+                                  name:
+                                    description: Name of a property to set
+                                    type: string
+                                  value:
+                                    description: Value of a property to set
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            windowsOptions:
+                              description: |-
+                                The Windows specific settings applied to all containers.
+                                If unspecified, the options within a container's SecurityContext will be used.
+                                If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: |-
+                                    GMSACredentialSpec is where the GMSA admission webhook
+                                    (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                    GMSA credential spec named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: |-
+                                    HostProcess determines if a container should be run as a 'Host Process' container.
+                                    All of a Pod's containers must have the same effective HostProcess value
+                                    (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                    In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: |-
+                                    The UserName in Windows to run the entrypoint of the container process.
+                                    Defaults to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        serviceAccount:
+                          description: |-
+                            DeprecatedServiceAccount is a deprecated alias for ServiceAccountName.
+                            Deprecated: Use serviceAccountName instead.
+                          type: string
+                        serviceAccountName:
+                          description: |-
+                            ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                          type: string
+                        setHostnameAsFQDN:
+                          description: |-
+                            If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+                            In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
+                            In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN.
+                            If a pod does not have FQDN, this has no effect.
+                            Default to false.
+                          type: boolean
+                        shareProcessNamespace:
+                          description: |-
+                            Share a single process namespace between all of the containers in a pod.
+                            When this is set containers will be able to view and signal processes from other containers
+                            in the same pod, and the first process in each container will not be assigned PID 1.
+                            HostPID and ShareProcessNamespace cannot both be set.
+                            Optional: Default to false.
+                          type: boolean
+                        subdomain:
+                          description: |-
+                            If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                            If not specified, the pod will not have a domainname at all.
+                          type: string
+                        terminationGracePeriodSeconds:
+                          description: |-
+                            Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
+                            Value must be non-negative integer. The value zero indicates stop immediately via
+                            the kill signal (no opportunity to shut down).
+                            If this value is nil, the default grace period will be used instead.
+                            The grace period is the duration in seconds after the processes running in the pod are sent
+                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                            Set this value longer than the expected cleanup time for your process.
+                            Defaults to 30 seconds.
+                          format: int64
+                          type: integer
+                        tolerations:
+                          description: If specified, the pod's tolerations.
+                          items:
+                            description: |-
+                              The pod this Toleration is attached to tolerates any taint that matches
+                              the triple <key,value,effect> using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: |-
+                                  Effect indicates the taint effect to match. Empty means match all taint effects.
+                                  When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                              key:
+                                description: |-
+                                  Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                  If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: |-
+                                  Operator represents a key's relationship to the value.
+                                  Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                                  Exists is equivalent to wildcard for value, so that a pod can
+                                  tolerate all taints of a particular category.
+                                  Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                                type: string
+                              tolerationSeconds:
+                                description: |-
+                                  TolerationSeconds represents the period of time the toleration (which must be
+                                  of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                  it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                  negative values will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: |-
+                                  Value is the taint value the toleration matches to.
+                                  If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        topologySpreadConstraints:
+                          description: |-
+                            TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                            domains. Scheduler will schedule pods in a way which abides by the constraints.
+                            All topologySpreadConstraints are ANDed.
+                          items:
+                            description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                            properties:
+                              labelSelector:
+                                description: |-
+                                  LabelSelector is used to find matching pods.
+                                  Pods that match this label selector are counted to determine the number of pods
+                                  in their corresponding topology domain.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                description: |-
+                                  MatchLabelKeys is a set of pod label keys to select the pods over which
+                                  spreading will be calculated. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are ANDed with labelSelector
+                                  to select the group of existing pods over which spreading will be calculated
+                                  for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                  MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                  Keys that don't exist in the incoming pod labels will
+                                  be ignored. A null or empty list means only match against labelSelector.
+
+                                  This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              maxSkew:
+                                description: |-
+                                  MaxSkew describes the degree to which pods may be unevenly distributed.
+                                  When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                  between the number of matching pods in the target topology and the global minimum.
+                                  The global minimum is the minimum number of matching pods in an eligible domain
+                                  or zero if the number of eligible domains is less than MinDomains.
+                                  For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                  labelSelector spread as 2/2/1:
+                                  In this case, the global minimum is 1.
+                                  | zone1 | zone2 | zone3 |
+                                  |  P P  |  P P  |   P   |
+                                  - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                  scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                  violate MaxSkew(1).
+                                  - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                  When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                  to topologies that satisfy it.
+                                  It's a required field. Default value is 1 and 0 is not allowed.
+                                format: int32
+                                type: integer
+                              minDomains:
+                                description: |-
+                                  MinDomains indicates a minimum number of eligible domains.
+                                  When the number of eligible domains with matching topology keys is less than minDomains,
+                                  Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                  And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                  this value has no effect on scheduling.
+                                  As a result, when the number of eligible domains is less than minDomains,
+                                  scheduler won't schedule more than maxSkew Pods to those domains.
+                                  If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                  Valid values are integers greater than 0.
+                                  When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                  For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                  labelSelector spread as 2/2/2:
+                                  | zone1 | zone2 | zone3 |
+                                  |  P P  |  P P  |  P P  |
+                                  The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                  In this situation, new pod with the same labelSelector cannot be scheduled,
+                                  because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                  it will violate MaxSkew.
+                                format: int32
+                                type: integer
+                              nodeAffinityPolicy:
+                                description: |-
+                                  NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                  when calculating pod topology spread skew. Options are:
+                                  - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                  - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                  If this value is nil, the behavior is equivalent to the Honor policy.
+                                type: string
+                              nodeTaintsPolicy:
+                                description: |-
+                                  NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                  pod topology spread skew. Options are:
+                                  - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                  has a toleration, are included.
+                                  - Ignore: node taints are ignored. All nodes are included.
+
+                                  If this value is nil, the behavior is equivalent to the Ignore policy.
+                                type: string
+                              topologyKey:
+                                description: |-
+                                  TopologyKey is the key of node labels. Nodes that have a label with this key
+                                  and identical values are considered to be in the same topology.
+                                  We consider each <key, value> as a "bucket", and try to put balanced number
+                                  of pods into each bucket.
+                                  We define a domain as a particular instance of a topology.
+                                  Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                  nodeAffinityPolicy and nodeTaintsPolicy.
+                                  e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                  And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                  It's a required field.
+                                type: string
+                              whenUnsatisfiable:
+                                description: |-
+                                  WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                  the spread constraint.
+                                  - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                  - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                    but giving higher precedence to topologies that would help reduce the
+                                    skew.
+                                  A constraint is considered "Unsatisfiable" for an incoming pod
+                                  if and only if every possible node assignment for that pod would violate
+                                  "MaxSkew" on some topology.
+                                  For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                  labelSelector spread as 3/1/1:
+                                  | zone1 | zone2 | zone3 |
+                                  | P P P |   P   |   P   |
+                                  If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                  to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                  MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                  won't make it *more* imbalanced.
+                                  It's a required field.
+                                type: string
+                            required:
+                              - maxSkew
+                              - topologyKey
+                              - whenUnsatisfiable
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - topologyKey
+                            - whenUnsatisfiable
+                          x-kubernetes-list-type: map
+                        volumes:
+                          description: |-
+                            List of volumes that can be mounted by containers belonging to the pod.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes
+                          items:
+                            description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                            properties:
+                              awsElasticBlockStore:
+                                description: |-
+                                  awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                  kubelet's host machine and then exposed to the pod.
+                                  Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                                  awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type of the volume that you want to mount.
+                                      Tip: Ensure that the filesystem type is supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                    type: string
+                                  partition:
+                                    description: |-
+                                      partition is the partition in the volume that you want to mount.
+                                      If omitted, the default is to mount by volume name.
+                                      Examples: For volume /dev/sda1, you specify the partition as "1".
+                                      Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    description: |-
+                                      readOnly value true will force the readOnly setting in VolumeMounts.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                    type: boolean
+                                  volumeID:
+                                    description: |-
+                                      volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                    type: string
+                                required:
+                                  - volumeID
+                                type: object
+                              azureDisk:
+                                description: |-
+                                  azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                  Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                                  are redirected to the disk.csi.azure.com CSI driver.
+                                properties:
+                                  cachingMode:
+                                    description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
+                                    type: string
+                                  diskName:
+                                    description: diskName is the Name of the data disk in the blob storage
+                                    type: string
+                                  diskURI:
+                                    description: diskURI is the URI of data disk in the blob storage
+                                    type: string
+                                  fsType:
+                                    default: ext4
+                                    description: |-
+                                      fsType is Filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  kind:
+                                    description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                                    type: string
+                                  readOnly:
+                                    default: false
+                                    description: |-
+                                      readOnly Defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                    type: boolean
+                                required:
+                                  - diskName
+                                  - diskURI
+                                type: object
+                              azureFile:
+                                description: |-
+                                  azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                  Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                                  are redirected to the file.csi.azure.com CSI driver.
+                                properties:
+                                  readOnly:
+                                    description: |-
+                                      readOnly defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                    type: boolean
+                                  secretName:
+                                    description: secretName is the  name of secret that contains Azure Storage Account Name and Key
+                                    type: string
+                                  shareName:
+                                    description: shareName is the azure share Name
+                                    type: string
+                                required:
+                                  - secretName
+                                  - shareName
+                                type: object
+                              cephfs:
+                                description: |-
+                                  cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                                  Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
+                                properties:
+                                  monitors:
+                                    description: |-
+                                      monitors is Required: Monitors is a collection of Ceph monitors
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                    type: boolean
+                                  secretFile:
+                                    description: |-
+                                      secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                    type: string
+                                  secretRef:
+                                    description: |-
+                                      secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  user:
+                                    description: |-
+                                      user is optional: User is the rados user name, default is admin
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                    type: string
+                                required:
+                                  - monitors
+                                type: object
+                              cinder:
+                                description: |-
+                                  cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                  Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                                  are redirected to the cinder.csi.openstack.org CSI driver.
+                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                    type: boolean
+                                  secretRef:
+                                    description: |-
+                                      secretRef is optional: points to a secret object containing parameters used to connect
+                                      to OpenStack.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  volumeID:
+                                    description: |-
+                                      volumeID used to identify the volume in cinder.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                    type: string
+                                required:
+                                  - volumeID
+                                type: object
+                              configMap:
+                                description: configMap represents a configMap that should populate this volume
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      defaultMode is optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      ConfigMap will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the ConfigMap,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                        - key
+                                        - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: optional specify whether the ConfigMap or its keys must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              csi:
+                                description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
+                                properties:
+                                  driver:
+                                    description: |-
+                                      driver is the name of the CSI driver that handles this volume.
+                                      Consult with your admin for the correct name as registered in the cluster.
+                                    type: string
+                                  fsType:
+                                    description: |-
+                                      fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                      If not provided, the empty value is passed to the associated CSI driver
+                                      which will determine the default filesystem to apply.
+                                    type: string
+                                  nodePublishSecretRef:
+                                    description: |-
+                                      nodePublishSecretRef is a reference to the secret object containing
+                                      sensitive information to pass to the CSI driver to complete the CSI
+                                      NodePublishVolume and NodeUnpublishVolume calls.
+                                      This field is optional, and  may be empty if no secret is required. If the
+                                      secret object contains more than one secret, all secret references are passed.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  readOnly:
+                                    description: |-
+                                      readOnly specifies a read-only configuration for the volume.
+                                      Defaults to false (read/write).
+                                    type: boolean
+                                  volumeAttributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      volumeAttributes stores driver-specific properties that are passed to the CSI
+                                      driver. Consult your driver's documentation for supported values.
+                                    type: object
+                                required:
+                                  - driver
+                                type: object
+                              downwardAPI:
+                                description: downwardAPI represents downward API about the pod that should populate this volume
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      Optional: mode bits to use on created files by default. Must be a
+                                      Optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: Items is a list of downward API volume file
+                                    items:
+                                      description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                      properties:
+                                        fieldRef:
+                                          description: 'Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.'
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select in the specified API version.
+                                              type: string
+                                          required:
+                                            - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        mode:
+                                          description: |-
+                                            Optional: mode bits used to set permissions on this file, must be an octal value
+                                            between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                          type: string
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              description: Specifies the output format of the exposed resources, defaults to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to select'
+                                              type: string
+                                          required:
+                                            - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                        - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              emptyDir:
+                                description: |-
+                                  emptyDir represents a temporary directory that shares a pod's lifetime.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                properties:
+                                  medium:
+                                    description: |-
+                                      medium represents what type of storage medium should back this directory.
+                                      The default is "" which means to use the node's default medium.
+                                      Must be an empty string (default) or Memory.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                    type: string
+                                  sizeLimit:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                      The size limit is also applicable for memory medium.
+                                      The maximum usage on memory medium EmptyDir would be the minimum value between
+                                      the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                      The default is nil which means that the limit is undefined.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              ephemeral:
+                                description: |-
+                                  ephemeral represents a volume that is handled by a cluster storage driver.
+                                  The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                  and deleted when the pod is removed.
+
+                                  Use this if:
+                                  a) the volume is only needed while the pod runs,
+                                  b) features of normal volumes like restoring from snapshot or capacity
+                                     tracking are needed,
+                                  c) the storage driver is specified through a storage class, and
+                                  d) the storage driver supports dynamic volume provisioning through
+                                     a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                     information on the connection between this volume type
+                                     and PersistentVolumeClaim).
+
+                                  Use PersistentVolumeClaim or one of the vendor-specific
+                                  APIs for volumes that persist for longer than the lifecycle
+                                  of an individual pod.
+
+                                  Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                  be used that way - see the documentation of the driver for
+                                  more information.
+
+                                  A pod can use both types of ephemeral volumes and
+                                  persistent volumes at the same time.
+                                properties:
+                                  volumeClaimTemplate:
+                                    description: |-
+                                      Will be used to create a stand-alone PVC to provision the volume.
+                                      The pod in which this EphemeralVolumeSource is embedded will be the
+                                      owner of the PVC, i.e. the PVC will be deleted together with the
+                                      pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                      `<volume name>` is the name from the `PodSpec.Volumes` array
+                                      entry. Pod validation will reject the pod if the concatenated name
+                                      is not valid for a PVC (for example, too long).
+
+                                      An existing PVC with that name that is not owned by the pod
+                                      will *not* be used for the pod to avoid using an unrelated
+                                      volume by mistake. Starting the pod is then blocked until
+                                      the unrelated PVC is removed. If such a pre-created PVC is
+                                      meant to be used by the pod, the PVC has to updated with an
+                                      owner reference to the pod once the pod exists. Normally
+                                      this should not be necessary, but it may be useful when
+                                      manually reconstructing a broken cluster.
+
+                                      This field is read-only and no changes will be made by Kubernetes
+                                      to the PVC after it has been created.
+
+                                      Required, must not be nil.
+                                    properties:
+                                      metadata:
+                                        description: |-
+                                          May contain labels and annotations that will be copied into the PVC
+                                          when creating it. No other fields are allowed and will be rejected during
+                                          validation.
+                                        type: object
+                                      spec:
+                                        description: |-
+                                          The specification for the PersistentVolumeClaim. The entire content is
+                                          copied unchanged into the PVC that gets created from this
+                                          template. The same fields as in a PersistentVolumeClaim
+                                          are also valid here.
+                                        properties:
+                                          accessModes:
+                                            description: |-
+                                              accessModes contains the desired access modes the volume should have.
+                                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          dataSource:
+                                            description: |-
+                                              dataSource field can be used to specify either:
+                                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                              * An existing PVC (PersistentVolumeClaim)
+                                              If the provisioner or an external controller can support the specified data source,
+                                              it will create a new volume based on the contents of the specified data source.
+                                              When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                              and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                              If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                            properties:
+                                              apiGroup:
+                                                description: |-
+                                                  APIGroup is the group for the resource being referenced.
+                                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                  For any other third-party types, APIGroup is required.
+                                                type: string
+                                              kind:
+                                                description: Kind is the type of resource being referenced
+                                                type: string
+                                              name:
+                                                description: Name is the name of resource being referenced
+                                                type: string
+                                            required:
+                                              - kind
+                                              - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          dataSourceRef:
+                                            description: |-
+                                              dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                              volume is desired. This may be any object from a non-empty API group (non
+                                              core object) or a PersistentVolumeClaim object.
+                                              When this field is specified, volume binding will only succeed if the type of
+                                              the specified object matches some installed volume populator or dynamic
+                                              provisioner.
+                                              This field will replace the functionality of the dataSource field and as such
+                                              if both fields are non-empty, they must have the same value. For backwards
+                                              compatibility, when namespace isn't specified in dataSourceRef,
+                                              both fields (dataSource and dataSourceRef) will be set to the same
+                                              value automatically if one of them is empty and the other is non-empty.
+                                              When namespace is specified in dataSourceRef,
+                                              dataSource isn't set to the same value and must be empty.
+                                              There are three important differences between dataSource and dataSourceRef:
+                                              * While dataSource only allows two specific types of objects, dataSourceRef
+                                                allows any non-core object, as well as PersistentVolumeClaim objects.
+                                              * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                                preserves all values, and generates an error if a disallowed value is
+                                                specified.
+                                              * While dataSource only allows local objects, dataSourceRef allows objects
+                                                in any namespaces.
+                                              (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                              (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                            properties:
+                                              apiGroup:
+                                                description: |-
+                                                  APIGroup is the group for the resource being referenced.
+                                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                  For any other third-party types, APIGroup is required.
+                                                type: string
+                                              kind:
+                                                description: Kind is the type of resource being referenced
+                                                type: string
+                                              name:
+                                                description: Name is the name of resource being referenced
+                                                type: string
+                                              namespace:
+                                                description: |-
+                                                  Namespace is the namespace of resource being referenced
+                                                  Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                  (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                                type: string
+                                            required:
+                                              - kind
+                                              - name
+                                            type: object
+                                          resources:
+                                            description: |-
+                                              resources represents the minimum resources the volume should have.
+                                              Users are allowed to specify resource requirements
+                                              that are lower than previous value but must still be higher than capacity recorded in the
+                                              status field of the claim.
+                                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Requests describes the minimum amount of compute resources required.
+                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                            type: object
+                                          selector:
+                                            description: selector is a label query over volumes to consider for binding.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          storageClassName:
+                                            description: |-
+                                              storageClassName is the name of the StorageClass required by the claim.
+                                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                            type: string
+                                          volumeAttributesClassName:
+                                            description: |-
+                                              volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                              If specified, the CSI driver will create or update the volume with the attributes defined
+                                              in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                              it can be changed after the claim is created. An empty string or nil value indicates that no
+                                              VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                              this field can be reset to its previous value (including nil) to cancel the modification.
+                                              If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                              set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                              exists.
+                                              More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                            type: string
+                                          volumeMode:
+                                            description: |-
+                                              volumeMode defines what type of volume is required by the claim.
+                                              Value of Filesystem is implied when not included in claim spec.
+                                            type: string
+                                          volumeName:
+                                            description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                            type: string
+                                        type: object
+                                    required:
+                                      - spec
+                                    type: object
+                                type: object
+                              fc:
+                                description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  lun:
+                                    description: 'lun is Optional: FC target lun number'
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    description: |-
+                                      readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                    type: boolean
+                                  targetWWNs:
+                                    description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  wwids:
+                                    description: |-
+                                      wwids Optional: FC volume world wide identifiers (wwids)
+                                      Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              flexVolume:
+                                description: |-
+                                  flexVolume represents a generic volume resource that is
+                                  provisioned/attached using an exec based plugin.
+                                  Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
+                                properties:
+                                  driver:
+                                    description: driver is the name of the driver to use for this volume.
+                                    type: string
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                    type: string
+                                  options:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'options is Optional: this field holds extra command options if any.'
+                                    type: object
+                                  readOnly:
+                                    description: |-
+                                      readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                    type: boolean
+                                  secretRef:
+                                    description: |-
+                                      secretRef is Optional: secretRef is reference to the secret object containing
+                                      sensitive information to pass to the plugin scripts. This may be
+                                      empty if no secret object is specified. If the secret object
+                                      contains more than one secret, all secrets are passed to the plugin
+                                      scripts.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                  - driver
+                                type: object
+                              flocker:
+                                description: |-
+                                  flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                                  Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
+                                properties:
+                                  datasetName:
+                                    description: |-
+                                      datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                      should be considered as deprecated
+                                    type: string
+                                  datasetUUID:
+                                    description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
+                                    type: string
+                                type: object
+                              gcePersistentDisk:
+                                description: |-
+                                  gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                  kubelet's host machine and then exposed to the pod.
+                                  Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                                  gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is filesystem type of the volume that you want to mount.
+                                      Tip: Ensure that the filesystem type is supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    type: string
+                                  partition:
+                                    description: |-
+                                      partition is the partition in the volume that you want to mount.
+                                      If omitted, the default is to mount by volume name.
+                                      Examples: For volume /dev/sda1, you specify the partition as "1".
+                                      Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    format: int32
+                                    type: integer
+                                  pdName:
+                                    description: |-
+                                      pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the ReadOnly setting in VolumeMounts.
+                                      Defaults to false.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    type: boolean
+                                required:
+                                  - pdName
+                                type: object
+                              gitRepo:
+                                description: |-
+                                  gitRepo represents a git repository at a particular revision.
+                                  Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                  EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                  into the Pod's container.
+                                properties:
+                                  directory:
+                                    description: |-
+                                      directory is the target directory name.
+                                      Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                      git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                      the subdirectory with the given name.
+                                    type: string
+                                  repository:
+                                    description: repository is the URL
+                                    type: string
+                                  revision:
+                                    description: revision is the commit hash for the specified revision.
+                                    type: string
+                                required:
+                                  - repository
+                                type: object
+                              glusterfs:
+                                description: |-
+                                  glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                  Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                                properties:
+                                  endpoints:
+                                    description: endpoints is the endpoint name that details Glusterfs topology.
+                                    type: string
+                                  path:
+                                    description: |-
+                                      path is the Glusterfs volume path.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                      Defaults to false.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                    type: boolean
+                                required:
+                                  - endpoints
+                                  - path
+                                type: object
+                              hostPath:
+                                description: |-
+                                  hostPath represents a pre-existing file or directory on the host
+                                  machine that is directly exposed to the container. This is generally
+                                  used for system agents or other privileged things that are allowed
+                                  to see the host machine. Most containers will NOT need this.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                properties:
+                                  path:
+                                    description: |-
+                                      path of the directory on the host.
+                                      If the path is a symlink, it will follow the link to the real path.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type for HostPath Volume
+                                      Defaults to ""
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                    type: string
+                                required:
+                                  - path
+                                type: object
+                              image:
+                                description: |-
+                                  image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                                  The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                                  - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                                  The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                                  A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                                  The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                                  The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                                  The volume will be mounted read-only (ro).
+                                  Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
+                                  The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                                properties:
+                                  pullPolicy:
+                                    description: |-
+                                      Policy for pulling OCI objects. Possible values are:
+                                      Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                      Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                      IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                    type: string
+                                  reference:
+                                    description: |-
+                                      Required: Image or artifact reference to be used.
+                                      Behaves in the same way as pod.spec.containers[*].image.
+                                      Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level config management to default or override
+                                      container images in workload controllers like Deployments and StatefulSets.
+                                    type: string
+                                type: object
+                              iscsi:
+                                description: |-
+                                  iscsi represents an ISCSI Disk resource that is attached to a
+                                  kubelet's host machine and then exposed to the pod.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+                                properties:
+                                  chapAuthDiscovery:
+                                    description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
+                                    type: boolean
+                                  chapAuthSession:
+                                    description: chapAuthSession defines whether support iSCSI Session CHAP authentication
+                                    type: boolean
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type of the volume that you want to mount.
+                                      Tip: Ensure that the filesystem type is supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                    type: string
+                                  initiatorName:
+                                    description: |-
+                                      initiatorName is the custom iSCSI Initiator Name.
+                                      If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                      <target portal>:<volume name> will be created for the connection.
+                                    type: string
+                                  iqn:
+                                    description: iqn is the target iSCSI Qualified Name.
+                                    type: string
+                                  iscsiInterface:
+                                    default: default
+                                    description: |-
+                                      iscsiInterface is the interface Name that uses an iSCSI transport.
+                                      Defaults to 'default' (tcp).
+                                    type: string
+                                  lun:
+                                    description: lun represents iSCSI Target Lun number.
+                                    format: int32
+                                    type: integer
+                                  portals:
+                                    description: |-
+                                      portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                      is other than default (typically TCP ports 860 and 3260).
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the ReadOnly setting in VolumeMounts.
+                                      Defaults to false.
+                                    type: boolean
+                                  secretRef:
+                                    description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  targetPortal:
+                                    description: |-
+                                      targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                      is other than default (typically TCP ports 860 and 3260).
+                                    type: string
+                                required:
+                                  - iqn
+                                  - lun
+                                  - targetPortal
+                                type: object
+                              name:
+                                description: |-
+                                  name of the volume.
+                                  Must be a DNS_LABEL and unique within the pod.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              nfs:
+                                description: |-
+                                  nfs represents an NFS mount on the host that shares a pod's lifetime
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                properties:
+                                  path:
+                                    description: |-
+                                      path that is exported by the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the NFS export to be mounted with read-only permissions.
+                                      Defaults to false.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: boolean
+                                  server:
+                                    description: |-
+                                      server is the hostname or IP address of the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: string
+                                required:
+                                  - path
+                                  - server
+                                type: object
+                              persistentVolumeClaim:
+                                description: |-
+                                  persistentVolumeClaimVolumeSource represents a reference to a
+                                  PersistentVolumeClaim in the same namespace.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                properties:
+                                  claimName:
+                                    description: |-
+                                      claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly Will force the ReadOnly setting in VolumeMounts.
+                                      Default false.
+                                    type: boolean
+                                required:
+                                  - claimName
+                                type: object
+                              photonPersistentDisk:
+                                description: |-
+                                  photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                                  Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  pdID:
+                                    description: pdID is the ID that identifies Photon Controller persistent disk
+                                    type: string
+                                required:
+                                  - pdID
+                                type: object
+                              portworxVolume:
+                                description: |-
+                                  portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                                  Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                                  are redirected to the pxd.portworx.com CSI driver.
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fSType represents the filesystem type to mount
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                    type: boolean
+                                  volumeID:
+                                    description: volumeID uniquely identifies a Portworx volume
+                                    type: string
+                                required:
+                                  - volumeID
+                                type: object
+                              projected:
+                                description: projected items for all in one resources secrets, configmaps, and downward API
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      defaultMode are the mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  sources:
+                                    description: |-
+                                      sources is the list of volume projections. Each entry in this list
+                                      handles one source.
+                                    items:
+                                      description: |-
+                                        Projection that may be projected along with other supported volume types.
+                                        Exactly one of these fields must be set.
+                                      properties:
+                                        clusterTrustBundle:
+                                          description: |-
+                                            ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                            of ClusterTrustBundle objects in an auto-updating file.
+
+                                            Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                                            ClusterTrustBundle objects can either be selected by name, or by the
+                                            combination of signer name and a label selector.
+
+                                            Kubelet performs aggressive normalization of the PEM contents written
+                                            into the pod filesystem.  Esoteric PEM features such as inter-block
+                                            comments and block headers are stripped.  Certificates are deduplicated.
+                                            The ordering of certificates within the file is arbitrary, and Kubelet
+                                            may change the order over time.
+                                          properties:
+                                            labelSelector:
+                                              description: |-
+                                                Select all ClusterTrustBundles that match this label selector.  Only has
+                                                effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                                interpreted as "match nothing".  If set but empty, interpreted as "match
+                                                everything".
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                  items:
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label key that the selector applies to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                      - key
+                                                      - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            name:
+                                              description: |-
+                                                Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                                with signerName and labelSelector.
+                                              type: string
+                                            optional:
+                                              description: |-
+                                                If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                                aren't available.  If using name, then the named ClusterTrustBundle is
+                                                allowed not to exist.  If using signerName, then the combination of
+                                                signerName and labelSelector is allowed to match zero
+                                                ClusterTrustBundles.
+                                              type: boolean
+                                            path:
+                                              description: Relative path from the volume root to write the bundle.
+                                              type: string
+                                            signerName:
+                                              description: |-
+                                                Select all ClusterTrustBundles that match this signer name.
+                                                Mutually-exclusive with name.  The contents of all selected
+                                                ClusterTrustBundles will be unified and deduplicated.
+                                              type: string
+                                          required:
+                                            - path
+                                          type: object
+                                        configMap:
+                                          description: configMap information about the configMap data to project
+                                          properties:
+                                            items:
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                ConfigMap will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the ConfigMap,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
+                                              items:
+                                                description: Maps a string key to a path within a volume.
+                                                properties:
+                                                  key:
+                                                    description: key is the key to project.
+                                                    type: string
+                                                  mode:
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
+                                                    type: string
+                                                required:
+                                                  - key
+                                                  - path
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: optional specify whether the ConfigMap or its keys must be defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        downwardAPI:
+                                          description: downwardAPI information about the downwardAPI data to project
+                                          properties:
+                                            items:
+                                              description: Items is a list of DownwardAPIVolume file
+                                              items:
+                                                description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                                properties:
+                                                  fieldRef:
+                                                    description: 'Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.'
+                                                    properties:
+                                                      apiVersion:
+                                                        description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                        type: string
+                                                      fieldPath:
+                                                        description: Path of the field to select in the specified API version.
+                                                        type: string
+                                                    required:
+                                                      - fieldPath
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  mode:
+                                                    description: |-
+                                                      Optional: mode bits used to set permissions on this file, must be an octal value
+                                                      between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    description: |-
+                                                      Selects a resource of the container: only resources limits and requests
+                                                      (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                    properties:
+                                                      containerName:
+                                                        description: 'Container name: required for volumes, optional for env vars'
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        description: Specifies the output format of the exposed resources, defaults to "1"
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        description: 'Required: resource to select'
+                                                        type: string
+                                                    required:
+                                                      - resource
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                required:
+                                                  - path
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        podCertificate:
+                                          description: |-
+                                            Projects an auto-rotating credential bundle (private key and certificate
+                                            chain) that the pod can use either as a TLS client or server.
+
+                                            Kubelet generates a private key and uses it to send a
+                                            PodCertificateRequest to the named signer.  Once the signer approves the
+                                            request and issues a certificate chain, Kubelet writes the key and
+                                            certificate chain to the pod filesystem.  The pod does not start until
+                                            certificates have been issued for each podCertificate projected volume
+                                            source in its spec.
+
+                                            Kubelet will begin trying to rotate the certificate at the time indicated
+                                            by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                            timestamp.
+
+                                            Kubelet can write a single file, indicated by the credentialBundlePath
+                                            field, or separate files, indicated by the keyPath and
+                                            certificateChainPath fields.
+
+                                            The credential bundle is a single file in PEM format.  The first PEM
+                                            entry is the private key (in PKCS#8 format), and the remaining PEM
+                                            entries are the certificate chain issued by the signer (typically,
+                                            signers will return their certificate chain in leaf-to-root order).
+
+                                            Prefer using the credential bundle format, since your application code
+                                            can read it atomically.  If you use keyPath and certificateChainPath,
+                                            your application must make two separate file reads. If these coincide
+                                            with a certificate rotation, it is possible that the private key and leaf
+                                            certificate you read may not correspond to each other.  Your application
+                                            will need to check for this condition, and re-read until they are
+                                            consistent.
+
+                                            The named signer controls chooses the format of the certificate it
+                                            issues; consult the signer implementation's documentation to learn how to
+                                            use the certificates it issues.
+                                          properties:
+                                            certificateChainPath:
+                                              description: |-
+                                                Write the certificate chain at this path in the projected volume.
+
+                                                Most applications should use credentialBundlePath.  When using keyPath
+                                                and certificateChainPath, your application needs to check that the key
+                                                and leaf certificate are consistent, because it is possible to read the
+                                                files mid-rotation.
+                                              type: string
+                                            credentialBundlePath:
+                                              description: |-
+                                                Write the credential bundle at this path in the projected volume.
+
+                                                The credential bundle is a single file that contains multiple PEM blocks.
+                                                The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                                key.
+
+                                                The remaining blocks are CERTIFICATE blocks, containing the issued
+                                                certificate chain from the signer (leaf and any intermediates).
+
+                                                Using credentialBundlePath lets your Pod's application code make a single
+                                                atomic read that retrieves a consistent key and certificate chain.  If you
+                                                project them to separate files, your application code will need to
+                                                additionally check that the leaf certificate was issued to the key.
+                                              type: string
+                                            keyPath:
+                                              description: |-
+                                                Write the key at this path in the projected volume.
+
+                                                Most applications should use credentialBundlePath.  When using keyPath
+                                                and certificateChainPath, your application needs to check that the key
+                                                and leaf certificate are consistent, because it is possible to read the
+                                                files mid-rotation.
+                                              type: string
+                                            keyType:
+                                              description: |-
+                                                The type of keypair Kubelet will generate for the pod.
+
+                                                Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                                "ECDSAP521", and "ED25519".
+                                              type: string
+                                            maxExpirationSeconds:
+                                              description: |-
+                                                maxExpirationSeconds is the maximum lifetime permitted for the
+                                                certificate.
+
+                                                Kubelet copies this value verbatim into the PodCertificateRequests it
+                                                generates for this projection.
+
+                                                If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                                will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                                value is 7862400 (91 days).
+
+                                                The signer implementation is then free to issue a certificate with any
+                                                lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                                seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                                `kubernetes.io` signers will never issue certificates with a lifetime
+                                                longer than 24 hours.
+                                              format: int32
+                                              type: integer
+                                            signerName:
+                                              description: Kubelet's generated CSRs will be addressed to this signer.
+                                              type: string
+                                            userAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                userAnnotations allow pod authors to pass additional information to
+                                                the signer implementation.  Kubernetes does not restrict or validate this
+                                                metadata in any way.
+
+                                                These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                                the PodCertificateRequest objects that Kubelet creates.
+
+                                                Entries are subject to the same validation as object metadata annotations,
+                                                with the addition that all keys must be domain-prefixed. No restrictions
+                                                are placed on values, except an overall size limitation on the entire field.
+
+                                                Signers should document the keys and values they support. Signers should
+                                                deny requests that contain keys they do not recognize.
+                                              type: object
+                                          required:
+                                            - keyType
+                                            - signerName
+                                          type: object
+                                        secret:
+                                          description: secret information about the secret data to project
+                                          properties:
+                                            items:
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                Secret will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the Secret,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
+                                              items:
+                                                description: Maps a string key to a path within a volume.
+                                                properties:
+                                                  key:
+                                                    description: key is the key to project.
+                                                    type: string
+                                                  mode:
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
+                                                    type: string
+                                                required:
+                                                  - key
+                                                  - path
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: optional field specify whether the Secret or its key must be defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        serviceAccountToken:
+                                          description: serviceAccountToken is information about the serviceAccountToken data to project
+                                          properties:
+                                            audience:
+                                              description: |-
+                                                audience is the intended audience of the token. A recipient of a token
+                                                must identify itself with an identifier specified in the audience of the
+                                                token, and otherwise should reject the token. The audience defaults to the
+                                                identifier of the apiserver.
+                                              type: string
+                                            expirationSeconds:
+                                              description: |-
+                                                expirationSeconds is the requested duration of validity of the service
+                                                account token. As the token approaches expiration, the kubelet volume
+                                                plugin will proactively rotate the service account token. The kubelet will
+                                                start trying to rotate the token if the token is older than 80 percent of
+                                                its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                and must be at least 10 minutes.
+                                              format: int64
+                                              type: integer
+                                            path:
+                                              description: |-
+                                                path is the path relative to the mount point of the file to project the
+                                                token into.
+                                              type: string
+                                          required:
+                                            - path
+                                          type: object
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              quobyte:
+                                description: |-
+                                  quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                                  Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
+                                properties:
+                                  group:
+                                    description: |-
+                                      group to map volume access to
+                                      Default is no group
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                      Defaults to false.
+                                    type: boolean
+                                  registry:
+                                    description: |-
+                                      registry represents a single or multiple Quobyte Registry services
+                                      specified as a string as host:port pair (multiple entries are separated with commas)
+                                      which acts as the central registry for volumes
+                                    type: string
+                                  tenant:
+                                    description: |-
+                                      tenant owning the given Quobyte volume in the Backend
+                                      Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                    type: string
+                                  user:
+                                    description: |-
+                                      user to map volume access to
+                                      Defaults to serivceaccount user
+                                    type: string
+                                  volume:
+                                    description: volume is a string that references an already created Quobyte volume by name.
+                                    type: string
+                                required:
+                                  - registry
+                                  - volume
+                                type: object
+                              rbd:
+                                description: |-
+                                  rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                  Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type of the volume that you want to mount.
+                                      Tip: Ensure that the filesystem type is supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                    type: string
+                                  image:
+                                    description: |-
+                                      image is the rados image name.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                    type: string
+                                  keyring:
+                                    default: /etc/ceph/keyring
+                                    description: |-
+                                      keyring is the path to key ring for RBDUser.
+                                      Default is /etc/ceph/keyring.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                    type: string
+                                  monitors:
+                                    description: |-
+                                      monitors is a collection of Ceph monitors.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  pool:
+                                    default: rbd
+                                    description: |-
+                                      pool is the rados pool name.
+                                      Default is rbd.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the ReadOnly setting in VolumeMounts.
+                                      Defaults to false.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                    type: boolean
+                                  secretRef:
+                                    description: |-
+                                      secretRef is name of the authentication secret for RBDUser. If provided
+                                      overrides keyring.
+                                      Default is nil.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  user:
+                                    default: admin
+                                    description: |-
+                                      user is the rados user name.
+                                      Default is admin.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                    type: string
+                                required:
+                                  - image
+                                  - monitors
+                                type: object
+                              scaleIO:
+                                description: |-
+                                  scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                  Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
+                                properties:
+                                  fsType:
+                                    default: xfs
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs".
+                                      Default is "xfs".
+                                    type: string
+                                  gateway:
+                                    description: gateway is the host address of the ScaleIO API Gateway.
+                                    type: string
+                                  protectionDomain:
+                                    description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly Defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                    type: boolean
+                                  secretRef:
+                                    description: |-
+                                      secretRef references to the secret for ScaleIO user and other
+                                      sensitive information. If this is not provided, Login operation will fail.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  sslEnabled:
+                                    description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
+                                    type: boolean
+                                  storageMode:
+                                    default: ThinProvisioned
+                                    description: |-
+                                      storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                      Default is ThinProvisioned.
+                                    type: string
+                                  storagePool:
+                                    description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
+                                    type: string
+                                  system:
+                                    description: system is the name of the storage system as configured in ScaleIO.
+                                    type: string
+                                  volumeName:
+                                    description: |-
+                                      volumeName is the name of a volume already created in the ScaleIO system
+                                      that is associated with this volume source.
+                                    type: string
+                                required:
+                                  - gateway
+                                  - secretRef
+                                  - system
+                                type: object
+                              secret:
+                                description: |-
+                                  secret represents a secret that should populate this volume.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values
+                                      for mode bits. Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: |-
+                                      items If unspecified, each key-value pair in the Data field of the referenced
+                                      Secret will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the Secret,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                        - key
+                                        - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  optional:
+                                    description: optional field specify whether the Secret or its keys must be defined
+                                    type: boolean
+                                  secretName:
+                                    description: |-
+                                      secretName is the name of the secret in the pod's namespace to use.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                    type: string
+                                type: object
+                              storageos:
+                                description: |-
+                                  storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                  Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                    type: boolean
+                                  secretRef:
+                                    description: |-
+                                      secretRef specifies the secret to use for obtaining the StorageOS API
+                                      credentials.  If not specified, default values will be attempted.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  volumeName:
+                                    description: |-
+                                      volumeName is the human-readable name of the StorageOS volume.  Volume
+                                      names are only unique within a namespace.
+                                    type: string
+                                  volumeNamespace:
+                                    description: |-
+                                      volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                      namespace is specified then the Pod's namespace will be used.  This allows the
+                                      Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                      Set VolumeName to any name to override the default behaviour.
+                                      Set to "default" if you are not using namespaces within StorageOS.
+                                      Namespaces that do not pre-exist within StorageOS will be created.
+                                    type: string
+                                type: object
+                              vsphereVolume:
+                                description: |-
+                                  vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                                  Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                                  are redirected to the csi.vsphere.vmware.com CSI driver.
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  storagePolicyID:
+                                    description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                    type: string
+                                  storagePolicyName:
+                                    description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
+                                    type: string
+                                  volumePath:
+                                    description: volumePath is the path that identifies vSphere volume vmdk
+                                    type: string
+                                required:
+                                  - volumePath
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      required:
+                        - containers
+                      type: object
+                  type: object
+                type:
+                  default: rw
+                  description: 'Type of service to forward traffic to. Default: `rw`.'
+                  enum:
+                    - rw
+                    - ro
+                    - r
+                  type: string
+              required:
+                - cluster
+                - pgbouncer
+              type: object
+            status:
+              description: |-
+                Most recently observed status of the Pooler. This data may not be up to
+                date. Populated by the system. Read-only.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                instances:
+                  description: The number of pods trying to be scheduled
+                  format: int32
+                  type: integer
+                secrets:
+                  description: The resource version of the config object
+                  properties:
+                    clientCA:
+                      description: The client CA secret version
+                      properties:
+                        name:
+                          description: The name of the secret
+                          type: string
+                        version:
+                          description: The ResourceVersion of the secret
+                          type: string
+                      type: object
+                    clientTLS:
+                      description: The client TLS secret version
+                      properties:
+                        name:
+                          description: The name of the secret
+                          type: string
+                        version:
+                          description: The ResourceVersion of the secret
+                          type: string
+                      type: object
+                    pgBouncerSecrets:
+                      description: The version of the secrets used by PgBouncer
+                      properties:
+                        authQuery:
+                          description: The auth query secret version
+                          properties:
+                            name:
+                              description: The name of the secret
+                              type: string
+                            version:
+                              description: The ResourceVersion of the secret
+                              type: string
+                          type: object
+                      type: object
+                    serverCA:
+                      description: The server CA secret version
+                      properties:
+                        name:
+                          description: The name of the secret
+                          type: string
+                        version:
+                          description: The ResourceVersion of the secret
+                          type: string
+                      type: object
+                    serverTLS:
+                      description: The server TLS secret version
+                      properties:
+                        name:
+                          description: The name of the secret
+                          type: string
+                        version:
+                          description: The ResourceVersion of the secret
+                          type: string
+                      type: object
+                  type: object
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        scale:
+          specReplicasPath: .spec.instances
+          statusReplicasPath: .status.instances
+        status: {}

--- a/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-publications-postgresql-cnpg-io.yaml
+++ b/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-publications-postgresql-cnpg-io.yaml
@@ -1,0 +1,188 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+    helm.sh/resource-policy: keep
+  name: publications.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: Publication
+    listKind: PublicationList
+    plural: publications
+    singular: publication
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.cluster.name
+          name: Cluster
+          type: string
+        - jsonPath: .spec.name
+          name: PG Name
+          type: string
+        - jsonPath: .status.applied
+          name: Applied
+          type: boolean
+        - description: Latest reconciliation message
+          jsonPath: .status.message
+          name: Message
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: Publication is the Schema for the publications API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: PublicationSpec defines the desired state of Publication
+              properties:
+                cluster:
+                  description: The name of the PostgreSQL cluster that identifies the "publisher"
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                dbname:
+                  description: |-
+                    The name of the database where the publication will be installed in
+                    the "publisher" cluster
+                  type: string
+                  x-kubernetes-validations:
+                    - message: dbname is immutable
+                      rule: self == oldSelf
+                name:
+                  description: The name of the publication inside PostgreSQL
+                  type: string
+                  x-kubernetes-validations:
+                    - message: name is immutable
+                      rule: self == oldSelf
+                parameters:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    Publication parameters part of the `WITH` clause as expected by
+                    PostgreSQL `CREATE PUBLICATION` command
+                  type: object
+                publicationReclaimPolicy:
+                  default: retain
+                  description: The policy for end-of-life maintenance of this publication
+                  enum:
+                    - delete
+                    - retain
+                  type: string
+                target:
+                  description: Target of the publication as expected by PostgreSQL `CREATE PUBLICATION` command
+                  properties:
+                    allTables:
+                      description: |-
+                        Marks the publication as one that replicates changes for all tables
+                        in the database, including tables created in the future.
+                        Corresponding to `FOR ALL TABLES` in PostgreSQL.
+                      type: boolean
+                      x-kubernetes-validations:
+                        - message: allTables is immutable
+                          rule: self == oldSelf
+                    objects:
+                      description: Just the following schema objects
+                      items:
+                        description: PublicationTargetObject is an object to publish
+                        properties:
+                          table:
+                            description: |-
+                              Specifies a list of tables to add to the publication. Corresponding
+                              to `FOR TABLE` in PostgreSQL.
+                            properties:
+                              columns:
+                                description: The columns to publish
+                                items:
+                                  type: string
+                                type: array
+                              name:
+                                description: The table name
+                                type: string
+                              only:
+                                description: Whether to limit to the table only or include all its descendants
+                                type: boolean
+                              schema:
+                                description: The schema name
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          tablesInSchema:
+                            description: |-
+                              Marks the publication as one that replicates changes for all tables
+                              in the specified list of schemas, including tables created in the
+                              future. Corresponding to `FOR TABLES IN SCHEMA` in PostgreSQL.
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: tablesInSchema and table are mutually exclusive
+                            rule: (has(self.tablesInSchema) && !has(self.table)) || (!has(self.tablesInSchema) && has(self.table))
+                      maxItems: 100000
+                      type: array
+                      x-kubernetes-validations:
+                        - message: specifying a column list when the publication also publishes tablesInSchema is not supported
+                          rule: '!(self.exists(o, has(o.table) && has(o.table.columns)) && self.exists(o, has(o.tablesInSchema)))'
+                  type: object
+                  x-kubernetes-validations:
+                    - message: allTables and objects are mutually exclusive
+                      rule: (has(self.allTables) && !has(self.objects)) || (!has(self.allTables) && has(self.objects))
+              required:
+                - cluster
+                - dbname
+                - name
+                - target
+              type: object
+            status:
+              description: PublicationStatus defines the observed state of Publication
+              properties:
+                applied:
+                  description: Applied is true if the publication was reconciled correctly
+                  type: boolean
+                message:
+                  description: Message is the reconciliation output message
+                  type: string
+                observedGeneration:
+                  description: |-
+                    A sequence number representing the latest
+                    desired state that was synchronized
+                  format: int64
+                  type: integer
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-scheduledbackups-postgresql-cnpg-io.yaml
+++ b/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-scheduledbackups-postgresql-cnpg-io.yaml
@@ -1,0 +1,188 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+    helm.sh/resource-policy: keep
+  name: scheduledbackups.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: ScheduledBackup
+    listKind: ScheduledBackupList
+    plural: scheduledbackups
+    singular: scheduledbackup
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.cluster.name
+          name: Cluster
+          type: string
+        - jsonPath: .status.lastScheduleTime
+          name: Last Backup
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ScheduledBackup is the Schema for the scheduledbackups API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Specification of the desired behavior of the ScheduledBackup.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                backupOwnerReference:
+                  default: none
+                  description: |-
+                    Indicates which ownerReference should be put inside the created backup resources.<br />
+                    - none: no owner reference for created backup objects (same behavior as before the field was introduced)<br />
+                    - self: sets the Scheduled backup object as owner of the backup<br />
+                    - cluster: set the cluster as owner of the backup<br />
+                  enum:
+                    - none
+                    - self
+                    - cluster
+                  type: string
+                cluster:
+                  description: The cluster to backup
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                immediate:
+                  description: If the first backup has to be immediately start after creation or not
+                  type: boolean
+                method:
+                  default: barmanObjectStore
+                  description: |-
+                    The backup method to be used, possible options are `barmanObjectStore`,
+                    `volumeSnapshot` or `plugin`. Defaults to: `barmanObjectStore`.
+                  enum:
+                    - barmanObjectStore
+                    - volumeSnapshot
+                    - plugin
+                  type: string
+                online:
+                  description: |-
+                    Whether the default type of backup with volume snapshots is
+                    online/hot (`true`, default) or offline/cold (`false`)
+                    Overrides the default setting specified in the cluster field '.spec.backup.volumeSnapshot.online'
+                  type: boolean
+                onlineConfiguration:
+                  description: |-
+                    Configuration parameters to control the online/hot backup with volume snapshots
+                    Overrides the default settings specified in the cluster '.backup.volumeSnapshot.onlineConfiguration' stanza
+                  properties:
+                    immediateCheckpoint:
+                      description: |-
+                        Control whether the I/O workload for the backup initial checkpoint will
+                        be limited, according to the `checkpoint_completion_target` setting on
+                        the PostgreSQL server. If set to true, an immediate checkpoint will be
+                        used, meaning PostgreSQL will complete the checkpoint as soon as
+                        possible. `false` by default.
+                      type: boolean
+                    waitForArchive:
+                      default: true
+                      description: |-
+                        If false, the function will return immediately after the backup is completed,
+                        without waiting for WAL to be archived.
+                        This behavior is only useful with backup software that independently monitors WAL archiving.
+                        Otherwise, WAL required to make the backup consistent might be missing and make the backup useless.
+                        By default, or when this parameter is true, pg_backup_stop will wait for WAL to be archived when archiving is
+                        enabled.
+                        On a standby, this means that it will wait only when archive_mode = always.
+                        If write activity on the primary is low, it may be useful to run pg_switch_wal on the primary in order to trigger
+                        an immediate segment switch.
+                      type: boolean
+                  type: object
+                pluginConfiguration:
+                  description: Configuration parameters passed to the plugin managing this backup
+                  properties:
+                    name:
+                      description: Name is the name of the plugin managing this backup
+                      type: string
+                    parameters:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Parameters are the configuration parameters passed to the backup
+                        plugin for this backup
+                      type: object
+                  required:
+                    - name
+                  type: object
+                schedule:
+                  description: |-
+                    The schedule does not follow the same format used in Kubernetes CronJobs
+                    as it includes an additional seconds specifier,
+                    see https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format
+                  type: string
+                suspend:
+                  description: If this backup is suspended or not
+                  type: boolean
+                target:
+                  description: |-
+                    The policy to decide which instance should perform this backup. If empty,
+                    it defaults to `cluster.spec.backup.target`.
+                    Available options are empty string, `primary` and `prefer-standby`.
+                    `primary` to have backups run always on primary instances,
+                    `prefer-standby` to have backups run preferably on the most updated
+                    standby, if available.
+                  enum:
+                    - primary
+                    - prefer-standby
+                  type: string
+              required:
+                - cluster
+                - schedule
+              type: object
+            status:
+              description: |-
+                Most recently observed status of the ScheduledBackup. This data may not be up
+                to date. Populated by the system. Read-only.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                lastCheckTime:
+                  description: The latest time the schedule
+                  format: date-time
+                  type: string
+                lastScheduleTime:
+                  description: Information when was the last time that backup was successfully scheduled.
+                  format: date-time
+                  type: string
+                nextScheduleTime:
+                  description: Next time we will run a backup
+                  format: date-time
+                  type: string
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-subscriptions-postgresql-cnpg-io.yaml
+++ b/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-subscriptions-postgresql-cnpg-io.yaml
@@ -1,0 +1,147 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+    helm.sh/resource-policy: keep
+  name: subscriptions.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: Subscription
+    listKind: SubscriptionList
+    plural: subscriptions
+    singular: subscription
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.cluster.name
+          name: Cluster
+          type: string
+        - jsonPath: .spec.name
+          name: PG Name
+          type: string
+        - jsonPath: .status.applied
+          name: Applied
+          type: boolean
+        - description: Latest reconciliation message
+          jsonPath: .status.message
+          name: Message
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: Subscription is the Schema for the subscriptions API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SubscriptionSpec defines the desired state of Subscription
+              properties:
+                cluster:
+                  description: The name of the PostgreSQL cluster that identifies the "subscriber"
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                dbname:
+                  description: |-
+                    The name of the database where the publication will be installed in
+                    the "subscriber" cluster
+                  type: string
+                  x-kubernetes-validations:
+                    - message: dbname is immutable
+                      rule: self == oldSelf
+                externalClusterName:
+                  description: The name of the external cluster with the publication ("publisher")
+                  type: string
+                name:
+                  description: The name of the subscription inside PostgreSQL
+                  type: string
+                  x-kubernetes-validations:
+                    - message: name is immutable
+                      rule: self == oldSelf
+                parameters:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    Subscription parameters included in the `WITH` clause of the PostgreSQL
+                    `CREATE SUBSCRIPTION` command. Most parameters cannot be changed
+                    after the subscription is created and will be ignored if modified
+                    later, except for a limited set documented at:
+                    https://www.postgresql.org/docs/current/sql-altersubscription.html#SQL-ALTERSUBSCRIPTION-PARAMS-SET
+                  type: object
+                publicationDBName:
+                  description: |-
+                    The name of the database containing the publication on the external
+                    cluster. Defaults to the one in the external cluster definition.
+                  type: string
+                publicationName:
+                  description: |-
+                    The name of the publication inside the PostgreSQL database in the
+                    "publisher"
+                  type: string
+                subscriptionReclaimPolicy:
+                  default: retain
+                  description: The policy for end-of-life maintenance of this subscription
+                  enum:
+                    - delete
+                    - retain
+                  type: string
+              required:
+                - cluster
+                - dbname
+                - externalClusterName
+                - name
+                - publicationName
+              type: object
+            status:
+              description: SubscriptionStatus defines the observed state of Subscription
+              properties:
+                applied:
+                  description: Applied is true if the subscription was reconciled correctly
+                  type: boolean
+                message:
+                  description: Message is the reconciliation output message
+                  type: string
+                observedGeneration:
+                  description: |-
+                    A sequence number representing the latest
+                    desired state that was synchronized
+                  format: int64
+                  type: integer
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/generated/manifests/prod-axon/bootstrap/Namespace-cnpg-system.yaml
+++ b/generated/manifests/prod-axon/bootstrap/Namespace-cnpg-system.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+  name: cnpg-system

--- a/generated/manifests/prod-axon/bootstrap/Namespace-media.yaml
+++ b/generated/manifests/prod-axon/bootstrap/Namespace-media.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+  name: media

--- a/generated/manifests/prod-axon/cloudnative-pg/CiliumNetworkPolicy-allow-kube-apiserver-egress.yaml
+++ b/generated/manifests/prod-axon/cloudnative-pg/CiliumNetworkPolicy-allow-kube-apiserver-egress.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: allow-kube-apiserver-egress
+  namespace: cnpg-system
+spec:
+  description: Allow CloudNativePG operator to talk to kube-apiserver.
+  egress:
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "6443"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      k8s:io.kubernetes.pod.namespace: cnpg-system

--- a/generated/manifests/prod-axon/cloudnative-pg/ClusterRole-cloudnative-pg-edit.yaml
+++ b/generated/manifests/prod-axon/cloudnative-pg/ClusterRole-cloudnative-pg-edit.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: cloudnative-pg
+    app.kubernetes.io/name: cloudnative-pg
+  name: cloudnative-pg-edit
+rules:
+  - apiGroups:
+      - postgresql.cnpg.io
+    resources:
+      - backups
+      - clusters
+      - clusters/status
+      - databases
+      - failoverquorums
+      - poolers
+      - publications
+      - scheduledbackups
+      - imagecatalogs
+      - clusterimagecatalogs
+      - subscriptions
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update

--- a/generated/manifests/prod-axon/cloudnative-pg/ClusterRole-cloudnative-pg-view.yaml
+++ b/generated/manifests/prod-axon/cloudnative-pg/ClusterRole-cloudnative-pg-view.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: cloudnative-pg
+    app.kubernetes.io/name: cloudnative-pg
+  name: cloudnative-pg-view
+rules:
+  - apiGroups:
+      - postgresql.cnpg.io
+    resources:
+      - backups
+      - clusters
+      - clusters/status
+      - databases
+      - failoverquorums
+      - poolers
+      - publications
+      - scheduledbackups
+      - imagecatalogs
+      - clusterimagecatalogs
+      - subscriptions
+    verbs:
+      - get
+      - list
+      - watch

--- a/generated/manifests/prod-axon/cloudnative-pg/ClusterRole-cloudnative-pg.yaml
+++ b/generated/manifests/prod-axon/cloudnative-pg/ClusterRole-cloudnative-pg.yaml
@@ -1,0 +1,234 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: cloudnative-pg
+    app.kubernetes.io/name: cloudnative-pg
+  name: cloudnative-pg
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - patch
+  - apiGroups:
+      - postgresql.cnpg.io
+    resources:
+      - clusterimagecatalogs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps/status
+      - secrets/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+      - pods
+      - pods/exec
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/status
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - podmonitors
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - postgresql.cnpg.io
+    resources:
+      - backups
+      - clusters
+      - databases
+      - poolers
+      - publications
+      - scheduledbackups
+      - subscriptions
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - postgresql.cnpg.io
+    resources:
+      - failoverquorums
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - postgresql.cnpg.io
+    resources:
+      - backups/status
+      - databases/status
+      - publications/status
+      - scheduledbackups/status
+      - subscriptions/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - postgresql.cnpg.io
+    resources:
+      - imagecatalogs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - postgresql.cnpg.io
+    resources:
+      - clusters/finalizers
+      - poolers/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - postgresql.cnpg.io
+    resources:
+      - clusters/status
+      - poolers/status
+      - failoverquorums/status
+    verbs:
+      - get
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshots
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - watch

--- a/generated/manifests/prod-axon/cloudnative-pg/ClusterRoleBinding-cloudnative-pg.yaml
+++ b/generated/manifests/prod-axon/cloudnative-pg/ClusterRoleBinding-cloudnative-pg.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: cloudnative-pg
+    app.kubernetes.io/name: cloudnative-pg
+  name: cloudnative-pg
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cloudnative-pg
+subjects:
+  - kind: ServiceAccount
+    name: cloudnative-pg
+    namespace: cnpg-system

--- a/generated/manifests/prod-axon/cloudnative-pg/ConfigMap-cnpg-controller-manager-config.yaml
+++ b/generated/manifests/prod-axon/cloudnative-pg/ConfigMap-cnpg-controller-manager-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data: {}
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: cloudnative-pg
+    app.kubernetes.io/name: cloudnative-pg
+  name: cnpg-controller-manager-config
+  namespace: cnpg-system

--- a/generated/manifests/prod-axon/cloudnative-pg/ConfigMap-cnpg-default-monitoring.yaml
+++ b/generated/manifests/prod-axon/cloudnative-pg/ConfigMap-cnpg-default-monitoring.yaml
@@ -1,0 +1,494 @@
+apiVersion: v1
+data:
+  queries: |
+    backends:
+      query: |
+        SELECT sa.datname
+          , sa.usename
+          , sa.application_name
+          , states.state
+          , COALESCE(sa.count, 0) AS total
+          , COALESCE(sa.max_tx_secs, 0) AS max_tx_duration_seconds
+        FROM ( VALUES ('active')
+          , ('idle')
+          , ('idle in transaction')
+          , ('idle in transaction (aborted)')
+          , ('fastpath function call')
+          , ('disabled')
+          ) AS states(state)
+        LEFT JOIN (
+          SELECT datname
+            , state
+            , usename
+            , COALESCE(application_name, '') AS application_name
+            , pg_catalog.count(*)
+            , COALESCE(EXTRACT (EPOCH FROM (pg_catalog.max(pg_catalog.now() OPERATOR(pg_catalog.-) xact_start))), 0) AS max_tx_secs
+          FROM pg_catalog.pg_stat_activity
+          GROUP BY datname, state, usename, application_name
+        ) sa ON states.state OPERATOR(pg_catalog.=) sa.state
+        WHERE sa.usename IS NOT NULL
+      metrics:
+        - datname:
+            usage: "LABEL"
+            description: "Name of the database"
+        - usename:
+            usage: "LABEL"
+            description: "Name of the user"
+        - application_name:
+            usage: "LABEL"
+            description: "Name of the application"
+        - state:
+            usage: "LABEL"
+            description: "State of the backend"
+        - total:
+            usage: "GAUGE"
+            description: "Number of backends"
+        - max_tx_duration_seconds:
+            usage: "GAUGE"
+            description: "Maximum duration of a transaction in seconds"
+
+    backends_waiting:
+      query: |
+        SELECT pg_catalog.count(*) AS total
+        FROM pg_catalog.pg_locks blocked_locks
+        JOIN pg_catalog.pg_locks blocking_locks
+          ON blocking_locks.locktype OPERATOR(pg_catalog.=) blocked_locks.locktype
+          AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database
+          AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
+          AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
+          AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple
+          AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid
+          AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
+          AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
+          AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
+          AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
+          AND blocking_locks.pid OPERATOR(pg_catalog.<>) blocked_locks.pid
+        JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid OPERATOR(pg_catalog.=) blocking_locks.pid
+        WHERE NOT blocked_locks.granted
+      metrics:
+        - total:
+            usage: "GAUGE"
+            description: "Total number of backends that are currently waiting on other queries"
+
+    pg_database:
+      query: |
+        SELECT datname
+          , pg_catalog.pg_database_size(datname) AS size_bytes
+          , pg_catalog.age(datfrozenxid) AS xid_age
+          , pg_catalog.mxid_age(datminmxid) AS mxid_age
+        FROM pg_catalog.pg_database
+        WHERE datallowconn
+      metrics:
+        - datname:
+            usage: "LABEL"
+            description: "Name of the database"
+        - size_bytes:
+            usage: "GAUGE"
+            description: "Disk space used by the database"
+        - xid_age:
+            usage: "GAUGE"
+            description: "Number of transactions from the frozen XID to the current one"
+        - mxid_age:
+            usage: "GAUGE"
+            description: "Number of multiple transactions (Multixact) from the frozen XID to the current one"
+
+    pg_postmaster:
+      query: |
+        SELECT EXTRACT(EPOCH FROM pg_postmaster_start_time) AS start_time
+        FROM pg_catalog.pg_postmaster_start_time()
+      metrics:
+        - start_time:
+            usage: "GAUGE"
+            description: "Time at which postgres started (based on epoch)"
+
+    pg_replication:
+      query: |
+        SELECT CASE WHEN (
+            NOT pg_catalog.pg_is_in_recovery()
+            OR pg_catalog.pg_last_wal_receive_lsn() OPERATOR(pg_catalog.=) pg_catalog.pg_last_wal_replay_lsn())
+          THEN 0
+          ELSE GREATEST (0,
+            EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) pg_catalog.pg_last_xact_replay_timestamp())))
+          END AS lag,
+          pg_catalog.pg_is_in_recovery() AS in_recovery,
+          EXISTS (TABLE pg_catalog.pg_stat_wal_receiver) AS is_wal_receiver_up,
+          (SELECT pg_catalog.count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas
+      metrics:
+        - lag:
+            usage: "GAUGE"
+            description: "Replication lag behind primary in seconds"
+        - in_recovery:
+            usage: "GAUGE"
+            description: "Whether the instance is in recovery"
+        - is_wal_receiver_up:
+            usage: "GAUGE"
+            description: "Whether the instance wal_receiver is up"
+        - streaming_replicas:
+            usage: "GAUGE"
+            description: "Number of streaming replicas connected to the instance"
+
+    pg_replication_slots:
+      query: |
+        SELECT slot_name,
+          slot_type,
+          database,
+          active,
+          (CASE pg_catalog.pg_is_in_recovery()
+            WHEN TRUE THEN pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_last_wal_receive_lsn(), restart_lsn)
+            ELSE pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), restart_lsn)
+          END) as pg_wal_lsn_diff
+        FROM pg_catalog.pg_replication_slots
+        WHERE NOT temporary
+      metrics:
+        - slot_name:
+            usage: "LABEL"
+            description: "Name of the replication slot"
+        - slot_type:
+            usage: "LABEL"
+            description: "Type of the replication slot"
+        - database:
+            usage: "LABEL"
+            description: "Name of the database"
+        - active:
+            usage: "GAUGE"
+            description: "Flag indicating whether the slot is active"
+        - pg_wal_lsn_diff:
+            usage: "GAUGE"
+            description: "Replication lag in bytes"
+
+    pg_stat_archiver:
+      query: |
+        SELECT archived_count
+          , failed_count
+          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_archived_time)), -1) AS seconds_since_last_archival
+          , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_failed_time)), -1) AS seconds_since_last_failure
+          , COALESCE(EXTRACT(EPOCH FROM last_archived_time), -1) AS last_archived_time
+          , COALESCE(EXTRACT(EPOCH FROM last_failed_time), -1) AS last_failed_time
+          , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn
+          , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn
+          , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time
+        FROM pg_catalog.pg_stat_archiver
+      predicate_query: |
+        SELECT NOT pg_catalog.pg_is_in_recovery()
+          OR pg_catalog.current_setting('archive_mode') OPERATOR(pg_catalog.=) 'always'
+      metrics:
+        - archived_count:
+            usage: "COUNTER"
+            description: "Number of WAL files that have been successfully archived"
+        - failed_count:
+            usage: "COUNTER"
+            description: "Number of failed attempts for archiving WAL files"
+        - seconds_since_last_archival:
+            usage: "GAUGE"
+            description: "Seconds since the last successful archival operation"
+        - seconds_since_last_failure:
+            usage: "GAUGE"
+            description: "Seconds since the last failed archival operation"
+        - last_archived_time:
+            usage: "GAUGE"
+            description: "Epoch of the last time WAL archiving succeeded"
+        - last_failed_time:
+            usage: "GAUGE"
+            description: "Epoch of the last time WAL archiving failed"
+        - last_archived_wal_start_lsn:
+            usage: "GAUGE"
+            description: "Archived WAL start LSN"
+        - last_failed_wal_start_lsn:
+            usage: "GAUGE"
+            description: "Last failed WAL LSN"
+        - stats_reset_time:
+            usage: "GAUGE"
+            description: "Time at which these statistics were last reset"
+
+    pg_stat_bgwriter:
+      runonserver: "<17.0.0"
+      query: |
+        SELECT checkpoints_timed
+          , checkpoints_req
+          , checkpoint_write_time
+          , checkpoint_sync_time
+          , buffers_checkpoint
+          , buffers_clean
+          , maxwritten_clean
+          , buffers_backend
+          , buffers_backend_fsync
+          , buffers_alloc
+        FROM pg_catalog.pg_stat_bgwriter
+      metrics:
+        - checkpoints_timed:
+            usage: "COUNTER"
+            description: "Number of scheduled checkpoints that have been performed"
+        - checkpoints_req:
+            usage: "COUNTER"
+            description: "Number of requested checkpoints that have been performed"
+        - checkpoint_write_time:
+            usage: "COUNTER"
+            description: "Total amount of time that has been spent in the portion of checkpoint processing where files are written to disk, in milliseconds"
+        - checkpoint_sync_time:
+            usage: "COUNTER"
+            description: "Total amount of time that has been spent in the portion of checkpoint processing where files are synchronized to disk, in milliseconds"
+        - buffers_checkpoint:
+            usage: "COUNTER"
+            description: "Number of buffers written during checkpoints"
+        - buffers_clean:
+            usage: "COUNTER"
+            description: "Number of buffers written by the background writer"
+        - maxwritten_clean:
+            usage: "COUNTER"
+            description: "Number of times the background writer stopped a cleaning scan because it had written too many buffers"
+        - buffers_backend:
+            usage: "COUNTER"
+            description: "Number of buffers written directly by a backend"
+        - buffers_backend_fsync:
+            usage: "COUNTER"
+            description: "Number of times a backend had to execute its own fsync call (normally the background writer handles those even when the backend does its own write)"
+        - buffers_alloc:
+            usage: "COUNTER"
+            description: "Number of buffers allocated"
+
+    pg_stat_bgwriter_17:
+      runonserver: ">=17.0.0"
+      name: pg_stat_bgwriter
+      query: |
+        SELECT buffers_clean
+          , maxwritten_clean
+          , buffers_alloc
+          , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time
+        FROM pg_catalog.pg_stat_bgwriter
+      metrics:
+        - buffers_clean:
+            usage: "COUNTER"
+            description: "Number of buffers written by the background writer"
+        - maxwritten_clean:
+            usage: "COUNTER"
+            description: "Number of times the background writer stopped a cleaning scan because it had written too many buffers"
+        - buffers_alloc:
+            usage: "COUNTER"
+            description: "Number of buffers allocated"
+        - stats_reset_time:
+            usage: "GAUGE"
+            description: "Time at which these statistics were last reset"
+
+    pg_stat_checkpointer:
+      runonserver: ">=17.0.0"
+      query: |
+        SELECT num_timed AS checkpoints_timed
+          , num_requested AS checkpoints_req
+          , restartpoints_timed
+          , restartpoints_req
+          , restartpoints_done
+          , write_time
+          , sync_time
+          , buffers_written
+          , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time
+        FROM pg_catalog.pg_stat_checkpointer
+      metrics:
+        - checkpoints_timed:
+            usage: "COUNTER"
+            description: "Number of scheduled checkpoints that have been performed"
+        - checkpoints_req:
+            usage: "COUNTER"
+            description: "Number of requested checkpoints that have been performed"
+        - restartpoints_timed:
+            usage: "COUNTER"
+            description: "Number of scheduled restartpoints due to timeout or after a failed attempt to perform it"
+        - restartpoints_req:
+            usage: "COUNTER"
+            description: "Number of requested restartpoints that have been performed"
+        - restartpoints_done:
+            usage: "COUNTER"
+            description: "Number of restartpoints that have been performed"
+        - write_time:
+            usage: "COUNTER"
+            description: "Total amount of time that has been spent in the portion of processing checkpoints and restartpoints where files are written to disk, in milliseconds"
+        - sync_time:
+            usage: "COUNTER"
+            description: "Total amount of time that has been spent in the portion of processing checkpoints and restartpoints where files are synchronized to disk, in milliseconds"
+        - buffers_written:
+            usage: "COUNTER"
+            description: "Number of buffers written during checkpoints and restartpoints"
+        - stats_reset_time:
+            usage: "GAUGE"
+            description: "Time at which these statistics were last reset"
+
+    pg_stat_database:
+      query: |
+        SELECT datname
+          , xact_commit
+          , xact_rollback
+          , blks_read
+          , blks_hit
+          , tup_returned
+          , tup_fetched
+          , tup_inserted
+          , tup_updated
+          , tup_deleted
+          , conflicts
+          , temp_files
+          , temp_bytes
+          , deadlocks
+          , blk_read_time
+          , blk_write_time
+        FROM pg_catalog.pg_stat_database
+      metrics:
+        - datname:
+            usage: "LABEL"
+            description: "Name of this database"
+        - xact_commit:
+            usage: "COUNTER"
+            description: "Number of transactions in this database that have been committed"
+        - xact_rollback:
+            usage: "COUNTER"
+            description: "Number of transactions in this database that have been rolled back"
+        - blks_read:
+            usage: "COUNTER"
+            description: "Number of disk blocks read in this database"
+        - blks_hit:
+            usage: "COUNTER"
+            description: "Number of times disk blocks were found already in the buffer cache, so that a read was not necessary (this only includes hits in the PostgreSQL buffer cache, not the operating system's file system cache)"
+        - tup_returned:
+            usage: "COUNTER"
+            description: "Number of rows returned by queries in this database"
+        - tup_fetched:
+            usage: "COUNTER"
+            description: "Number of rows fetched by queries in this database"
+        - tup_inserted:
+            usage: "COUNTER"
+            description: "Number of rows inserted by queries in this database"
+        - tup_updated:
+            usage: "COUNTER"
+            description: "Number of rows updated by queries in this database"
+        - tup_deleted:
+            usage: "COUNTER"
+            description: "Number of rows deleted by queries in this database"
+        - conflicts:
+            usage: "COUNTER"
+            description: "Number of queries canceled due to conflicts with recovery in this database"
+        - temp_files:
+            usage: "COUNTER"
+            description: "Number of temporary files created by queries in this database"
+        - temp_bytes:
+            usage: "COUNTER"
+            description: "Total amount of data written to temporary files by queries in this database"
+        - deadlocks:
+            usage: "COUNTER"
+            description: "Number of deadlocks detected in this database"
+        - blk_read_time:
+            usage: "COUNTER"
+            description: "Time spent reading data file blocks by backends in this database, in milliseconds"
+        - blk_write_time:
+            usage: "COUNTER"
+            description: "Time spent writing data file blocks by backends in this database, in milliseconds"
+
+    pg_stat_replication:
+      primary: true
+      query: |
+        SELECT usename
+          , COALESCE(application_name, '') AS application_name
+          , COALESCE(client_addr::text, '') AS client_addr
+          , COALESCE(client_port::text, '') AS client_port
+          , EXTRACT(EPOCH FROM backend_start) AS backend_start
+          , COALESCE(pg_catalog.age(backend_xmin), 0) AS backend_xmin_age
+          , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), sent_lsn) AS sent_diff_bytes
+          , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), write_lsn) AS write_diff_bytes
+          , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), flush_lsn) AS flush_diff_bytes
+          , COALESCE(pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), replay_lsn),0) AS replay_diff_bytes
+          , COALESCE((EXTRACT(EPOCH FROM write_lag)),0)::float AS write_lag_seconds
+          , COALESCE((EXTRACT(EPOCH FROM flush_lag)),0)::float AS flush_lag_seconds
+          , COALESCE((EXTRACT(EPOCH FROM replay_lag)),0)::float AS replay_lag_seconds
+        FROM pg_catalog.pg_stat_replication
+      metrics:
+        - usename:
+            usage: "LABEL"
+            description: "Name of the replication user"
+        - application_name:
+            usage: "LABEL"
+            description: "Name of the application"
+        - client_addr:
+            usage: "LABEL"
+            description: "Client IP address"
+        - client_port:
+            usage: "LABEL"
+            description: "Client TCP port"
+        - backend_start:
+            usage: "COUNTER"
+            description: "Time when this process was started"
+        - backend_xmin_age:
+            usage: "COUNTER"
+            description: "The age of this standby's xmin horizon"
+        - sent_diff_bytes:
+            usage: "GAUGE"
+            description: "Difference in bytes from the last write-ahead log location sent on this connection"
+        - write_diff_bytes:
+            usage: "GAUGE"
+            description: "Difference in bytes from the last write-ahead log location written to disk by this standby server"
+        - flush_diff_bytes:
+            usage: "GAUGE"
+            description: "Difference in bytes from the last write-ahead log location flushed to disk by this standby server"
+        - replay_diff_bytes:
+            usage: "GAUGE"
+            description: "Difference in bytes from the last write-ahead log location replayed into the database on this standby server"
+        - write_lag_seconds:
+            usage: "GAUGE"
+            description: "Time elapsed between flushing recent WAL locally and receiving notification that this standby server has written it"
+        - flush_lag_seconds:
+            usage: "GAUGE"
+            description: "Time elapsed between flushing recent WAL locally and receiving notification that this standby server has written and flushed it"
+        - replay_lag_seconds:
+            usage: "GAUGE"
+            description: "Time elapsed between flushing recent WAL locally and receiving notification that this standby server has written, flushed and applied it"
+
+    pg_settings:
+      query: |
+        SELECT name,
+        CASE setting WHEN 'on' THEN '1' WHEN 'off' THEN '0' ELSE setting END AS setting
+        FROM pg_catalog.pg_settings
+        WHERE vartype IN ('integer', 'real', 'bool')
+        ORDER BY 1
+      metrics:
+        - name:
+            usage: "LABEL"
+            description: "Name of the setting"
+        - setting:
+            usage: "GAUGE"
+            description: "Setting value"
+
+    pg_extensions:
+      query: |
+        SELECT
+          pg_catalog.current_database() as datname,
+          name as extname,
+          default_version,
+          installed_version,
+          CASE
+            WHEN default_version OPERATOR(pg_catalog.=) installed_version THEN 0
+            ELSE 1
+        END AS update_available
+        FROM pg_catalog.pg_available_extensions
+        WHERE installed_version IS NOT NULL
+      metrics:
+        - datname:
+            usage: "LABEL"
+            description: "Name of the database"
+        - extname:
+            usage: "LABEL"
+            description: "Extension name"
+        - default_version:
+            usage: "LABEL"
+            description: "Default version"
+        - installed_version:
+            usage: "LABEL"
+            description: "Installed version"
+        - update_available:
+            usage: "GAUGE"
+            description: "An update is available"
+      target_databases:
+        - '*'
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: cloudnative-pg
+    app.kubernetes.io/name: cloudnative-pg
+    cnpg.io/reload: ""
+  name: cnpg-default-monitoring
+  namespace: cnpg-system

--- a/generated/manifests/prod-axon/cloudnative-pg/Deployment-cloudnative-pg.yaml
+++ b/generated/manifests/prod-axon/cloudnative-pg/Deployment-cloudnative-pg.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: cloudnative-pg
+    app.kubernetes.io/name: cloudnative-pg
+  name: cloudnative-pg
+  namespace: cnpg-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: cloudnative-pg
+      app.kubernetes.io/name: cloudnative-pg
+  template:
+    metadata:
+      annotations:
+        checksum/config: 904d2cf17720ad88a7d135fcc1d6616b8855560c1a8885f99632af04802cdf30
+        checksum/monitoring-config: 0c2d351dbf2fa8785c473d4ce19286c8f8a3346766e1abcee226c166f06c4975
+        checksum/rbac: a84d0dea594271c343f106f458f5fc63c18244de31a6f4c8851a75e415adfb70
+      labels:
+        app.kubernetes.io/instance: cloudnative-pg
+        app.kubernetes.io/name: cloudnative-pg
+    spec:
+      containers:
+        - args:
+            - controller
+            - --leader-elect
+            - --max-concurrent-reconciles=10
+            - --config-map-name=cnpg-controller-manager-config
+            - --webhook-port=9443
+          command:
+            - /manager
+          env:
+            - name: OPERATOR_IMAGE_NAME
+              value: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.1
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MONITORING_QUERIES_CONFIGMAP
+              value: cnpg-default-monitoring
+          image: ghcr.io/cloudnative-pg/cloudnative-pg:1.29.1
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /readyz
+              port: webhook-server
+              scheme: HTTPS
+            initialDelaySeconds: 3
+          name: manager
+          ports:
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: webhook-server
+              scheme: HTTPS
+            initialDelaySeconds: 3
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 10001
+            runAsUser: 10001
+            seccompProfile:
+              type: RuntimeDefault
+          startupProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /readyz
+              port: webhook-server
+              scheme: HTTPS
+            periodSeconds: 5
+          volumeMounts:
+            - mountPath: /controller
+              name: scratch-data
+            - mountPath: /run/secrets/cnpg.io/webhook
+              name: webhook-certificates
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: cloudnative-pg
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - emptyDir: {}
+          name: scratch-data
+        - name: webhook-certificates
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: cnpg-webhook-cert

--- a/generated/manifests/prod-axon/cloudnative-pg/MutatingWebhookConfiguration-cnpg-mutating-webhook-configuration.yaml
+++ b/generated/manifests/prod-axon/cloudnative-pg/MutatingWebhookConfiguration-cnpg-mutating-webhook-configuration.yaml
@@ -1,0 +1,92 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: cloudnative-pg
+    app.kubernetes.io/name: cloudnative-pg
+  name: cnpg-mutating-webhook-configuration
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: cnpg-webhook-service
+        namespace: cnpg-system
+        path: /mutate-postgresql-cnpg-io-v1-backup
+        port: 443
+    failurePolicy: Fail
+    name: mbackup.cnpg.io
+    rules:
+      - apiGroups:
+          - postgresql.cnpg.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - backups
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: cnpg-webhook-service
+        namespace: cnpg-system
+        path: /mutate-postgresql-cnpg-io-v1-cluster
+        port: 443
+    failurePolicy: Fail
+    name: mcluster.cnpg.io
+    rules:
+      - apiGroups:
+          - postgresql.cnpg.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - clusters
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: cnpg-webhook-service
+        namespace: cnpg-system
+        path: /mutate-postgresql-cnpg-io-v1-database
+        port: 443
+    failurePolicy: Fail
+    name: mdatabase.cnpg.io
+    rules:
+      - apiGroups:
+          - postgresql.cnpg.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - databases
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: cnpg-webhook-service
+        namespace: cnpg-system
+        path: /mutate-postgresql-cnpg-io-v1-scheduledbackup
+        port: 443
+    failurePolicy: Fail
+    name: mscheduledbackup.cnpg.io
+    rules:
+      - apiGroups:
+          - postgresql.cnpg.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - scheduledbackups
+    sideEffects: None

--- a/generated/manifests/prod-axon/cloudnative-pg/Service-cnpg-webhook-service.yaml
+++ b/generated/manifests/prod-axon/cloudnative-pg/Service-cnpg-webhook-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: cloudnative-pg
+    app.kubernetes.io/name: cloudnative-pg
+  name: cnpg-webhook-service
+  namespace: cnpg-system
+spec:
+  ports:
+    - name: webhook-server
+      port: 443
+      targetPort: webhook-server
+  selector:
+    app.kubernetes.io/instance: cloudnative-pg
+    app.kubernetes.io/name: cloudnative-pg
+  type: ClusterIP

--- a/generated/manifests/prod-axon/cloudnative-pg/ServiceAccount-cloudnative-pg.yaml
+++ b/generated/manifests/prod-axon/cloudnative-pg/ServiceAccount-cloudnative-pg.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: cloudnative-pg
+    app.kubernetes.io/name: cloudnative-pg
+  name: cloudnative-pg
+  namespace: cnpg-system

--- a/generated/manifests/prod-axon/cloudnative-pg/StorageClass-longhorn-single.yaml
+++ b/generated/manifests/prod-axon/cloudnative-pg/StorageClass-longhorn-single.yaml
@@ -1,0 +1,11 @@
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-single
+parameters:
+  numberOfReplicas: "1"
+  staleReplicaTimeout: "30"
+provisioner: driver.longhorn.io
+reclaimPolicy: Retain
+volumeBindingMode: Immediate

--- a/generated/manifests/prod-axon/cloudnative-pg/ValidatingWebhookConfiguration-cnpg-validating-webhook-configuration.yaml
+++ b/generated/manifests/prod-axon/cloudnative-pg/ValidatingWebhookConfiguration-cnpg-validating-webhook-configuration.yaml
@@ -1,0 +1,113 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: cloudnative-pg
+    app.kubernetes.io/name: cloudnative-pg
+  name: cnpg-validating-webhook-configuration
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: cnpg-webhook-service
+        namespace: cnpg-system
+        path: /validate-postgresql-cnpg-io-v1-backup
+        port: 443
+    failurePolicy: Fail
+    name: vbackup.cnpg.io
+    rules:
+      - apiGroups:
+          - postgresql.cnpg.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - backups
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: cnpg-webhook-service
+        namespace: cnpg-system
+        path: /validate-postgresql-cnpg-io-v1-cluster
+        port: 443
+    failurePolicy: Fail
+    name: vcluster.cnpg.io
+    rules:
+      - apiGroups:
+          - postgresql.cnpg.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - clusters
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: cnpg-webhook-service
+        namespace: cnpg-system
+        path: /validate-postgresql-cnpg-io-v1-scheduledbackup
+        port: 443
+    failurePolicy: Fail
+    name: vscheduledbackup.cnpg.io
+    rules:
+      - apiGroups:
+          - postgresql.cnpg.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - scheduledbackups
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: cnpg-webhook-service
+        namespace: cnpg-system
+        path: /validate-postgresql-cnpg-io-v1-database
+        port: 443
+    failurePolicy: Fail
+    name: vdatabase.cnpg.io
+    rules:
+      - apiGroups:
+          - postgresql.cnpg.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - databases
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: cnpg-webhook-service
+        namespace: cnpg-system
+        path: /validate-postgresql-cnpg-io-v1-pooler
+        port: 443
+    failurePolicy: Fail
+    name: vpooler.cnpg.io
+    rules:
+      - apiGroups:
+          - postgresql.cnpg.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - poolers
+    sideEffects: None

--- a/generated/manifests/prod-axon/configarr/CiliumNetworkPolicy-allow-arr-egress-configarr.yaml
+++ b/generated/manifests/prod-axon/configarr/CiliumNetworkPolicy-allow-arr-egress-configarr.yaml
@@ -1,0 +1,39 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-arr-egress-configarr
+  namespace: media
+spec:
+  description: Allow configarr to reach the sonarr/radarr/lidarr/whisparr APIs.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: sonarr
+      toPorts:
+        - ports:
+            - port: "8989"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: radarr
+      toPorts:
+        - ports:
+            - port: "7878"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: lidarr
+      toPorts:
+        - ports:
+            - port: "8686"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: whisparr
+      toPorts:
+        - ports:
+            - port: "6969"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: configarr

--- a/generated/manifests/prod-axon/configarr/CiliumNetworkPolicy-allow-dns-egress-configarr.yaml
+++ b/generated/manifests/prod-axon/configarr/CiliumNetworkPolicy-allow-dns-egress-configarr.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-dns-egress-configarr
+  namespace: media
+spec:
+  description: Allow configarr to resolve via kube-dns.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: configarr

--- a/generated/manifests/prod-axon/configarr/CiliumNetworkPolicy-allow-internet-egress-configarr.yaml
+++ b/generated/manifests/prod-axon/configarr/CiliumNetworkPolicy-allow-internet-egress-configarr.yaml
@@ -1,0 +1,17 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-internet-egress-configarr
+  namespace: media
+spec:
+  description: Allow configarr to fetch the TRaSH/recyclarr config templates over HTTPS.
+  egress:
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: configarr

--- a/generated/manifests/prod-axon/configarr/ConfigMap-configarr.yaml
+++ b/generated/manifests/prod-axon/configarr/ConfigMap-configarr.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+data:
+  config.yml: |-
+    # Explicit upstream template sources (defaults, pinned for clarity).
+    trashGuideUrl: https://github.com/TRaSH-Guides/Guides
+    recyclarrConfigUrl: https://github.com/recyclarr/config-templates
+
+    sonarr:
+      series:
+        base_url: http://sonarr:8989
+        api_key: !env SONARR_API_KEY
+        quality_definition:
+          type: series
+        include:
+          - template: sonarr-quality-definition-series
+
+    radarr:
+      movies:
+        base_url: http://radarr:7878
+        api_key: !env RADARR_API_KEY
+        quality_definition:
+          type: movie
+        include:
+          - template: radarr-quality-definition-movie
+
+    # experimental support (configarr Lidarr v2): conservative baseline only.
+    lidarr:
+      main:
+        base_url: http://lidarr:8686
+        api_key: !env LIDARR_API_KEY
+
+    # experimental support (configarr Whisparr v3): conservative baseline only.
+    whisparr:
+      main:
+        base_url: http://whisparr:6969
+        api_key: !env WHISPARR_API_KEY
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: configarr
+    app.kubernetes.io/name: configarr
+  name: configarr
+  namespace: media

--- a/generated/manifests/prod-axon/configarr/CronJob-configarr.yaml
+++ b/generated/manifests/prod-axon/configarr/CronJob-configarr.yaml
@@ -1,0 +1,75 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  labels:
+    app.kubernetes.io/controller: configarr
+    app.kubernetes.io/instance: configarr
+    app.kubernetes.io/name: configarr
+  name: configarr
+  namespace: media
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 6
+      template:
+        metadata:
+          annotations:
+            checksum/configMaps: 09af9ea5d26aaf4daa086abc551a18fb55edded31dcc8aa181a3238658453236
+          labels:
+            app.kubernetes.io/controller: configarr
+            app.kubernetes.io/instance: configarr
+            app.kubernetes.io/name: configarr
+        spec:
+          automountServiceAccountToken: false
+          containers:
+            - env:
+                - name: LIDARR_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: lidarr
+                      name: media-arr-api-keys
+                - name: RADARR_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: radarr
+                      name: media-arr-api-keys
+                - name: SONARR_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: sonarr
+                      name: media-arr-api-keys
+                - name: TZ
+                  value: America/Los_Angeles
+                - name: WHISPARR_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: whisparr
+                      name: media-arr-api-keys
+              image: ghcr.io/raydak-labs/configarr:1.28.0
+              name: main
+              volumeMounts:
+                - mountPath: /app/config/config.yml
+                  name: config
+                  readOnly: true
+                  subPath: config.yml
+                - mountPath: /app/repos
+                  name: repos
+          dnsPolicy: ClusterFirst
+          enableServiceLinks: false
+          hostIPC: false
+          hostNetwork: false
+          hostPID: false
+          restartPolicy: Never
+          serviceAccountName: configarr
+          volumes:
+            - configMap:
+                name: configarr
+              name: config
+            - emptyDir: {}
+              name: repos
+  schedule: 0 0 * * *
+  startingDeadlineSeconds: 30
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/generated/manifests/prod-axon/configarr/ServiceAccount-configarr.yaml
+++ b/generated/manifests/prod-axon/configarr/ServiceAccount-configarr.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: configarr
+    app.kubernetes.io/name: configarr
+  name: configarr
+  namespace: media

--- a/generated/manifests/prod-axon/dash/CiliumNetworkPolicy-allow-api-egress-dash.yaml
+++ b/generated/manifests/prod-axon/dash/CiliumNetworkPolicy-allow-api-egress-dash.yaml
@@ -1,0 +1,46 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-api-egress-dash
+  namespace: media
+spec:
+  description: Allow dash to reach the in-namespace media APIs it surfaces.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: lidarr
+      toPorts:
+        - ports:
+            - port: "8686"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: radarr
+      toPorts:
+        - ports:
+            - port: "7878"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: sabnzbd
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: sonarr
+      toPorts:
+        - ports:
+            - port: "8989"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: whisparr
+      toPorts:
+        - ports:
+            - port: "6969"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: dash

--- a/generated/manifests/prod-axon/dash/CiliumNetworkPolicy-allow-apiserver-egress-dash.yaml
+++ b/generated/manifests/prod-axon/dash/CiliumNetworkPolicy-allow-apiserver-egress-dash.yaml
@@ -1,0 +1,17 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-apiserver-egress-dash
+  namespace: media
+spec:
+  description: Allow dash to reach the kube-apiserver for cluster resource discovery.
+  egress:
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "6443"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: dash

--- a/generated/manifests/prod-axon/dash/CiliumNetworkPolicy-allow-dns-egress-dash.yaml
+++ b/generated/manifests/prod-axon/dash/CiliumNetworkPolicy-allow-dns-egress-dash.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-dns-egress-dash
+  namespace: media
+spec:
+  description: Allow dash to resolve via kube-dns.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: dash

--- a/generated/manifests/prod-axon/dash/CiliumNetworkPolicy-allow-gateway-ingress-dash.yaml
+++ b/generated/manifests/prod-axon/dash/CiliumNetworkPolicy-allow-gateway-ingress-dash.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-gateway-ingress-dash
+  namespace: media
+spec:
+  description: Allow Envoy Gateway proxies to reach dash.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: dash
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP

--- a/generated/manifests/prod-axon/dash/CiliumNetworkPolicy-allow-internet-egress-dash.yaml
+++ b/generated/manifests/prod-axon/dash/CiliumNetworkPolicy-allow-internet-egress-dash.yaml
@@ -1,0 +1,19 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-internet-egress-dash
+  namespace: media
+spec:
+  description: Allow dash to reach the public internet.
+  egress:
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: dash

--- a/generated/manifests/prod-axon/dash/ClusterRole-media-dash-discovery.yaml
+++ b/generated/manifests/prod-axon/dash/ClusterRole-media-dash-discovery.yaml
@@ -1,0 +1,40 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: media-dash-discovery
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - pods
+      - nodes
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - nodes
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - get
+      - list
+      - watch

--- a/generated/manifests/prod-axon/dash/ClusterRoleBinding-media-dash-discovery.yaml
+++ b/generated/manifests/prod-axon/dash/ClusterRoleBinding-media-dash-discovery.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: media-dash-discovery
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: media-dash-discovery
+subjects:
+  - kind: ServiceAccount
+    name: dash
+    namespace: media

--- a/generated/manifests/prod-axon/dash/ConfigMap-dash-config.yaml
+++ b/generated/manifests/prod-axon/dash/ConfigMap-dash-config.yaml
@@ -1,0 +1,94 @@
+apiVersion: v1
+data:
+  bookmarks.yaml: |
+    - Media:
+        - Jellyfin:
+            - abbr: JF
+              href: https://jellyfin.json64.dev/
+        - Bazarr:
+            - abbr: BZ
+              href: https://bazarr.json64.dev/
+        - Whisparr:
+            - abbr: WH
+              href: https://whisparr.json64.dev/
+  kubernetes.yaml: |
+    mode: cluster
+  services.yaml: |
+    - Media:
+        - Sonarr:
+            href: https://sonarr.json64.dev/
+            icon: sonarr.png
+            widget:
+              type: sonarr
+              url: http://sonarr:8989
+              key: "{{HOMEPAGE_VAR_SONARR_KEY}}"
+        - Radarr:
+            href: https://radarr.json64.dev/
+            icon: radarr.png
+            widget:
+              type: radarr
+              url: http://radarr:7878
+              key: "{{HOMEPAGE_VAR_RADARR_KEY}}"
+        - Lidarr:
+            href: https://lidarr.json64.dev/
+            icon: lidarr.png
+            widget:
+              type: lidarr
+              url: http://lidarr:8686
+              key: "{{HOMEPAGE_VAR_LIDARR_KEY}}"
+        - Prowlarr:
+            href: https://prowlarr.json64.dev/
+            icon: prowlarr.png
+            # No widget: prowlarr API is admin-gated; surfaced as bookmark only.
+    - Downloaders:
+        - SABnzbd:
+            href: https://nzb.json64.dev/
+            icon: sabnzbd.png
+            widget:
+              type: sabnzbd
+              url: http://sabnzbd:8080
+              key: "{{HOMEPAGE_VAR_SABNZBD_KEY}}"
+        - qBittorrent:
+            href: https://torrent.json64.dev/
+            icon: qbittorrent.png
+            # No widget: the qbt WebUI is OIDC/loopback-locked; homepage cannot
+            # authenticate to it. Torrent status is visible via the *arrs.
+    - Watch:
+        - Jellyfin:
+            href: https://jellyfin.json64.dev/
+            icon: jellyfin.png
+  settings.yaml: |
+    title: Media Dashboard
+    theme: dark
+    color: slate
+    headerStyle: clean
+    layout:
+      Media:
+        style: row
+        columns: 4
+      Downloaders:
+        style: row
+        columns: 2
+  widgets.yaml: |
+    - resources:
+        backend: kubernetes
+        expanded: true
+        cpu: true
+        memory: true
+    - kubernetes:
+        cluster:
+          show: true
+          cpu: true
+          memory: true
+          showLabel: true
+        nodes:
+          show: true
+          cpu: true
+          memory: true
+    - search:
+        provider: duckduckgo
+        target: _blank
+kind: ConfigMap
+metadata:
+  name: dash-config
+  namespace: media

--- a/generated/manifests/prod-axon/dash/Deployment-dash.yaml
+++ b/generated/manifests/prod-axon/dash/Deployment-dash.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: dash
+    app.kubernetes.io/name: dash
+  name: dash
+  namespace: media
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/controller: main
+      app.kubernetes.io/instance: dash
+      app.kubernetes.io/name: dash
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/controller: main
+        app.kubernetes.io/instance: dash
+        app.kubernetes.io/name: dash
+    spec:
+      automountServiceAccountToken: true
+      containers:
+        - env:
+            - name: HOMEPAGE_ALLOWED_HOSTS
+              value: dash.json64.dev
+            - name: HOMEPAGE_VAR_LIDARR_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: lidarr
+                  name: media-arr-api-keys
+            - name: HOMEPAGE_VAR_RADARR_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: radarr
+                  name: media-arr-api-keys
+            - name: HOMEPAGE_VAR_SABNZBD_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: sabnzbd
+                  name: media-arr-api-keys
+            - name: HOMEPAGE_VAR_SONARR_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: sonarr
+                  name: media-arr-api-keys
+            - name: PGID
+              value: "65536"
+            - name: PUID
+              value: "1027"
+            - name: TZ
+              value: America/Los_Angeles
+          image: ghcr.io/gethomepage/homepage:v1.13.2
+          name: main
+          volumeMounts:
+            - mountPath: /app/config/bookmarks.yaml
+              name: config
+              readOnly: true
+              subPath: bookmarks.yaml
+            - mountPath: /app/config/kubernetes.yaml
+              name: config
+              readOnly: true
+              subPath: kubernetes.yaml
+            - mountPath: /app/config/services.yaml
+              name: config
+              readOnly: true
+              subPath: services.yaml
+            - mountPath: /app/config/settings.yaml
+              name: config
+              readOnly: true
+              subPath: settings.yaml
+            - mountPath: /app/config/widgets.yaml
+              name: config
+              readOnly: true
+              subPath: widgets.yaml
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      serviceAccountName: dash
+      volumes:
+        - configMap:
+            name: dash-config
+          name: config

--- a/generated/manifests/prod-axon/dash/HTTPRoute-dash.yaml
+++ b/generated/manifests/prod-axon/dash/HTTPRoute-dash.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: dash
+  namespace: media
+spec:
+  hostnames:
+    - dash.json64.dev
+  parentRefs:
+    - name: default-gateway
+      namespace: gateways
+      sectionName: json64-dev-https
+  rules:
+    - backendRefs:
+        - name: dash
+          port: 3000

--- a/generated/manifests/prod-axon/dash/SecurityPolicy-dash-oidc.yaml
+++ b/generated/manifests/prod-axon/dash/SecurityPolicy-dash-oidc.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: dash-oidc
+  namespace: media
+spec:
+  oidc:
+    clientID: dash
+    clientSecret:
+      name: dash-oidc-client-secret
+    forwardAccessToken: true
+    provider:
+      issuer: https://idm.json64.dev/oauth2/openid/dash
+    scopes:
+      - email
+      - openid
+      - profile
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: dash

--- a/generated/manifests/prod-axon/dash/Service-dash.yaml
+++ b/generated/manifests/prod-axon/dash/Service-dash.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: dash
+    app.kubernetes.io/name: dash
+    app.kubernetes.io/service: dash
+  name: dash
+  namespace: media
+spec:
+  ports:
+    - name: http
+      port: 3000
+      protocol: TCP
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: dash
+    app.kubernetes.io/name: dash
+  type: ClusterIP

--- a/generated/manifests/prod-axon/dash/ServiceAccount-dash.yaml
+++ b/generated/manifests/prod-axon/dash/ServiceAccount-dash.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: dash
+    app.kubernetes.io/name: dash
+  name: dash
+  namespace: media

--- a/generated/manifests/prod-axon/dash/SopsSecret-dash-oidc-client-secret.yaml
+++ b/generated/manifests/prod-axon/dash/SopsSecret-dash-oidc-client-secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: dash-oidc-client-secret
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: 08507fc65573594775d184a682be942e91ce6ad71837af4f25df14435c33f098
+spec:
+    secretTemplates:
+        - name: dash-oidc-client-secret
+          stringData:
+            client-secret: ENC[AES256_GCM,data:9zKYssKaorW12VEVVLA1pnYAfhvYHQTU3UZG7ZsPdGjpHVgHqndwXp4lkTpjL+HeFtbJCOYM7rOhfsCDyJVuBVBd6HvE0sXN,iv:DaRf1HhwlzDd4TEH6kfVF3MTb0llf9sIDHeYze8eeMY=,tag:NeJQkpWe9AKwI0MLjkf3nw==,type:str]
+          type: Opaque
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0SjlSY1FOb2RNVW80OUJL
+            RFVKa3FNSFJrVmNaVjFnQmk2RDdWTld2RUg4CjFobW1oajJObmlVNHdIbTQwbTN1
+            c0N4a1liYXd2amNTMSs2dmZCejRIMDgKLS0tIEhEdlkyMlN1TkNJYmt5VnZCMEZy
+            Z1hKMFlQMkpWN1NIODZrTjNTc2VQUVkKuq/HaC6g5Z9ucwLz+3Gzn9pi3qqw7FzF
+            oCrWKwbgf8Yc74ZpXoQWeCxiv4ChWQ4wuQ5Zb3+gD5LPUPRga/N8ZA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:44Z"
+    mac: ENC[AES256_GCM,data:leBJhza7lUmCE5hr9jAHo6CRpkYJIRD6MuIo34Oj6ar8ABRCqz/gMdFcXuy0E2VhMK8ekQ5vlWMWzEWCQCMEo5bYCH2mEjAkI7NnyYBFyzTovCAwDK0+zyAeDQMJe5xvyqGZ8rnJ2qU66cuswAgrA8rMSWWQyJ9e51Tbxwr8QrI=,iv:F+hARghPl54mxMkQxdFSeO3hxWhTUvM/KbKQL2gf1rg=,tag:pygpaLvLabdWG5NeNBd4zA==,type:str]
+    version: 3.13.1

--- a/generated/manifests/prod-axon/flaresolverr/CiliumNetworkPolicy-allow-dns-egress-flaresolverr.yaml
+++ b/generated/manifests/prod-axon/flaresolverr/CiliumNetworkPolicy-allow-dns-egress-flaresolverr.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-dns-egress-flaresolverr
+  namespace: media
+spec:
+  description: Allow flaresolverr to resolve via kube-dns.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: flaresolverr

--- a/generated/manifests/prod-axon/flaresolverr/CiliumNetworkPolicy-allow-internet-egress-flaresolverr.yaml
+++ b/generated/manifests/prod-axon/flaresolverr/CiliumNetworkPolicy-allow-internet-egress-flaresolverr.yaml
@@ -1,0 +1,19 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-internet-egress-flaresolverr
+  namespace: media
+spec:
+  description: Allow flaresolverr to reach the public internet.
+  egress:
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: flaresolverr

--- a/generated/manifests/prod-axon/flaresolverr/Deployment-flaresolverr.yaml
+++ b/generated/manifests/prod-axon/flaresolverr/Deployment-flaresolverr.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: flaresolverr
+    app.kubernetes.io/name: flaresolverr
+  name: flaresolverr
+  namespace: media
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/controller: main
+      app.kubernetes.io/instance: flaresolverr
+      app.kubernetes.io/name: flaresolverr
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/controller: main
+        app.kubernetes.io/instance: flaresolverr
+        app.kubernetes.io/name: flaresolverr
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: LOG_LEVEL
+              value: info
+            - name: PGID
+              value: "65536"
+            - name: PUID
+              value: "1027"
+            - name: TZ
+              value: America/Los_Angeles
+          image: ghcr.io/flaresolverr/flaresolverr:v3.5.0
+          name: main
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      serviceAccountName: flaresolverr

--- a/generated/manifests/prod-axon/flaresolverr/Service-flaresolverr.yaml
+++ b/generated/manifests/prod-axon/flaresolverr/Service-flaresolverr.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: flaresolverr
+    app.kubernetes.io/name: flaresolverr
+    app.kubernetes.io/service: flaresolverr
+  name: flaresolverr
+  namespace: media
+spec:
+  ports:
+    - name: http
+      port: 8191
+      protocol: TCP
+      targetPort: 8191
+  selector:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: flaresolverr
+    app.kubernetes.io/name: flaresolverr
+  type: ClusterIP

--- a/generated/manifests/prod-axon/flaresolverr/ServiceAccount-flaresolverr.yaml
+++ b/generated/manifests/prod-axon/flaresolverr/ServiceAccount-flaresolverr.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: flaresolverr
+    app.kubernetes.io/name: flaresolverr
+  name: flaresolverr
+  namespace: media

--- a/generated/manifests/prod-axon/glance/CiliumNetworkPolicy-allow-api-egress-glance.yaml
+++ b/generated/manifests/prod-axon/glance/CiliumNetworkPolicy-allow-api-egress-glance.yaml
@@ -1,0 +1,46 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-api-egress-glance
+  namespace: media
+spec:
+  description: Allow glance to reach the in-namespace media APIs it monitors.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: lidarr
+      toPorts:
+        - ports:
+            - port: "8686"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: radarr
+      toPorts:
+        - ports:
+            - port: "7878"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: sabnzbd
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: sonarr
+      toPorts:
+        - ports:
+            - port: "8989"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: whisparr
+      toPorts:
+        - ports:
+            - port: "6969"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: glance

--- a/generated/manifests/prod-axon/glance/CiliumNetworkPolicy-allow-dns-egress-glance.yaml
+++ b/generated/manifests/prod-axon/glance/CiliumNetworkPolicy-allow-dns-egress-glance.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-dns-egress-glance
+  namespace: media
+spec:
+  description: Allow glance to resolve via kube-dns.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: glance

--- a/generated/manifests/prod-axon/glance/CiliumNetworkPolicy-allow-gateway-ingress-glance.yaml
+++ b/generated/manifests/prod-axon/glance/CiliumNetworkPolicy-allow-gateway-ingress-glance.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-gateway-ingress-glance
+  namespace: media
+spec:
+  description: Allow Envoy Gateway proxies to reach glance.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: glance
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/generated/manifests/prod-axon/glance/CiliumNetworkPolicy-allow-internet-egress-glance.yaml
+++ b/generated/manifests/prod-axon/glance/CiliumNetworkPolicy-allow-internet-egress-glance.yaml
@@ -1,0 +1,19 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-internet-egress-glance
+  namespace: media
+spec:
+  description: Allow glance to reach the public internet.
+  egress:
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: glance

--- a/generated/manifests/prod-axon/glance/ConfigMap-glance.yaml
+++ b/generated/manifests/prod-axon/glance/ConfigMap-glance.yaml
@@ -1,0 +1,87 @@
+apiVersion: v1
+data:
+  glance.yml: |-
+    theme:
+      # Catppuccin Mocha
+      background-color: 240 21 15
+      contrast-multiplier: 1.2
+      primary-color: 217 92 83
+      positive-color: 115 54 76
+      negative-color: 347 70 65
+
+    pages:
+      - name: Home
+        columns:
+          - size: small
+            widgets:
+              - type: clock
+                hour-format: 12h
+              - type: calendar
+                first-day-of-week: monday
+          - size: full
+            widgets:
+              - type: rss
+                limit: 10
+                collapse-after: 3
+                cache: 12h
+                feeds:
+                  - url: https://selfh.st/rss/
+                    title: selfh.st
+
+      - name: Media
+        columns:
+          - size: full
+            widgets:
+              - type: monitor
+                cache: 1m
+                title: Media Services
+                sites:
+                  - title: Sonarr
+                    url: http://sonarr:8989/
+                    icon: si:sonarr
+                  - title: Radarr
+                    url: http://radarr:7878/
+                    icon: si:radarr
+                  - title: Lidarr
+                    url: http://lidarr:8686/
+                    icon: si:lidarr
+                  - title: Whisparr
+                    url: http://whisparr:6969/
+                    icon: si:w
+                  - title: SABnzbd
+                    url: http://sabnzbd:8080/
+                    icon: si:sabnzbd
+                  - title: Jellyfin
+                    url: https://jellyfin.json64.dev/
+                    icon: si:jellyfin
+          - size: small
+            widgets:
+              - type: bookmarks
+                groups:
+                  - title: Media UIs
+                    links:
+                      - title: Jellyfin
+                        url: https://jellyfin.json64.dev/
+                      - title: Sonarr
+                        url: https://sonarr.json64.dev/
+                      - title: Radarr
+                        url: https://radarr.json64.dev/
+                      - title: Lidarr
+                        url: https://lidarr.json64.dev/
+                      - title: Whisparr
+                        url: https://whisparr.json64.dev/
+                      - title: Prowlarr
+                        url: https://prowlarr.json64.dev/
+                      - title: Bazarr
+                        url: https://bazarr.json64.dev/
+                      - title: SABnzbd
+                        url: https://nzb.json64.dev/
+                      - title: qBittorrent
+                        url: https://torrent.json64.dev/
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: glance
+    app.kubernetes.io/name: glance
+  name: glance
+  namespace: media

--- a/generated/manifests/prod-axon/glance/Deployment-glance.yaml
+++ b/generated/manifests/prod-axon/glance/Deployment-glance.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: glance
+    app.kubernetes.io/name: glance
+  name: glance
+  namespace: media
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/controller: main
+      app.kubernetes.io/instance: glance
+      app.kubernetes.io/name: glance
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/configMaps: 232a76f086cfb2d497c1e12f8d2aabdbb3d35b6ad3cf877f679becd8c58a944d
+      labels:
+        app.kubernetes.io/controller: main
+        app.kubernetes.io/instance: glance
+        app.kubernetes.io/name: glance
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: PGID
+              value: "65536"
+            - name: PUID
+              value: "1027"
+            - name: TZ
+              value: America/Los_Angeles
+          image: glanceapp/glance:v0.8.5
+          name: main
+          volumeMounts:
+            - mountPath: /app/config/glance.yml
+              name: config
+              readOnly: true
+              subPath: glance.yml
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      serviceAccountName: glance
+      volumes:
+        - configMap:
+            name: glance
+          name: config

--- a/generated/manifests/prod-axon/glance/HTTPRoute-glance.yaml
+++ b/generated/manifests/prod-axon/glance/HTTPRoute-glance.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: glance
+  namespace: media
+spec:
+  hostnames:
+    - glance.json64.dev
+  parentRefs:
+    - name: default-gateway
+      namespace: gateways
+      sectionName: json64-dev-https
+  rules:
+    - backendRefs:
+        - name: glance
+          port: 8080

--- a/generated/manifests/prod-axon/glance/SecurityPolicy-glance-oidc.yaml
+++ b/generated/manifests/prod-axon/glance/SecurityPolicy-glance-oidc.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: glance-oidc
+  namespace: media
+spec:
+  oidc:
+    clientID: glance
+    clientSecret:
+      name: glance-oidc-client-secret
+    forwardAccessToken: true
+    provider:
+      issuer: https://idm.json64.dev/oauth2/openid/glance
+    scopes:
+      - email
+      - openid
+      - profile
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: glance

--- a/generated/manifests/prod-axon/glance/Service-glance.yaml
+++ b/generated/manifests/prod-axon/glance/Service-glance.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: glance
+    app.kubernetes.io/name: glance
+    app.kubernetes.io/service: glance
+  name: glance
+  namespace: media
+spec:
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: glance
+    app.kubernetes.io/name: glance
+  type: ClusterIP

--- a/generated/manifests/prod-axon/glance/ServiceAccount-glance.yaml
+++ b/generated/manifests/prod-axon/glance/ServiceAccount-glance.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: glance
+    app.kubernetes.io/name: glance
+  name: glance
+  namespace: media

--- a/generated/manifests/prod-axon/glance/SopsSecret-glance-oidc-client-secret.yaml
+++ b/generated/manifests/prod-axon/glance/SopsSecret-glance-oidc-client-secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: glance-oidc-client-secret
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: f5c983a39c91502eb95b5ee74c6bd9452b2d2f6a69bcd24b0caf1e7fc8feb51d
+spec:
+    secretTemplates:
+        - name: glance-oidc-client-secret
+          stringData:
+            client-secret: ENC[AES256_GCM,data:wP78mzGu581xh9ldLNisSCbtwHQmpzN0NnzCZ6DDtk6hb7FyvS7tdLAEBJWkS/897NjOy8mZtryvwyygjmFMzBypXnUYf5qL,iv:ijnrTav32Yya8kIjHv64Y5H2/AgFU+cp3CNG4blDKeI=,tag:mzVgorlARxH8CpKaSxOFQA==,type:str]
+          type: Opaque
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSYzZmd2hFS0kwenBFWFZn
+            TGRnUGhRZnJhbysrb2F6NDNHTUY5eS9yUVFrCmRqcXZtQ2R2KzRLWXFrSUhQbUtu
+            Ym12QXZrS2dYTVNIa0tUUDZ3SWJqQTgKLS0tIEZscmNpd3UwZTVVV2p2Y3RXdU5t
+            S2x6ZERuOTVkSDlnemYrclUyMGZqNGsK+dkAWruSiIJ7rTFUO+iqm5q8a6gJPgrZ
+            3tcm7z5/7zc2Aq5VFBD3HkN8gpJ6RenRq1jMj+WFrve0ttGMN1w2aw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:45Z"
+    mac: ENC[AES256_GCM,data:31Z7ikqdLwXoXBIiI/fptT9bxmuHzDwpjWrLLxeDdjdzW5ouG0WihHVOl20rhECW7I/NBC3vWLuKiPfWu976it3fr6A7roeloWoTXdjdFigVrEEhcatgzPt7tfQ8t9GfcWQVpUBnIL+0O2UYJB4KLk7v8PAOk75EjweW0RCF98g=,iv:RdoHthYwkGOcizQPFqPdFpJQCJhH7zr3d6+voKUMHew=,tag:Q8TlBfezzuU8i7o/anXfOQ==,type:str]
+    version: 3.13.1

--- a/generated/manifests/prod-axon/grafana/Deployment-grafana.yaml
+++ b/generated/manifests/prod-axon/grafana/Deployment-grafana.yaml
@@ -20,7 +20,7 @@ spec:
       annotations:
         checksum/config: 136f80ec3418f043afe65d5c9afeafab129e9d1c39453f1fafe9d3bb9d77897d
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
-        checksum/secret: 11b909e7f9b2742e766dc39f9766b95149e79c07f0a503a15d226d8fadfd36b7
+        checksum/secret: b3d4ed11f1f7f33ce690b5de19c246f0268fab4f0ba9cf0848224bd1cc6a0ed0
         kubectl.kubernetes.io/default-container: grafana
       labels:
         app.kubernetes.io/instance: grafana

--- a/generated/manifests/prod-axon/grafana/SopsSecret-grafana.yaml
+++ b/generated/manifests/prod-axon/grafana/SopsSecret-grafana.yaml
@@ -8,12 +8,12 @@ metadata:
     name: grafana
     namespace: monitoring
     annotations:
-        secrets.json64.dev/plaintext-sha256: 66522052b29752b098dfc01c397f68c639a0f10ce1b7a0aa1016083f38246b68
+        secrets.json64.dev/plaintext-sha256: 37081ca4c7e04fe4b26504b00ba3ce9643b11349283180bd8398c3a135027beb
 spec:
     secretTemplates:
         - data:
-            admin-password: ENC[AES256_GCM,data:Hr+eI95fCSr38ZxHh11YRWJzaK411MOXOuihkf2ouBFtWnuSVWzyvOQY1mSr7NT1J2EPKDtt6Ow=,iv:rSimrBIQQDbuLnBrRCJduuKla+1TQLkRuAnBwvekIpo=,tag:HEnMvUo3vlPmJ/lWAxk4rQ==,type:str]
-            admin-user: ENC[AES256_GCM,data:8BT2iCa/Dp0=,iv:/YYCYzHykPVxwJiHAEDc3fK2VNfwRKSiYQSOpeQE5kE=,tag:ZWIFQKtYsc0PdzUZBv+fDQ==,type:str]
+            admin-password: ENC[AES256_GCM,data:YeeDnD8977rHUDwcf+4jyPNutxqxAw4wun6EWVcq40wXr8ioYXfVH3LrQxGmBuRYJtcnRVJ0gG4=,iv:5/M/pEleRKyZpVOMOIaDughhZ2ejinyq3EN10yuh7nA=,tag:jmOp73E1WmtLLSIuS28+wA==,type:str]
+            admin-user: ENC[AES256_GCM,data:EA/KumKnZAU=,iv:Y6iWP1bRwAi6rtLniLy3163QPXcM6dew+SNB4Vbseok=,tag:FnYVMVqCJNSDwN6PiuNfAQ==,type:str]
             ldap-toml: ""
           name: grafana
           type: Opaque
@@ -21,14 +21,14 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMbERkblpuaTBqd2YwdDdn
-            Wk0rWXltalY1cHUxNThXYVZ3ME9CT1RrRmk0CkF1dWJHdWY2ZnpkcHBiK1R1WEk5
-            T09ZSHg1NDRtOWIxVzE0ZnVoQ2E0WHcKLS0tIEQyNWNLY3BYdENXZ0dFWnBoTlBD
-            bFE4V2RRWWhBZXQ3c2U1WjRiVFdWeHcKtpOMNB7Mk4KhCtZeBtpXLOKTxfzFpFbM
-            5BjFhQRmrlCFdXmvBBTKP8x8aTBPdaNuYi5SPB6hCbBPsN0tc1xpNQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKN3RFdFo4eDJlYXpxRG4r
+            VllSYTJpVzFjWWRiTnhZSjhvSmhPZEVpZGhvClpmd2ppa0V1RndYNzNjQjFRblV2
+            SlRUU0oyRjVBdjIzaDRJY08xUFZYa1EKLS0tIGVlT0JEaWlta3Vqa0w0eU9PaDdJ
+            NmoxVnNoY1czRzREMG1PUGhRYkV5L0EK1Jld1CcJqeXugD4zrKq8L/HQz62HCGqc
+            qJYz4BDdArOdDjAZOftAThYdzrawkm+AggWX7gKRV1LEi6MeYue2+A==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-06-09T19:45:20Z"
-    mac: ENC[AES256_GCM,data:R5nsVn9ZHlNPy2c0JdxofRK0uk5f7p/Em7JF1mvVzXhl3zMFRjOa5cPHv5Yvu9XUwbEiI7FmBvh5vfr03b+eZ79HyyVXQW1Tbm6TM77wXCkDRqgalo9hj6atfCRghkbrxR2MxehQPigBbxcGG6OjNEvc6h7iw9xYh2FYplX6nlI=,iv:j5i5mHAwTqoh7756HyQ3DxzCDvNOf2r4AKd5XF0K1QQ=,tag:Lk1inIWtGl6WBZ6jiSK1RQ==,type:str]
+    lastmodified: "2026-06-11T18:37:45Z"
+    mac: ENC[AES256_GCM,data:aZNChcBKu2mGBXf2+haGk9hfcMdN6xQw3kw/vxmRS2Esr8dRD/iy7yvTqssalmE7Y9fnJQwju2aUrd1jL4j7cSi7hzyQP9RcoK4q0EeaFfKRIsezd5a2sJ9hyaSsWiuJRVtVBSy7zeZXnqUOYg22OnAuyla5u+kc22qk7hFB4H8=,iv:pqPOczcVq6+FC9taQtGwKaaVVkF0cIoxcqL4WN3OTvw=,tag:w8aC9z6ItgSUE3GdTvpjoQ==,type:str]
     version: 3.13.1

--- a/generated/manifests/prod-axon/komga/CiliumNetworkPolicy-allow-dns-egress-komga.yaml
+++ b/generated/manifests/prod-axon/komga/CiliumNetworkPolicy-allow-dns-egress-komga.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-dns-egress-komga
+  namespace: media
+spec:
+  description: Allow komga to resolve via kube-dns.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: komga

--- a/generated/manifests/prod-axon/komga/CiliumNetworkPolicy-allow-gateway-ingress-komga.yaml
+++ b/generated/manifests/prod-axon/komga/CiliumNetworkPolicy-allow-gateway-ingress-komga.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-gateway-ingress-komga
+  namespace: media
+spec:
+  description: Allow Envoy Gateway proxies to reach komga.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: komga
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+      toPorts:
+        - ports:
+            - port: "25600"
+              protocol: TCP

--- a/generated/manifests/prod-axon/komga/Deployment-komga.yaml
+++ b/generated/manifests/prod-axon/komga/Deployment-komga.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: komga
+    app.kubernetes.io/name: komga
+  name: komga
+  namespace: media
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/controller: main
+      app.kubernetes.io/instance: komga
+      app.kubernetes.io/name: komga
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/controller: main
+        app.kubernetes.io/instance: komga
+        app.kubernetes.io/name: komga
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: PGID
+              value: "65536"
+            - name: PUID
+              value: "1027"
+            - name: TZ
+              value: America/Los_Angeles
+          image: ghcr.io/gotson/komga:1.24.4
+          name: main
+          volumeMounts:
+            - mountPath: /config
+              name: config
+            - mountPath: /data
+              name: data
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      serviceAccountName: komga
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: komga
+        - name: data
+          persistentVolumeClaim:
+            claimName: media-data-nfs

--- a/generated/manifests/prod-axon/komga/HTTPRoute-komga.yaml
+++ b/generated/manifests/prod-axon/komga/HTTPRoute-komga.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: komga
+  namespace: media
+spec:
+  hostnames:
+    - komga.json64.dev
+  parentRefs:
+    - name: default-gateway
+      namespace: gateways
+      sectionName: json64-dev-https
+  rules:
+    - backendRefs:
+        - name: komga
+          port: 25600

--- a/generated/manifests/prod-axon/komga/PersistentVolumeClaim-komga.yaml
+++ b/generated/manifests/prod-axon/komga/PersistentVolumeClaim-komga.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: komga
+    app.kubernetes.io/name: komga
+  name: komga
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: longhorn

--- a/generated/manifests/prod-axon/komga/SecurityPolicy-komga-oidc.yaml
+++ b/generated/manifests/prod-axon/komga/SecurityPolicy-komga-oidc.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: komga-oidc
+  namespace: media
+spec:
+  oidc:
+    clientID: komga
+    clientSecret:
+      name: komga-oidc-client-secret
+    forwardAccessToken: true
+    provider:
+      issuer: https://idm.json64.dev/oauth2/openid/komga
+    scopes:
+      - email
+      - openid
+      - profile
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: komga

--- a/generated/manifests/prod-axon/komga/Service-komga.yaml
+++ b/generated/manifests/prod-axon/komga/Service-komga.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: komga
+    app.kubernetes.io/name: komga
+    app.kubernetes.io/service: komga
+  name: komga
+  namespace: media
+spec:
+  ports:
+    - name: http
+      port: 25600
+      protocol: TCP
+      targetPort: 25600
+  selector:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: komga
+    app.kubernetes.io/name: komga
+  type: ClusterIP

--- a/generated/manifests/prod-axon/komga/ServiceAccount-komga.yaml
+++ b/generated/manifests/prod-axon/komga/ServiceAccount-komga.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: komga
+    app.kubernetes.io/name: komga
+  name: komga
+  namespace: media

--- a/generated/manifests/prod-axon/komga/SopsSecret-komga-oidc-client-secret.yaml
+++ b/generated/manifests/prod-axon/komga/SopsSecret-komga-oidc-client-secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: komga-oidc-client-secret
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: b6f2275ebb8d81ae47a075bd41224b550fa3443e2273032102e87318ede80c1b
+spec:
+    secretTemplates:
+        - name: komga-oidc-client-secret
+          stringData:
+            client-secret: ENC[AES256_GCM,data:6hJVFcEwhRm/Tg2+7f67Y3+gKMesru4atPvKN2Zg8YVHbSzd9jRE2YM8WjLS9jkUyege5O/t0RfJ1Sd0OzKGhM7kQbtRS4xz,iv:IGP8Y8j38aTME9zhVNHddoIcPPMAvOZFLBc9VBdvlQA=,tag:6Mjf6vyhDs1lYDfAOuURNA==,type:str]
+          type: Opaque
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnaHFJRk9QS2s0L3ZBaVEr
+            aWloYy9JNjhxVEMzSnhWQXdkMURJekdBMWlFCmU0WVZ4WnlRcktZdXBIcTBlMG50
+            czNMUHlCK0htd01FVmN2NnFYYjJ1dzQKLS0tIDFxUGQ1ekwycXQvVzgrbGd0NUJs
+            cG9XakJrREgyQ2drcEd5b0l2Z0kwNTQKkLbCAQz4CubNyga2AGSg/yIhem7e0VSM
+            Bx5nsRx6ri8q11JC0AYk2nPbhlgT5BtlKB5QKHbQhoTbAh4CqveYcg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:45Z"
+    mac: ENC[AES256_GCM,data:a9mmF0rQkLCXrSfsDTUjnpyL/qPdTfAET2oEDbLH40+Ag1P7QnsqQAHI+0WdY4S9E7I/iiXXDWJppkwqrOmw/WKLFyOluFncmngLAFJVO8Ii38/r2PWqu/ellapAdk/TT2uemgPX8XdZYuhxRf4T4uZh9xDYyEOPW6k8dZ7tzCc=,iv:TvtHVUkFGkpVaHMDNB8F8il9xr29jR45cEGzZnB0ExY=,tag:KFMRQslNvIx+ScIniHuZBQ==,type:str]
+    version: 3.13.1

--- a/generated/manifests/prod-axon/kube-prometheus-stack/SopsSecret-alertmanager-kube-prometheus-stack-alertmanager.yaml
+++ b/generated/manifests/prod-axon/kube-prometheus-stack/SopsSecret-alertmanager-kube-prometheus-stack-alertmanager.yaml
@@ -7,14 +7,14 @@ metadata:
     name: alertmanager-kube-prometheus-stack-alertmanager
     namespace: monitoring
     annotations:
-        secrets.json64.dev/plaintext-sha256: 525db2e32e48f11d4b684d2531d7d2902a7f9660354f125c53d83c30bd534ec8
+        secrets.json64.dev/plaintext-sha256: 9c148df3f6f4d05de589b2cd86014919db55d3a503fd40b3c81303b84b1b0568
 spec:
     secretTemplates:
         - data:
-            alertmanager.yaml: ENC[AES256_GCM,data:ty22Ghw2y9VmXH+qnZ8fS+bi75qQu2JNgdUCgxks9qCUHq7wZaxwQ8QobfbTKxXAJb7SkfqOPkwF0grKC8OKTz7rxzCUCuT847CDwbpAgPZmSNOVEWG+SLBgt6BijnF7GIZ/jkAGe0WcnF4lmf7+LQEs0cOZwKzsIewgXfW2zTmscdEmal/oDxkGnuMoIqFnrXSQkKARknhz2WwyTNKxgkYc3t3juoRMSmuJjTaeNxwE5H6TYpL91gbJ5Ev53RYkrsmNDAylXt7YL3SaL3Qj7GDtzLM6JmxkGn3Z07BbysWu5OutrqAKuZEfwz1fbLHBJ59Mw6UTa7pNEWiNS+m6Azdxc3q9zp7PlVZkuvNQJxzgrrGB+2RcuSzbV6ip8105jYwWR1iD4u2oLhyeiLZ5gIL885jePaiIJ6T5v4y7C8zYZQJW6UDNVvAMWOiwIe4EyCj1oUZ/8XCxGP6H20GU5Ot4FzErHweYnGtA0Jo5vuHMEaJ5kR9hjwErlMXEnwjiP4vmJqpETeQ1t48qWGAlpAy+pTpudfRoHE8HAGV4mTOqQmYm6cHFPCx7eBNE6veCGyqUZJCENoX+WZXI+vgvdxc/GsIM9HeUybJ7ldLrnH4Yy6x8YlsY/TCx/xrawPteDkpczdujaWZ9/6g0JHRucajQ+jxosFpa/KKs/ZRvurIvexb1LeBdFmMHUHYBcJVJ/KnzDugmLAGB5qZPvSXk28kV/c7fZAHdJPY5sCT+G/Vttx5vJtTYpjTRX7ORndnjHEGzxecNz1hCjXuh3xTbPOEcgVIABRBHX+Z/IL30hkxhVABsqppJrQm2YfIuMJpHKixAigARhuo7v4VDFwRMBnl7FiM8OpAJt0z6Rp8V+WLavuif7Wo4/EvUleyUtS4Z/hlMRVObsMTCj4KCgPg8K0jPf7KuT+L6QGzUoHxYrck131RzuJP9T6Ofsoanv2VoaqDnK+TjKq7JDTLmHxcoqznI4s4DTQMHFsvbhBnL3XEjo+kRf7nieKXxkkFgk6UayUXQJKc3EhS7NqVOkoFiOmQwLoW2ycUCyC1kWL41a31rwsBB1xNUtyA8nLwduNlj5HbmTIu1Ira9pcrHbjKnst8gRK9672T4PXh9nnUV1XODotZY+SFznUXjV163ltvGD2A78Pr55MWC9f1yLk6H3EpeQk3NMrHt3nqNUOLRjN+TNVv9AGYkIVCxBRvsWT+bq25SiGWjAzWn4whDb3p2GNOpyUNky6okShzwJxfVPCoisics,iv:rEB63AlCg6ltHOBxgItEVy2l/iOdJ0Ak1kW6L/+n/JM=,tag:mEPgVfIzm04s5ukExovmmw==,type:str]
+            alertmanager.yaml: ENC[AES256_GCM,data:DFgsN9SfTpZLPhkSkp91Ftkr9qq3JUuRgT9+9mQw2GavhRHUrTbElKQVx55lZgz0Um6ZPNQQqwYHAZIsIdV0maIk4lL7qdnt4sFzgmjduhLGsqAi2PZLDeQFirih9e+BuVZJ09mTVaVHJ9QE+lBpzbVtcqwj1ykwnJJI94jIyeko3ExIJrtlYbzSXlEbqtPL6YycJ0KTOklPqtVWEPY2dha4vxahx+ztvLMLPE1Ty0TUKF2sv2cztDNv1NmInOXjtW83KU3gCtzDtrW1yzDp9+6/jQiA4i1MONjNJxOgwMC/h1ssWyS1WEaFLytpfjgCxhhK1TwRaJr3DqUkzRTjazERxYXyscIwUJLBMFodrZFwhX8sj+0mXkC+9imaGXQEzDDvao1IU3Jj1ODRy2bvH0S+pPtm6EVJZKGHBUfZPR56m4J0i0nOdsBUeC7kkQq8zqi7dc3zCo0EcALQ/lJaz6J3FKUcX9pkC8qrTveHMvtZzby98M2WomOJMhQUR8Rjm7pwjizSHnHn1ScJjPuyTB6eGKKcONFYfO/gPPbOcQjm8SMfNv4DYidsr2t0XADbv1C5+YPpp4yJwaqitSrDstJzSWqSz8Q2TgOj6/FBND+lkBEAV0oGlWcIw67x+T8AUvAua6G78lBvKqF26RWVxOlFIk+oEiJNqkK4pqHRKD9MgH2rTXeZxAiBKEtDtQ+jltnxKqaLpB/y1Yo/tUSQK5VQisrlpZmBiUV/NykyZXYvNEb49OeodfKzvBVGRBxPHaL0AwNJCrySl969CmknQY2poPCJcyOrrffxGdfHe/7XwqM/T/ef8LtsqmvVqqLHhpI0skXU4EKbl0vXIg5CISlroH9+ZD50eMiN96GQj8hj97LvmJ07h86sufDhWejtWLB+RNtrcjDgOBz+dNzxBLzFARVhojL9kCxeAQw9J4bgWYm+wmswSHzzVmvwi21CGtQ8raeJfEtJY1g8VMHZjwAdZ5cbdDaH1o9Du30uaTDlEYkIlo7sJxj7s091Y7J5cBAomi9f96d7X/oSsFw+e58JpxJRF6udmVzkXz1Kkd5eOMsxrNT6ijhb1gBs+GTBBEH2FD8V80WqrcWgEV4ShvsxMobGuY5yq6a5lQu2q/G2HGziuhHDMu3Vd9P/Kq5UXeFzfRgrXzQRFTfMwAzLcmv/Qj9VUDq4H770GyuDmzjg3zNAmUJAJ/GxMcBN8xzTQxlk3Ue0w+mwE65uDy4CWWZfCDclqO3HSzO4VugRBzrE3IUJ,iv:Zs/ZFYcHnDpIF86fxNSOtYdCHaf18TDgFQdenOM448s=,tag:Jpr8C9gNNRYIYKzitWdYfg==,type:str]
           labels:
             app: kube-prometheus-stack-alertmanager
-            chart: kube-prometheus-stack-86.1.0
+            chart: kube-prometheus-stack-86.2.0
             heritage: Helm
             release: kube-prometheus-stack
           name: alertmanager-kube-prometheus-stack-alertmanager
@@ -22,14 +22,14 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwWjlRWW5sczQ1NExCMWwx
-            dVYwVzBUVFN6VmcrQ3Jlcmpid05TZjVhMFh3Cnk1dkhOQzBFcU13Z295anIxSUx5
-            b2hNTWQ3TVJtZzhxSnIxdm91VmtCZXcKLS0tIGhyVDd4Q2FxT1JNVUloY01Nd0pr
-            SHhLeDRhQS9ma254eW9TMzVjRkd5ODQKosgiVy+z2Lm70XddKsmxZvQcTInkTB7L
-            a8BqSE+1r552akcj+BnC39064HfS5vTcr0ZRpkrUGtLMFr3NIgESoA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiUVlTWEpLN2kvYklVbVZt
+            MlVXdlh4SXFuSE5ZQ2JBRVJLUzczS29pS0hZCjR3TzlzSmUzcHRFMEg4bGZKdTRZ
+            VGE2aDlSVlExYk1ud014WnRGYlpMekkKLS0tIHQvRGxXWFNFc3g0endhSkV6cXU4
+            SnFVbWFDbytBNjhLVGFyQzRHRDRwMzgK/HBDu9YAB1+XuLTGprw4zmmIcbYdR+Je
+            7r2esUbMUJj1C0z7jAvG/p1h8IKd/omcteFtYe5I96D2i60sapQxkg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-06-09T19:45:20Z"
-    mac: ENC[AES256_GCM,data:hbzCPMc7W1A/1UAj0uayI/xYFwvAqXqGrWoYv08VOxLym10PdD4BPag8vM9sHDV9rnLFghvpEKS+2Hf5IPxaLzo7LuU/UAwljILPhyOxulehDcN4KbizTmkvhRSLn9qTfy8U/vmg2+9FlJYhQvzphF5gpB8HWL+UK21GaBrnIbg=,iv:mFbjs/RRLWioeqbuDhDnfEgqxGh0oDkprqSF/HJ37WM=,tag:vQ55D7COjw6csZDFwgpO2g==,type:str]
+    lastmodified: "2026-06-11T18:37:45Z"
+    mac: ENC[AES256_GCM,data:PKTJAvsz2v1gXiTwHRXas536RrWur1EBBRE6jFsaBpoNvb16r29YZ+EqtAvfEvTmtE5xFePzbKrkfTz9YSWzXtc8JwSqDnPJXysBUYOJB3koD7bXTKS9moNG4vNDgXV8h1mKYvhekNcCgJorHuxSvpkyEr7fi1IEh+YdNfgVG8c=,iv:nJXoJ01hS4vUBeMsgeCTgu3dTwXjADCRhPcvn6id0t4=,tag:w+PGIjtGO16YQntXLrVgRg==,type:str]
     version: 3.13.1

--- a/generated/manifests/prod-axon/lidarr/CiliumNetworkPolicy-allow-dns-egress-lidarr.yaml
+++ b/generated/manifests/prod-axon/lidarr/CiliumNetworkPolicy-allow-dns-egress-lidarr.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-dns-egress-lidarr
+  namespace: media
+spec:
+  description: Allow lidarr to resolve via kube-dns.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: lidarr

--- a/generated/manifests/prod-axon/lidarr/CiliumNetworkPolicy-allow-gateway-ingress-lidarr.yaml
+++ b/generated/manifests/prod-axon/lidarr/CiliumNetworkPolicy-allow-gateway-ingress-lidarr.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-gateway-ingress-lidarr
+  namespace: media
+spec:
+  description: Allow Envoy Gateway proxies to reach lidarr.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: lidarr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+      toPorts:
+        - ports:
+            - port: "8686"
+              protocol: TCP

--- a/generated/manifests/prod-axon/lidarr/CiliumNetworkPolicy-allow-postgres-egress-lidarr.yaml
+++ b/generated/manifests/prod-axon/lidarr/CiliumNetworkPolicy-allow-postgres-egress-lidarr.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-postgres-egress-lidarr
+  namespace: media
+spec:
+  description: Allow lidarr to reach the media-pg CNPG cluster.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/cluster: media-pg
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: lidarr

--- a/generated/manifests/prod-axon/lidarr/Deployment-lidarr.yaml
+++ b/generated/manifests/prod-axon/lidarr/Deployment-lidarr.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: lidarr
+    app.kubernetes.io/name: lidarr
+  name: lidarr
+  namespace: media
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/controller: main
+      app.kubernetes.io/instance: lidarr
+      app.kubernetes.io/name: lidarr
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/controller: main
+        app.kubernetes.io/instance: lidarr
+        app.kubernetes.io/name: lidarr
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: LIDARR__AUTH__APIKEY
+              valueFrom:
+                secretKeyRef:
+                  key: lidarr
+                  name: media-arr-api-keys
+            - name: LIDARR__AUTH__METHOD
+              value: External
+            - name: LIDARR__POSTGRES__HOST
+              value: media-pg-rw
+            - name: LIDARR__POSTGRES__LOGDB
+              value: lidarr-log
+            - name: LIDARR__POSTGRES__MAINDB
+              value: lidarr-main
+            - name: LIDARR__POSTGRES__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: media-pg-lidarr-password
+            - name: LIDARR__POSTGRES__PORT
+              value: "5432"
+            - name: LIDARR__POSTGRES__USER
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: media-pg-lidarr-password
+            - name: PGID
+              value: "65536"
+            - name: PUID
+              value: "1027"
+            - name: TZ
+              value: America/Los_Angeles
+          image: lscr.io/linuxserver/lidarr:3.1.0
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ping
+              port: 8686
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          name: main
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ping
+              port: 8686
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /config
+              name: config
+            - mountPath: /data
+              name: data
+            - mountPath: /scratch
+              name: scratch
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      serviceAccountName: lidarr
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: lidarr
+        - name: data
+          persistentVolumeClaim:
+            claimName: media-data-nfs
+        - name: scratch
+          persistentVolumeClaim:
+            claimName: media-scratch-nfs

--- a/generated/manifests/prod-axon/lidarr/HTTPRoute-lidarr.yaml
+++ b/generated/manifests/prod-axon/lidarr/HTTPRoute-lidarr.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: lidarr
+  namespace: media
+spec:
+  hostnames:
+    - lidarr.json64.dev
+  parentRefs:
+    - name: default-gateway
+      namespace: gateways
+      sectionName: json64-dev-https
+  rules:
+    - backendRefs:
+        - name: lidarr
+          port: 8686

--- a/generated/manifests/prod-axon/lidarr/PersistentVolumeClaim-lidarr.yaml
+++ b/generated/manifests/prod-axon/lidarr/PersistentVolumeClaim-lidarr.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: lidarr
+    app.kubernetes.io/name: lidarr
+  name: lidarr
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: longhorn

--- a/generated/manifests/prod-axon/lidarr/SecurityPolicy-lidarr-oidc.yaml
+++ b/generated/manifests/prod-axon/lidarr/SecurityPolicy-lidarr-oidc.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: lidarr-oidc
+  namespace: media
+spec:
+  oidc:
+    clientID: lidarr
+    clientSecret:
+      name: lidarr-oidc-client-secret
+    forwardAccessToken: true
+    provider:
+      issuer: https://idm.json64.dev/oauth2/openid/lidarr
+    scopes:
+      - email
+      - openid
+      - profile
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: lidarr

--- a/generated/manifests/prod-axon/lidarr/Service-lidarr.yaml
+++ b/generated/manifests/prod-axon/lidarr/Service-lidarr.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: lidarr
+    app.kubernetes.io/name: lidarr
+    app.kubernetes.io/service: lidarr
+  name: lidarr
+  namespace: media
+spec:
+  ports:
+    - name: http
+      port: 8686
+      protocol: TCP
+      targetPort: 8686
+  selector:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: lidarr
+    app.kubernetes.io/name: lidarr
+  type: ClusterIP

--- a/generated/manifests/prod-axon/lidarr/ServiceAccount-lidarr.yaml
+++ b/generated/manifests/prod-axon/lidarr/ServiceAccount-lidarr.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: lidarr
+    app.kubernetes.io/name: lidarr
+  name: lidarr
+  namespace: media

--- a/generated/manifests/prod-axon/lidarr/SopsSecret-lidarr-oidc-client-secret.yaml
+++ b/generated/manifests/prod-axon/lidarr/SopsSecret-lidarr-oidc-client-secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: lidarr-oidc-client-secret
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: 5ba0e0f71261a7b821daf700e372ba9c7327d896b8deb5f06c8257f522ddbf55
+spec:
+    secretTemplates:
+        - name: lidarr-oidc-client-secret
+          stringData:
+            client-secret: ENC[AES256_GCM,data:o8nKK936cmUhZsErcQARUWKsYsYoFon3fbe18HLotcnAuIE5cLmoI+jQ0U544gFxEv4NOfULMXXM4cGIuBWM7OoHYbuCLeJo,iv:QuVYrRfQKbQ2hvGfqBdlec0ndYEaH079B0H4pn1AgkE=,tag:85iVdu3NRBJy8AGQjZJVpQ==,type:str]
+          type: Opaque
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBicVo2dGlNZkNiYmExQjF5
+            T29PU2ZGalRlZkR2dEtIbDBsaXlXdUp6dVNZCjNJem1PQmVvbjJRd0l1dDFqUFM3
+            TGVMUXAyVW5oMUljWWZXaklhbXV3TjQKLS0tIC9iMG1ySFFaRG53Q2J4VENyRGVI
+            dlNWWFd4U2s5OFZBbE1pS21KUm9Wb00KxOP0mDEQm3SsOGh8JOH86L5fcS4H/r1r
+            mqz1S0jwENUJflcg6qhkMF0jkD0dWCqIetVtkt0JSjA6AjeKPIb+EA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:45Z"
+    mac: ENC[AES256_GCM,data:aRvPfnno7eGE30iuD9nwx13NZBigdbDBbmIjeBVojMzVjnBuSkvWxatR7EbO/AuL6ZfQgyhWruMy5yLQ0/L32ioLp8GfKJbDiIWrNtUN4V3iHKKpgeC8MM7o/2e/ctmPkjLUEyqrx8qcqDLjSUbsygrqRpEK8cy97x7oV70L71c=,iv:7bQzBSOz/G2/Y20j8zFsrvvUou5L4eQtByX4KxWax/A=,tag:Nx5yDUgSB6/EBX1TVd9AfQ==,type:str]
+    version: 3.13.1

--- a/generated/manifests/prod-axon/media-base/PersistentVolume-media-data-nfs.yaml
+++ b/generated/manifests/prod-axon/media-base/PersistentVolume-media-data-nfs.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
+  name: media-data-nfs
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: 1Ti
+  claimRef:
+    name: media-data-nfs
+    namespace: media
+  mountOptions:
+    - nfsvers=4.1
+    - noatime
+  nfs:
+    path: /volume2/data
+    server: 10.10.10.10
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""

--- a/generated/manifests/prod-axon/media-base/PersistentVolume-media-scratch-local.yaml
+++ b/generated/manifests/prod-axon/media-base/PersistentVolume-media-scratch-local.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
+  name: media-scratch-local
+spec:
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 800Gi
+  claimRef:
+    name: media-scratch-local
+    namespace: media
+  local:
+    path: /cache/media-scratch
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - axon-01
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-scratch

--- a/generated/manifests/prod-axon/media-base/PersistentVolume-media-scratch-nfs.yaml
+++ b/generated/manifests/prod-axon/media-base/PersistentVolume-media-scratch-nfs.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
+  name: media-scratch-nfs
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: 800Gi
+  claimRef:
+    name: media-scratch-nfs
+    namespace: media
+  mountOptions:
+    - nfsvers=4.1
+    - noatime
+    - soft
+    - timeo=50
+  nfs:
+    path: /cache/media-scratch
+    server: 10.10.10.2
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""

--- a/generated/manifests/prod-axon/media-base/PersistentVolumeClaim-media-data-nfs.yaml
+++ b/generated/manifests/prod-axon/media-base/PersistentVolumeClaim-media-data-nfs.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
+  name: media-data-nfs
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Ti
+  storageClassName: ""
+  volumeName: media-data-nfs

--- a/generated/manifests/prod-axon/media-base/PersistentVolumeClaim-media-scratch-local.yaml
+++ b/generated/manifests/prod-axon/media-base/PersistentVolumeClaim-media-scratch-local.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
+  name: media-scratch-local
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 800Gi
+  storageClassName: local-scratch
+  volumeName: media-scratch-local

--- a/generated/manifests/prod-axon/media-base/PersistentVolumeClaim-media-scratch-nfs.yaml
+++ b/generated/manifests/prod-axon/media-base/PersistentVolumeClaim-media-scratch-nfs.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
+  name: media-scratch-nfs
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 800Gi
+  storageClassName: ""
+  volumeName: media-scratch-nfs

--- a/generated/manifests/prod-axon/media-base/StorageClass-local-scratch.yaml
+++ b/generated/manifests/prod-axon/media-base/StorageClass-local-scratch.yaml
@@ -1,0 +1,6 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-scratch
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer

--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-egress-bazarr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-egress-bazarr.yaml
@@ -1,0 +1,25 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-media-egress-bazarr
+  namespace: media
+spec:
+  description: Allow bazarr to reach its in-namespace media targets.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: sonarr
+      toPorts:
+        - ports:
+            - port: "8989"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: radarr
+      toPorts:
+        - ports:
+            - port: "7878"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: bazarr

--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-egress-lidarr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-egress-lidarr.yaml
@@ -1,0 +1,32 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-media-egress-lidarr
+  namespace: media
+spec:
+  description: Allow lidarr to reach its in-namespace media targets.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: prowlarr
+      toPorts:
+        - ports:
+            - port: "9696"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: sabnzbd
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: qbittorrent
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: lidarr

--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-egress-prowlarr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-egress-prowlarr.yaml
@@ -1,0 +1,46 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-media-egress-prowlarr
+  namespace: media
+spec:
+  description: Allow prowlarr to reach its in-namespace media targets.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: sonarr
+      toPorts:
+        - ports:
+            - port: "8989"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: radarr
+      toPorts:
+        - ports:
+            - port: "7878"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: lidarr
+      toPorts:
+        - ports:
+            - port: "8686"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: whisparr
+      toPorts:
+        - ports:
+            - port: "6969"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: flaresolverr
+      toPorts:
+        - ports:
+            - port: "8191"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: prowlarr

--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-egress-radarr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-egress-radarr.yaml
@@ -1,0 +1,32 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-media-egress-radarr
+  namespace: media
+spec:
+  description: Allow radarr to reach its in-namespace media targets.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: prowlarr
+      toPorts:
+        - ports:
+            - port: "9696"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: sabnzbd
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: qbittorrent
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: radarr

--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-egress-sonarr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-egress-sonarr.yaml
@@ -1,0 +1,32 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-media-egress-sonarr
+  namespace: media
+spec:
+  description: Allow sonarr to reach its in-namespace media targets.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: prowlarr
+      toPorts:
+        - ports:
+            - port: "9696"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: sabnzbd
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: qbittorrent
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sonarr

--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-egress-whisparr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-egress-whisparr.yaml
@@ -1,0 +1,32 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-media-egress-whisparr
+  namespace: media
+spec:
+  description: Allow whisparr to reach its in-namespace media targets.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: prowlarr
+      toPorts:
+        - ports:
+            - port: "9696"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: sabnzbd
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: qbittorrent
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: whisparr

--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-flaresolverr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-flaresolverr.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-media-ingress-flaresolverr
+  namespace: media
+spec:
+  description: Allow in-namespace callers to reach flaresolverr:8191.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: flaresolverr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: prowlarr
+      toPorts:
+        - ports:
+            - port: "8191"
+              protocol: TCP

--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-lidarr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-lidarr.yaml
@@ -1,0 +1,22 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-media-ingress-lidarr
+  namespace: media
+spec:
+  description: Allow in-namespace callers + dashboards to reach lidarr:8686.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: lidarr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: prowlarr
+        - matchLabels:
+            app.kubernetes.io/name: glance
+        - matchLabels:
+            app.kubernetes.io/name: dash
+      toPorts:
+        - ports:
+            - port: "8686"
+              protocol: TCP

--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-prowlarr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-prowlarr.yaml
@@ -1,0 +1,24 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-media-ingress-prowlarr
+  namespace: media
+spec:
+  description: Allow in-namespace callers to reach prowlarr:9696.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: prowlarr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: sonarr
+        - matchLabels:
+            app.kubernetes.io/name: radarr
+        - matchLabels:
+            app.kubernetes.io/name: lidarr
+        - matchLabels:
+            app.kubernetes.io/name: whisparr
+      toPorts:
+        - ports:
+            - port: "9696"
+              protocol: TCP

--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-radarr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-radarr.yaml
@@ -1,0 +1,24 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-media-ingress-radarr
+  namespace: media
+spec:
+  description: Allow in-namespace callers + dashboards to reach radarr:7878.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: radarr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: prowlarr
+        - matchLabels:
+            app.kubernetes.io/name: bazarr
+        - matchLabels:
+            app.kubernetes.io/name: glance
+        - matchLabels:
+            app.kubernetes.io/name: dash
+      toPorts:
+        - ports:
+            - port: "7878"
+              protocol: TCP

--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-sabnzbd.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-sabnzbd.yaml
@@ -1,0 +1,28 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-media-ingress-sabnzbd
+  namespace: media
+spec:
+  description: Allow in-namespace callers + dashboards to reach sabnzbd:8080.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sabnzbd
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: sonarr
+        - matchLabels:
+            app.kubernetes.io/name: radarr
+        - matchLabels:
+            app.kubernetes.io/name: lidarr
+        - matchLabels:
+            app.kubernetes.io/name: whisparr
+        - matchLabels:
+            app.kubernetes.io/name: glance
+        - matchLabels:
+            app.kubernetes.io/name: dash
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-sonarr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-sonarr.yaml
@@ -1,0 +1,24 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-media-ingress-sonarr
+  namespace: media
+spec:
+  description: Allow in-namespace callers + dashboards to reach sonarr:8989.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sonarr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: prowlarr
+        - matchLabels:
+            app.kubernetes.io/name: bazarr
+        - matchLabels:
+            app.kubernetes.io/name: glance
+        - matchLabels:
+            app.kubernetes.io/name: dash
+      toPorts:
+        - ports:
+            - port: "8989"
+              protocol: TCP

--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-whisparr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-whisparr.yaml
@@ -1,0 +1,22 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-media-ingress-whisparr
+  namespace: media
+spec:
+  description: Allow in-namespace callers + dashboards to reach whisparr:6969.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: whisparr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: prowlarr
+        - matchLabels:
+            app.kubernetes.io/name: glance
+        - matchLabels:
+            app.kubernetes.io/name: dash
+      toPorts:
+        - ports:
+            - port: "6969"
+              protocol: TCP

--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-pg-internal.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-pg-internal.yaml
@@ -1,0 +1,34 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-media-pg-internal
+  namespace: media
+spec:
+  description: 'media-pg ingress: app clients (5432), peer replication (5432/8000), CNPG operator status (8000).'
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: media-pg
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: media
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            cnpg.io/cluster: media-pg
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+            - port: "8000"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: cnpg-system
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP

--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-deny-media-ingress-configarr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-deny-media-ingress-configarr.yaml
@@ -1,0 +1,12 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: deny-media-ingress-configarr
+  namespace: media
+spec:
+  description: Default-deny all ingress to configarr (no inbound callers).
+  enableDefaultDeny:
+    ingress: true
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: configarr

--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-deny-media-ingress-unpackerr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-deny-media-ingress-unpackerr.yaml
@@ -1,0 +1,12 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: deny-media-ingress-unpackerr
+  namespace: media
+spec:
+  description: Default-deny all ingress to unpackerr (no inbound callers).
+  enableDefaultDeny:
+    ingress: true
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: unpackerr

--- a/generated/manifests/prod-axon/media-pg/CiliumNetworkPolicy-allow-media-pg-apiserver-egress.yaml
+++ b/generated/manifests/prod-axon/media-pg/CiliumNetworkPolicy-allow-media-pg-apiserver-egress.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: allow-media-pg-apiserver-egress
+  namespace: media
+spec:
+  description: Allow media-pg CNPG instance pods to talk to kube-apiserver.
+  egress:
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "6443"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: media-pg

--- a/generated/manifests/prod-axon/media-pg/Cluster-media-pg.yaml
+++ b/generated/manifests/prod-axon/media-pg/Cluster-media-pg.yaml
@@ -1,0 +1,45 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: media-pg
+  namespace: media
+spec:
+  affinity:
+    podAntiAffinityType: required
+  backup:
+    volumeSnapshot:
+      className: longhorn-snapshot
+  instances: 2
+  managed:
+    roles:
+      - login: true
+        name: sonarr
+        passwordSecret:
+          name: media-pg-sonarr-password
+      - login: true
+        name: radarr
+        passwordSecret:
+          name: media-pg-radarr-password
+      - login: true
+        name: lidarr
+        passwordSecret:
+          name: media-pg-lidarr-password
+      - login: true
+        name: whisparr
+        passwordSecret:
+          name: media-pg-whisparr-password
+      - login: true
+        name: prowlarr
+        passwordSecret:
+          name: media-pg-prowlarr-password
+      - login: true
+        name: bazarr
+        passwordSecret:
+          name: media-pg-bazarr-password
+      - login: true
+        name: romm
+        passwordSecret:
+          name: media-pg-romm-password
+  storage:
+    size: 20Gi
+    storageClass: longhorn-single

--- a/generated/manifests/prod-axon/media-pg/Database-bazarr.yaml
+++ b/generated/manifests/prod-axon/media-pg/Database-bazarr.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: bazarr
+  namespace: media
+spec:
+  cluster:
+    name: media-pg
+  name: bazarr
+  owner: bazarr

--- a/generated/manifests/prod-axon/media-pg/Database-lidarr-log.yaml
+++ b/generated/manifests/prod-axon/media-pg/Database-lidarr-log.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: lidarr-log
+  namespace: media
+spec:
+  cluster:
+    name: media-pg
+  name: lidarr-log
+  owner: lidarr

--- a/generated/manifests/prod-axon/media-pg/Database-lidarr-main.yaml
+++ b/generated/manifests/prod-axon/media-pg/Database-lidarr-main.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: lidarr-main
+  namespace: media
+spec:
+  cluster:
+    name: media-pg
+  name: lidarr-main
+  owner: lidarr

--- a/generated/manifests/prod-axon/media-pg/Database-prowlarr-log.yaml
+++ b/generated/manifests/prod-axon/media-pg/Database-prowlarr-log.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: prowlarr-log
+  namespace: media
+spec:
+  cluster:
+    name: media-pg
+  name: prowlarr-log
+  owner: prowlarr

--- a/generated/manifests/prod-axon/media-pg/Database-prowlarr-main.yaml
+++ b/generated/manifests/prod-axon/media-pg/Database-prowlarr-main.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: prowlarr-main
+  namespace: media
+spec:
+  cluster:
+    name: media-pg
+  name: prowlarr-main
+  owner: prowlarr

--- a/generated/manifests/prod-axon/media-pg/Database-radarr-log.yaml
+++ b/generated/manifests/prod-axon/media-pg/Database-radarr-log.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: radarr-log
+  namespace: media
+spec:
+  cluster:
+    name: media-pg
+  name: radarr-log
+  owner: radarr

--- a/generated/manifests/prod-axon/media-pg/Database-radarr-main.yaml
+++ b/generated/manifests/prod-axon/media-pg/Database-radarr-main.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: radarr-main
+  namespace: media
+spec:
+  cluster:
+    name: media-pg
+  name: radarr-main
+  owner: radarr

--- a/generated/manifests/prod-axon/media-pg/Database-romm.yaml
+++ b/generated/manifests/prod-axon/media-pg/Database-romm.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: romm
+  namespace: media
+spec:
+  cluster:
+    name: media-pg
+  name: romm
+  owner: romm

--- a/generated/manifests/prod-axon/media-pg/Database-sonarr-log.yaml
+++ b/generated/manifests/prod-axon/media-pg/Database-sonarr-log.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: sonarr-log
+  namespace: media
+spec:
+  cluster:
+    name: media-pg
+  name: sonarr-log
+  owner: sonarr

--- a/generated/manifests/prod-axon/media-pg/Database-sonarr-main.yaml
+++ b/generated/manifests/prod-axon/media-pg/Database-sonarr-main.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: sonarr-main
+  namespace: media
+spec:
+  cluster:
+    name: media-pg
+  name: sonarr-main
+  owner: sonarr

--- a/generated/manifests/prod-axon/media-pg/Database-whisparr-log.yaml
+++ b/generated/manifests/prod-axon/media-pg/Database-whisparr-log.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: whisparr-log
+  namespace: media
+spec:
+  cluster:
+    name: media-pg
+  name: whisparr-log
+  owner: whisparr

--- a/generated/manifests/prod-axon/media-pg/Database-whisparr-main.yaml
+++ b/generated/manifests/prod-axon/media-pg/Database-whisparr-main.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: whisparr-main
+  namespace: media
+spec:
+  cluster:
+    name: media-pg
+  name: whisparr-main
+  owner: whisparr

--- a/generated/manifests/prod-axon/media-pg/ScheduledBackup-media-pg-nightly.yaml
+++ b/generated/manifests/prod-axon/media-pg/ScheduledBackup-media-pg-nightly.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: media-pg-nightly
+  namespace: media
+spec:
+  cluster:
+    name: media-pg
+  method: volumeSnapshot
+  schedule: 0 0 4 * * *

--- a/generated/manifests/prod-axon/media-pg/SopsSecret-media-pg-bazarr-password.yaml
+++ b/generated/manifests/prod-axon/media-pg/SopsSecret-media-pg-bazarr-password.yaml
@@ -1,0 +1,29 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: media-pg-bazarr-password
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: 90122c87f44e96ac641f042d6f50175526344e5402440cc0fb3213ac778ceae0
+spec:
+    secretTemplates:
+        - name: media-pg-bazarr-password
+          stringData:
+            password: ENC[AES256_GCM,data:y9ztlvQznHsZFIXPU9LiJnrD3HSQe2SGkoKyl3s905N43WNVZk/QDkhHoIWua8hIqz45hoJkm+hqcddGW6wvyrecvn5i+ZAn,iv:rRIAajD0EE30hDxKMb1D+qEGAZWuuNWD3w29BKXhYwQ=,tag:8ML0836anoVagHmESTSIpg==,type:str]
+            username: ENC[AES256_GCM,data:lGkmoRCT,iv:EPDlD5F5kg6f5u32uI6APMQvmq9SDiuE9B2YexspjLg=,tag:539kibOFz69jGvyqbr09Aw==,type:str]
+          type: kubernetes.io/basic-auth
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBU1NTc3JMRnM2K3p1UnFV
+            VDJxSXNjbTNkMzQ2Q2Y1ODhNUjEySFZjc0VVCjNWQ0N1SGpERGtuOGdmMFlFUDZ4
+            ckJ2V0UwNy92a1BzU0hmellNSUs5ZE0KLS0tIFpoN2loZFN1TnF5YXBKRGM4ZDE4
+            eHBxd2RxYVE3b2Nva3huUm50MkF6YzQKaerdqukEta0mHLXMUYDXgeSKvxYWkwuq
+            Sz8epZzGvYhmCnsj0THJRwMbwOOL0/DjzB+zS6ABtcI1AQLtiQB8UQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:45Z"
+    mac: ENC[AES256_GCM,data:YsNjPWpbVt75Tm85c+ffoq413lJuqx29JqDjXPFgw+S95c3i/FWjjPYzurlHkv11OL0li2PKucbfKw3btE8jB/hy1g/lbvVQeqWqE9Rb6/U4CajpC5lGSHYvBhvnLNgHXPA/u3EwoWWLprx1uwLA4HuFJABI7qrhJeXdulsSJHQ=,iv:Z5UCjAoVmLvu43YpVI6cahStFBW9ER7kYGPhLFvXrJA=,tag:rNEJpPDAwLSoDLLGLnKPpQ==,type:str]
+    version: 3.13.1

--- a/generated/manifests/prod-axon/media-pg/SopsSecret-media-pg-lidarr-password.yaml
+++ b/generated/manifests/prod-axon/media-pg/SopsSecret-media-pg-lidarr-password.yaml
@@ -1,0 +1,29 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: media-pg-lidarr-password
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: 3f60a28e70f90dc7b0968ad335cdecf97a619a79c1a1a54117decac9705fef98
+spec:
+    secretTemplates:
+        - name: media-pg-lidarr-password
+          stringData:
+            password: ENC[AES256_GCM,data:JGrJ67Wm1y8ET9CgCnXmp2GHP8m9ift9qu8DSx2Zt40K4D12C4YsLuS8PXzczP69lkqCOEuDWkXWzyWwCvsfYgU/j8g5rVlK,iv:c1qT8Jn2xQWD1hrnESHFlNf2Os+51SuhI0/tp4svQcg=,tag:e5UgIVa+uQBkeMHpxLmLRQ==,type:str]
+            username: ENC[AES256_GCM,data:RUr8nAUQ,iv:r376G/FMBgmgiZhgnv0kWY7JkaQTSW+aFBcu3GVVB2s=,tag:i7b/f9nF4I5OvmUXwFEBjA==,type:str]
+          type: kubernetes.io/basic-auth
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPVjZMTU10SGpBLytWU2pH
+            c2tRVDRsZVVIenNsLzVJaXc3T1ArZ0VlbjNZClJnUzNXdkRJSzNwaGN1ODdjWlpT
+            VW0rNUFBQW1OWEpPcUZlYUc0U1NoWlEKLS0tIHh0Tzk1VE5FWjBscm5QTUU4ZWI2
+            T1N3ckhtRmV4bU5NSEtuODE1Ry9pTUkK4XD3zRCeYWJUz9Uc/JWNY3niDAcqSmWs
+            bG5rkx4HCXD6eCfOfR2I+y7qwmFoQ7FMvJIYpxgsKByZ/EBiez67kg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:45Z"
+    mac: ENC[AES256_GCM,data:knjcVqd6ZAo/tgqKaiGm//KTucnOtJ04fI1iQdIy6FJfp0YnuoC7Zmew5gxm5pyLBuhsgrlN1NO/wmGTUl6HjtWPSrdPpHheNsajk1Rqlhe01C+LcrMPF30925XoubOonYFI5VUjaYOl9tkWvVqZeeCg5ddN/KuBMjHSFQWeKGA=,iv:vic2EFj8qkX2MUnLkx4gqp6946bxNMEBq3i76mxpDS4=,tag:WLoA4S+KKNRMWoIZZTrN2Q==,type:str]
+    version: 3.13.1

--- a/generated/manifests/prod-axon/media-pg/SopsSecret-media-pg-prowlarr-password.yaml
+++ b/generated/manifests/prod-axon/media-pg/SopsSecret-media-pg-prowlarr-password.yaml
@@ -1,0 +1,29 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: media-pg-prowlarr-password
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: 19763a76b9bca23a6b63a9ec624178cb6e705a61fbf9fc88083aa5b20bddb467
+spec:
+    secretTemplates:
+        - name: media-pg-prowlarr-password
+          stringData:
+            password: ENC[AES256_GCM,data:V9+DWYmSWUPyGQ5CHCebWNDmuPG8vXgmvNordxQaW1E93+1KamN+6eRzRCVQYr1l2zr7Yp7lF3lgZEXCpAACzEZVUEQb7tQl,iv:VNMvXt8a0iclj+/E/yJnbyeLCN34WpAINlbRGAn8qfU=,tag:0M2u24RRVsH2nEBlpy4ESg==,type:str]
+            username: ENC[AES256_GCM,data:nPo+xFIuKmY=,iv:As25JpZeu4hJkT+JVhFiAnBV6ie0JwDjnqj2ZDXPVgo=,tag:sgxlQi2Va3UzGxb0zzNccw==,type:str]
+          type: kubernetes.io/basic-auth
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3Y2JaTnFxK0VJVy9aSjJK
+            L2Zka3Vaazl0RGNvN1hDYXBrZ3ZYY3FBdkVJCk9jTkVzT1lkTjl6T2R6UjZOTDcr
+            djZoV0U5NHhKenRrczV0c3gwM0g5NGsKLS0tIDV6Y2w2aWFTOXIrcm9kcFlpZjBx
+            aURGOFhFL3ZiSU1wbjdRZk5QNHM2RnMK5MQXpT9zWZzvb/GLYkNnwGuwFj/G+T+L
+            CKYHV9feTD2BEAyV8SSUTNb5JPtNzsI4/bfRrve0CsNNw9yATxrwdQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:46Z"
+    mac: ENC[AES256_GCM,data:MG9twJuLKAGHu2zxbBCxxyzAPaQDq8rbkAla8D5PTIrkKcEkmegfE/uQZp+pzk/qdki+bncpwW1/5bf9BhLpB/vG/nj5KebojcCMYtEW1lpYsuWep1sAmALsmz6hVdDDvR4Y5n0YHndVy2vjPgPR1xyxQw7OZjN44eAW8JEZ9kE=,iv:z3dASVBwsm23ALsY7LaITE+XlQqsDrDHZnhImDTbiGo=,tag:BZ+k6NxzjIlPlxVpaTBi5Q==,type:str]
+    version: 3.13.1

--- a/generated/manifests/prod-axon/media-pg/SopsSecret-media-pg-radarr-password.yaml
+++ b/generated/manifests/prod-axon/media-pg/SopsSecret-media-pg-radarr-password.yaml
@@ -1,0 +1,29 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: media-pg-radarr-password
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: 1a5260838ba98bf6fca5bd17c52173e143be05bcda8a3f882b258519ca6310ef
+spec:
+    secretTemplates:
+        - name: media-pg-radarr-password
+          stringData:
+            password: ENC[AES256_GCM,data:ufKNJSvC0loNUAICEyLpptd55BDjOOVek7pj6x2QJ9ffcZT4Y56KimjGmewe3rq/0A3Xkhf3171/4G42jG8Ricoo7xkqosoH,iv:hwbnj7O6U4yA6VTkaAegPoS/UwRxvgDwbUQn4XYpBXc=,tag:j7MBTgOko6934z2pPygybg==,type:str]
+            username: ENC[AES256_GCM,data:0B120pHa,iv:oEF4z81+nH5CXG+pOosE3ixpiDfZuVBm+1bHPzIpiPQ=,tag:of+L9gskfuz8ZgTqc7chWA==,type:str]
+          type: kubernetes.io/basic-auth
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqK1MzU1RRbldNSTRwZUtD
+            cld3NElYQmRTOFhBN2ZzTEVhS082OENLZlE0CjlybUxlWkUrOGc2RG43TG9rRFpl
+            dHJGOHZvM3VsSDFXc0pGQ1lJSlVqemMKLS0tIGhDOUU4b2s0UldodStGTkdTanQ4
+            b1Q3NWV1OE9rZ0tIYUoxYUZZeTlPM28KeYm05cXra9SiqjZf/0yghH5GOMW+P3KE
+            nYizuObe9OP5OR6lJTjYHQbAB3Z7WdE/hBO26ZIVcaXB2YEC6KUiog==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:46Z"
+    mac: ENC[AES256_GCM,data:++ZJR4HiFPjWTjE+zc5oftzPtcq0HTT+Gty+q1OtPzRh+ztanAPgLT9+pDljjHnG3P7vhj5iUBhmYdvvkahCwk3+2ZzW8xU8khUrzV+Zd/B9PGoAvkgSpUEH73A0jyPQtPBr0Ll1DM5pKmDqRgc9FlPoyBemzGg2kBnm7IX6DAw=,iv:YJRVY+GVGiumhkLRAEy87oV2l2lOFQW53lpj0L4YWV4=,tag:hYEU5o+9pfqIouNX95CA5A==,type:str]
+    version: 3.13.1

--- a/generated/manifests/prod-axon/media-pg/SopsSecret-media-pg-romm-password.yaml
+++ b/generated/manifests/prod-axon/media-pg/SopsSecret-media-pg-romm-password.yaml
@@ -1,0 +1,29 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: media-pg-romm-password
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: 7db7276d5bdcc1ac49f8019b7962736596d56ed90bc1066e2beca8d618036c2b
+spec:
+    secretTemplates:
+        - name: media-pg-romm-password
+          stringData:
+            password: ENC[AES256_GCM,data:wwXvXfNfC1IymxDtUULSfE1w3ucVvdC/CtaPGP2Fl006mBoyKYL1vGOcplkttlL5PE/zXtLv8n1Mbe92TBcLkIUx6Kda+tYK,iv:9XA/AuzIr+l4QQcYg2PvduAbTxz4y4tVohBDIhA6jbw=,tag:r5uigU/9QXxALWToAc9C4g==,type:str]
+            username: ENC[AES256_GCM,data:Rqj7VA==,iv:6Mf+Ib78UPqlWeJHUCAZ6fQDInfDqmkPTq7fc0E9Ko0=,tag:4tgXlCL8jGej3Vuy+zu4/Q==,type:str]
+          type: kubernetes.io/basic-auth
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQenlmY2UxVkM1WTlxN3FN
+            NkVXVHlsSEUzakVPTUEyMmtNak9XZGpXYTN3CmltaWczVWw5RGU4MTlqVnpzdVZi
+            WHo1K0l2UjYxaHJldDZiOEpWbndnYVEKLS0tIEt0YXZJY0UwTFZQc3JqNzJ6RGJu
+            SmRkbFFiZ3JwYkRLSHM2L0ZLR1ZEak0KucitSVZiOQ2DRcq0ajsrlzOY1UQfiviP
+            rOFIZfm3KoZiFzQ4ucPXu3HEGsSbY9x0bCJ8wscBATYIWN12f1IdUg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:46Z"
+    mac: ENC[AES256_GCM,data:gYBDeX7B56o/f36s1ePrUnaO7xgFiMvujPu1u5maJOseDJ64gttg/g+1CG2BvkWgPq56R19dJsVFRvv4DV448sInyN4VMpJoh708DsZKJ4xvjUvExWUrvbp7kASvsjqSek+0RHTyrb5SdkwGD0A/ttCjzDtzSVcZiJH4TG9fqEA=,iv:2GNqQ8YteCzIwYLgpPrN3tmRHxkUcsnvazG5G5hziQI=,tag:HgQhnuijhV3d4FLyrHTIZw==,type:str]
+    version: 3.13.1

--- a/generated/manifests/prod-axon/media-pg/SopsSecret-media-pg-sonarr-password.yaml
+++ b/generated/manifests/prod-axon/media-pg/SopsSecret-media-pg-sonarr-password.yaml
@@ -1,0 +1,29 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: media-pg-sonarr-password
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: bad2ec37aab16098e31a5a3bfb4f8166f441e7a32341af4a9fade0fc2653862e
+spec:
+    secretTemplates:
+        - name: media-pg-sonarr-password
+          stringData:
+            password: ENC[AES256_GCM,data:2B2odlmgUJfNv7k0gMBO4IFjIUC5mBqamZliGH/ZGKOI+4+aa4r4mspqIce4UnT4n3oDSJrnNmfVtvQ6+68dYJLbfzRKZamS,iv:bgg32jrklT9vmlREwsz4yYzd33QrqNC28L0ueg3rVLk=,tag:Wtx+YIerc+w3gbDX/btgfQ==,type:str]
+            username: ENC[AES256_GCM,data:KJ0cD1gR,iv:ceRvzMx3wTuopwfDlh84Ux0VXWRuoP8Pfdad4FKfTjU=,tag:Org+g66VDEH2mTI69IdHpg==,type:str]
+          type: kubernetes.io/basic-auth
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnYlUxckV5aWNNaEpDZVNJ
+            d3c5RTFKamdkQWIxQ3dGeEdlRnBnTEJCWkVBCmQ5blc5M1pPUGhlT1FaRkkzWkQ4
+            NzFoTkU1Yzg1S3FzZGlLb2NobkdlRjQKLS0tIHl6ZkZ5TGlUQ3BlQjhQYnk2ci8v
+            UWNua2ZqNVZwcDdRcnA1R1FkOExIejgKDJ8J3EL+RCETke4DSsKCNN2O1UdjWJ7W
+            Pucqqz7ezJS402TmQZOxLFP6CQ2qx2ySt5IIm5WyTEpDvLgfQTHZtg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:46Z"
+    mac: ENC[AES256_GCM,data:rg95rwIVl9yepiVIOVdve+oEA+BcUN7PeVCt8VNiyEE2QMlKsrn5V1irvmm9fC5miEKMDelJvP5kb6OreikSf7ryk0JSQiAqhkhEMihdJZmB4jxg1rMxVGxuvOPgY2arpCzuGElr+sIUw/Y96zuUIhS/EjWwxn6e3N/aOzx42QQ=,iv:w7SkMVjHtNHL603s0z0PLW/M7KKEFOYuq65iBUVn4K8=,tag:xALyXzGI6U2w1W6CKjnopA==,type:str]
+    version: 3.13.1

--- a/generated/manifests/prod-axon/media-pg/SopsSecret-media-pg-whisparr-password.yaml
+++ b/generated/manifests/prod-axon/media-pg/SopsSecret-media-pg-whisparr-password.yaml
@@ -1,0 +1,29 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: media-pg-whisparr-password
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: 53cd109868011c1520c090412139700c565c844b06d88d5b4e2969a1352ef25b
+spec:
+    secretTemplates:
+        - name: media-pg-whisparr-password
+          stringData:
+            password: ENC[AES256_GCM,data:9N1DDYMKrGWyRpNaCuP9dDyRIGG5uHSupbfTAONP4xDZncWidcuHo2tN/ENz2Gn1KopVcS5fx2MAOtPNdNncN6K74bXfw5IH,iv:50X7cf9UrI/eM91Klt4molbWjl0D6kuRjGeV4c2izuw=,tag:JC7mJCDD3v234vh4Nz9cNQ==,type:str]
+            username: ENC[AES256_GCM,data:SB5MYT60XY8=,iv:ATszxv+jdmL+5fVzAUeLS2vUCOWSWzsjbC8+5z6dcu0=,tag:qfHuQjAbulFBommNCNaO0g==,type:str]
+          type: kubernetes.io/basic-auth
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWY1JKRzR4VHBqcVJuOVNt
+            MU9hWk9QdEZZWHBxK0dRRjBNckVlMzd0WWhRCkpyd3p0Qit5NzJaMm5mZ0lad2NZ
+            NTNtQnkxMFdSSU54cGRHUVU1QmtiZ0UKLS0tIExmYzJNV2JjVlRSRUxoYXJMelp0
+            aWlvWkZLcXkxTDR0TCsvVDJ4amRWbkEKphFFJTZz2lSziI9EC5J60PeFRTXD8pW7
+            /9UsPQ8CcndX4rD3GkhB2AfPzKxBwqRwR0EK1ScdeprWsochH6yCtw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:46Z"
+    mac: ENC[AES256_GCM,data:zSimb6mhLhlaxy953P8b8NtGRvFxfQuJ/ddkgcSTG0uCPiTV7bbm3CmPbvL4Tpnbh2ndEqISS0Nyf7KQEhJwto2Fe4fEfd74dixpCjXM1gGE0157lNFPwoekRjFbIx2nntqwxiqfrUEq9zFjEGmXD7PBWV+BGU2cMgpIz38uPRg=,iv:go9gDE/qRnlf8FstNsMV3pnIbFGHTpqf4lXfXhzW/jI=,tag:NJ2RnLz8pK0qmq1BiMafTA==,type:str]
+    version: 3.13.1

--- a/generated/manifests/prod-axon/media-pg/VolumeSnapshotClass-longhorn-snapshot.yaml
+++ b/generated/manifests/prod-axon/media-pg/VolumeSnapshotClass-longhorn-snapshot.yaml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1
+deletionPolicy: Delete
+driver: driver.longhorn.io
+kind: VolumeSnapshotClass
+metadata:
+  name: longhorn-snapshot
+parameters:
+  type: snap

--- a/generated/manifests/prod-axon/media-secrets/SopsSecret-media-arr-api-keys.yaml
+++ b/generated/manifests/prod-axon/media-secrets/SopsSecret-media-arr-api-keys.yaml
@@ -1,0 +1,34 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: media-arr-api-keys
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: f925250481b76915cba97d29b5809772b5ce169df66bb1a00071c4efc6fe5798
+spec:
+    secretTemplates:
+        - name: media-arr-api-keys
+          stringData:
+            bazarr: ENC[AES256_GCM,data:s0rKtYj7bC3PsenlbrdV187V1pqgyzdQI5VofPJXgKI=,iv:1hcjZobCFpwT1Tec6sp2qMEYa7WTdOFguRTWMps7D9Q=,tag:KHb7v4NzCwcD7pWf/P86ew==,type:str]
+            lidarr: ENC[AES256_GCM,data:ts77IzN+mpISBDO9IXZPB6Ua4l6+sVKLSfMS9jDo8lY=,iv:WzSnTwJyID42YZZ+hpHcxTZg16L24nmAYrlqiuuFCxE=,tag:StDWz4wkEiIReR2QoYk3CQ==,type:str]
+            prowlarr: ENC[AES256_GCM,data:vhKsMdHRjtMl2jj+89X9kmJAmmzxNH6O14Pzo79XP3g=,iv:29mw5oqHmw4Z4+VVdTuDOliwiQkSPD/EZFMcVnfPeo4=,tag:nnC12ZHh1LqZwV6P2oNP/Q==,type:str]
+            radarr: ENC[AES256_GCM,data:4TM965ldfiX6j9dhRBIgHeBXqXCw4f3tDqRKLGDqkJE=,iv:e46A+ilMaB3pnwhUaUBYRODqwxwVMKEtrU0UywrJZH4=,tag:f8YgpOG8x2ajwRhlcwoSaA==,type:str]
+            sabnzbd: ENC[AES256_GCM,data:/P7oKsN3nGQrfiwvZIkheJICdNyZqEbsNiQEjVZUmbs=,iv:Dj5PJxzyOrD5lCvoMd+rKmxVDBGMvelg3MgTpgeifvQ=,tag:ECgAUlx7ixI5S3p17mjIgA==,type:str]
+            sonarr: ENC[AES256_GCM,data:xY/k3WYuUVIMuFtwEdP8UVRoZ+5WONnVCDW9gBEM3Y8=,iv:6M9PCzKbNchDWcsrnw+QA4hhzyIV22FBIpXxL/BmTGc=,tag:ht3+IJX/DR1S0mQEMxOHmA==,type:str]
+            whisparr: ENC[AES256_GCM,data:zdqBgCKUzoH0puIpczUarLmhv+hQkNt/iJncDx5WUso=,iv:X8K545Sy6HfehdXnSyNUhW3xRvrohAtIzN4ONXiQ2KQ=,tag:4rewNLJyiiqE3uM6vhSWLA==,type:str]
+          type: Opaque
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuY25DeWx3cXBYbFoxRGNX
+            SWlCMUV4Ti9wenB1SWxQL2gwQUtQZ3I5cXpjCmdtWDRDSW04a3pBMkxzT1ZXK2pS
+            SGVwUEliNklLQUxIbXBrS1kyVThYZXcKLS0tIHZIY3RIQWpVcXdFWFhFOVZTUWs1
+            MFpLQnl1dmgzWVRaSHNJcXUyUUYrd2sKoSV+hoMYNRarunnJVJuhMhLvH58bFNIR
+            vylj7A3tkR4No10tJpFcW0vO7fzsg5gR+nwcO4tgx3LupHIRV9IrxQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:46Z"
+    mac: ENC[AES256_GCM,data:OQ7dI+RRNs+BAvICY4ApFhsRquVGsRJTRCHcwjjCetQnnHSwr7L1zsCcuc42Hoa7dXWd2ciB8o0m6BNNV6LVc/iuuwiQdcSIurlV+PVigbFE568pi1quqdzF2hukkSkxtlK9204/XBU3xI/gc3ObyC2pVvhciV1czvAfZuXDrD8=,iv:2IoPKrnc+EHdrWP6RHDuLf3YAY3PiMNy26WeCVRH0PM=,tag:Ipe8uz/KL/urPuJAwxGwcg==,type:str]
+    version: 3.13.1

--- a/generated/manifests/prod-axon/prowlarr/CiliumNetworkPolicy-allow-dns-egress-prowlarr.yaml
+++ b/generated/manifests/prod-axon/prowlarr/CiliumNetworkPolicy-allow-dns-egress-prowlarr.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-dns-egress-prowlarr
+  namespace: media
+spec:
+  description: Allow prowlarr to resolve via kube-dns.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: prowlarr

--- a/generated/manifests/prod-axon/prowlarr/CiliumNetworkPolicy-allow-gateway-ingress-prowlarr.yaml
+++ b/generated/manifests/prod-axon/prowlarr/CiliumNetworkPolicy-allow-gateway-ingress-prowlarr.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-gateway-ingress-prowlarr
+  namespace: media
+spec:
+  description: Allow Envoy Gateway proxies to reach prowlarr.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: prowlarr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+      toPorts:
+        - ports:
+            - port: "9696"
+              protocol: TCP

--- a/generated/manifests/prod-axon/prowlarr/CiliumNetworkPolicy-allow-postgres-egress-prowlarr.yaml
+++ b/generated/manifests/prod-axon/prowlarr/CiliumNetworkPolicy-allow-postgres-egress-prowlarr.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-postgres-egress-prowlarr
+  namespace: media
+spec:
+  description: Allow prowlarr to reach the media-pg CNPG cluster.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/cluster: media-pg
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: prowlarr

--- a/generated/manifests/prod-axon/prowlarr/Deployment-prowlarr.yaml
+++ b/generated/manifests/prod-axon/prowlarr/Deployment-prowlarr.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: prowlarr
+    app.kubernetes.io/name: prowlarr
+  name: prowlarr
+  namespace: media
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/controller: main
+      app.kubernetes.io/instance: prowlarr
+      app.kubernetes.io/name: prowlarr
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/controller: main
+        app.kubernetes.io/instance: prowlarr
+        app.kubernetes.io/name: prowlarr
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: PGID
+              value: "65536"
+            - name: PROWLARR__AUTH__APIKEY
+              valueFrom:
+                secretKeyRef:
+                  key: prowlarr
+                  name: media-arr-api-keys
+            - name: PROWLARR__AUTH__METHOD
+              value: External
+            - name: PROWLARR__POSTGRES__HOST
+              value: media-pg-rw
+            - name: PROWLARR__POSTGRES__LOGDB
+              value: prowlarr-log
+            - name: PROWLARR__POSTGRES__MAINDB
+              value: prowlarr-main
+            - name: PROWLARR__POSTGRES__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: media-pg-prowlarr-password
+            - name: PROWLARR__POSTGRES__PORT
+              value: "5432"
+            - name: PROWLARR__POSTGRES__USER
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: media-pg-prowlarr-password
+            - name: PUID
+              value: "1027"
+            - name: TZ
+              value: America/Los_Angeles
+          image: lscr.io/linuxserver/prowlarr:2.4.0
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ping
+              port: 9696
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          name: main
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ping
+              port: 9696
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /config
+              name: config
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      serviceAccountName: prowlarr
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: prowlarr

--- a/generated/manifests/prod-axon/prowlarr/HTTPRoute-prowlarr.yaml
+++ b/generated/manifests/prod-axon/prowlarr/HTTPRoute-prowlarr.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: prowlarr
+  namespace: media
+spec:
+  hostnames:
+    - prowlarr.json64.dev
+  parentRefs:
+    - name: default-gateway
+      namespace: gateways
+      sectionName: json64-dev-https
+  rules:
+    - backendRefs:
+        - name: prowlarr
+          port: 9696

--- a/generated/manifests/prod-axon/prowlarr/PersistentVolumeClaim-prowlarr.yaml
+++ b/generated/manifests/prod-axon/prowlarr/PersistentVolumeClaim-prowlarr.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: prowlarr
+    app.kubernetes.io/name: prowlarr
+  name: prowlarr
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: longhorn

--- a/generated/manifests/prod-axon/prowlarr/SecurityPolicy-prowlarr-oidc.yaml
+++ b/generated/manifests/prod-axon/prowlarr/SecurityPolicy-prowlarr-oidc.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: prowlarr-oidc
+  namespace: media
+spec:
+  oidc:
+    clientID: prowlarr
+    clientSecret:
+      name: prowlarr-oidc-client-secret
+    forwardAccessToken: true
+    provider:
+      issuer: https://idm.json64.dev/oauth2/openid/prowlarr
+    scopes:
+      - email
+      - openid
+      - profile
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: prowlarr

--- a/generated/manifests/prod-axon/prowlarr/Service-prowlarr.yaml
+++ b/generated/manifests/prod-axon/prowlarr/Service-prowlarr.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: prowlarr
+    app.kubernetes.io/name: prowlarr
+    app.kubernetes.io/service: prowlarr
+  name: prowlarr
+  namespace: media
+spec:
+  ports:
+    - name: http
+      port: 9696
+      protocol: TCP
+      targetPort: 9696
+  selector:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: prowlarr
+    app.kubernetes.io/name: prowlarr
+  type: ClusterIP

--- a/generated/manifests/prod-axon/prowlarr/ServiceAccount-prowlarr.yaml
+++ b/generated/manifests/prod-axon/prowlarr/ServiceAccount-prowlarr.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: prowlarr
+    app.kubernetes.io/name: prowlarr
+  name: prowlarr
+  namespace: media

--- a/generated/manifests/prod-axon/prowlarr/SopsSecret-prowlarr-oidc-client-secret.yaml
+++ b/generated/manifests/prod-axon/prowlarr/SopsSecret-prowlarr-oidc-client-secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: prowlarr-oidc-client-secret
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: d82f2bb3e954e2077db5670d3c127e9567d3fe16c4ed7dd3c46a8cae7104b679
+spec:
+    secretTemplates:
+        - name: prowlarr-oidc-client-secret
+          stringData:
+            client-secret: ENC[AES256_GCM,data:fhAFzujWgZ6bwxWoLgAehimx3QdCuB/43yCf382P6BJgsZjtsACjUmjpAs6vNzMU7hchhhUUicBwrRQgwzmSA/97bJi6yte8,iv:XW/LoH0n/sdMge9LOjQEML5+uZ5yeV5r9VnVM6Z7Gi4=,tag:/le1XQjSqZSNpzFWfKbMLg==,type:str]
+          type: Opaque
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYYlFlbm84N2QxV3hpb3Vh
+            bTBQamRoSmVLSUx1UDFnVnpPQnJSemUzYmgwCmpUd0RhZ2NRN1JwM0p0NU1wbTF3
+            TjBMY2NXYittR1UrSmpPMklIOVMrMk0KLS0tIENaR2V4bHR2SVZadVBQSzZYeFNY
+            RkhKemhOK3dia1Y3YU14RGlNMEVBKzgKn9KvaNk+hTlZdrASkdWAqwb00ZObe2Um
+            e0qh2WwV8UUkUBn3AIneK1hQGNkC7kgoQ5PcXJaI15Sq+eVQj3c5dA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:47Z"
+    mac: ENC[AES256_GCM,data:gi1NgoV6l4ShZyBuNHd6Ru6lU5ZIjdZ589OYGrSvt3rsEBr6sE+ZVk9nzaG/OU85nN8U4T1x/TcnltT5urSqJJEF8dglYOQr7IVZBlYa+v72HnuRMEvekreXKaEdHR8NObS/ZFDW7Fx88ih4PA5QWoe32KkI5fv1cYtlSh+W8LI=,iv:Frz9MySS4qypetbKs1f1KJOkqaJ3Sb9SupNWZRCNesk=,tag:jvI92j4ToPI2pxwqXLzbMg==,type:str]
+    version: 3.13.1

--- a/generated/manifests/prod-axon/qbittorrent/CiliumNetworkPolicy-allow-arr-ingress-qbittorrent.yaml
+++ b/generated/manifests/prod-axon/qbittorrent/CiliumNetworkPolicy-allow-arr-ingress-qbittorrent.yaml
@@ -1,0 +1,28 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-arr-ingress-qbittorrent
+  namespace: media
+spec:
+  description: Allow the *arrs and unpackerr to reach qBittorrent's WebUI API (8080).
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: qbittorrent
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: sonarr
+        - matchLabels:
+            app.kubernetes.io/name: radarr
+        - matchLabels:
+            app.kubernetes.io/name: lidarr
+        - matchLabels:
+            app.kubernetes.io/name: whisparr
+        - matchLabels:
+            app.kubernetes.io/name: prowlarr
+        - matchLabels:
+            app.kubernetes.io/name: unpackerr
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/generated/manifests/prod-axon/qbittorrent/CiliumNetworkPolicy-allow-dns-egress-qbittorrent.yaml
+++ b/generated/manifests/prod-axon/qbittorrent/CiliumNetworkPolicy-allow-dns-egress-qbittorrent.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-dns-egress-qbittorrent
+  namespace: media
+spec:
+  description: Allow qbittorrent to resolve via kube-dns.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: qbittorrent

--- a/generated/manifests/prod-axon/qbittorrent/CiliumNetworkPolicy-allow-gateway-ingress-qbittorrent.yaml
+++ b/generated/manifests/prod-axon/qbittorrent/CiliumNetworkPolicy-allow-gateway-ingress-qbittorrent.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-gateway-ingress-qbittorrent
+  namespace: media
+spec:
+  description: Allow Envoy Gateway proxies to reach qbittorrent.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: qbittorrent
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/generated/manifests/prod-axon/qbittorrent/CiliumNetworkPolicy-allow-vpn-egress-qbittorrent.yaml
+++ b/generated/manifests/prod-axon/qbittorrent/CiliumNetworkPolicy-allow-vpn-egress-qbittorrent.yaml
@@ -1,0 +1,17 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-vpn-egress-qbittorrent
+  namespace: media
+spec:
+  description: Allow the gluetun sidecar to reach the ProtonVPN WireGuard endpoint (UDP 51820).
+  egress:
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "51820"
+              protocol: UDP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: qbittorrent

--- a/generated/manifests/prod-axon/qbittorrent/Deployment-qbittorrent.yaml
+++ b/generated/manifests/prod-axon/qbittorrent/Deployment-qbittorrent.yaml
@@ -1,0 +1,194 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: qbittorrent
+    app.kubernetes.io/name: qbittorrent
+  name: qbittorrent
+  namespace: media
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/controller: main
+      app.kubernetes.io/instance: qbittorrent
+      app.kubernetes.io/name: qbittorrent
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/controller: main
+        app.kubernetes.io/instance: qbittorrent
+        app.kubernetes.io/name: qbittorrent
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: PGID
+              value: "65536"
+            - name: PUID
+              value: "1027"
+            - name: TZ
+              value: America/Los_Angeles
+            - name: UMASK
+              value: "022"
+            - name: WEBUI_PORT
+              value: "8080"
+          image: lscr.io/linuxserver/qbittorrent:5.2.1-libtorrentv1
+          name: main
+          volumeMounts:
+            - mountPath: /config
+              name: config
+            - mountPath: /scratch
+              name: scratch
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              GTN=http://127.0.0.1:8000/v1/openvpn/portforwarded
+              QBT=http://127.0.0.1:8080
+              last=""
+              while true; do
+                # Compact-JSON assumption: gluetun's control server emits a single-line
+                # object like {"port":12345}; this sed grabs the first "port":<digits>. If
+                # gluetun ever pretty-prints the response, this extraction must change.
+                port="$(wget -qO- "$GTN" 2>/dev/null | sed -n 's/.*"port":\([0-9]*\).*/\1/p' || true)"
+                if [ -n "${port:-}" ] && [ "${port}" != "0" ] && [ "${port}" != "${last}" ]; then
+                  echo "port-sync: setting qBittorrent listen port to ${port}"
+                  if wget -qO- --post-data "json={\"listen_port\":${port}}" \
+                      "$QBT/api/v2/app/setPreferences" >/dev/null 2>&1; then
+                    last="${port}"
+                  else
+                    echo "port-sync: setPreferences failed (qBittorrent not ready?), will retry"
+                  fi
+                else
+                  echo "port-sync: no forwarded port from gluetun control server"
+                fi
+                sleep 60
+              done
+          image: busybox:1.38.0
+          name: port-sync
+          volumeMounts:
+            - mountPath: /config
+              name: config
+            - mountPath: /scratch
+              name: scratch
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      initContainers:
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              INI=/config/qBittorrent/qBittorrent.conf
+              mkdir -p /config/qBittorrent
+              ensure_key() {
+                # ensure_key <key-escaped-for-sed> <full-line>
+                key="$1"; line="$2"
+                if grep -q "^$key=" "$INI"; then
+                  sed -i "s|^$key=.*|$line|" "$INI"
+                else
+                  sed -i "/^\[Preferences\]/a $line" "$INI"
+                fi
+              }
+              if [ ! -f "$INI" ]; then
+                echo "seeding fresh $INI"
+                {
+                  printf '%s\n' '[Preferences]'
+                  printf '%s\n' 'WebUI\AuthSubnetWhitelist=127.0.0.1/32'
+                  printf '%s\n' 'WebUI\AuthSubnetWhitelistEnabled=true'
+                  printf '%s\n' 'WebUI\HostHeaderValidation=false'
+                } > "$INI"
+              else
+                echo "reconciling existing $INI"
+                grep -q '^\[Preferences\]' "$INI" || printf '[Preferences]\n' >> "$INI"
+                ensure_key 'WebUI\\AuthSubnetWhitelist' 'WebUI\AuthSubnetWhitelist=127.0.0.1/32'
+                ensure_key 'WebUI\\AuthSubnetWhitelistEnabled' 'WebUI\AuthSubnetWhitelistEnabled=true'
+                ensure_key 'WebUI\\HostHeaderValidation' 'WebUI\HostHeaderValidation=false'
+              fi
+          image: lscr.io/linuxserver/qbittorrent:5.2.1-libtorrentv1
+          name: config-seed
+          volumeMounts:
+            - mountPath: /config
+              name: config
+            - mountPath: /scratch
+              name: scratch
+        - env:
+            - name: FIREWALL_OUTBOUND_SUBNETS
+              value: 172.20.0.0/16,172.21.0.0/16,10.10.10.0/24
+            - name: VPN_PORT_FORWARDING
+              value: "on"
+            - name: VPN_PORT_FORWARDING_PROVIDER
+              value: protonvpn
+            - name: VPN_SERVICE_PROVIDER
+              value: custom
+            - name: VPN_TYPE
+              value: wireguard
+            - name: WIREGUARD_ADDRESSES
+              valueFrom:
+                secretKeyRef:
+                  key: addresses
+                  name: media-vpn
+            - name: WIREGUARD_ENDPOINT_IP
+              valueFrom:
+                secretKeyRef:
+                  key: endpoint-ip
+                  name: media-vpn
+            - name: WIREGUARD_ENDPOINT_PORT
+              valueFrom:
+                secretKeyRef:
+                  key: endpoint-port
+                  name: media-vpn
+            - name: WIREGUARD_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: private-key
+                  name: media-vpn
+            - name: WIREGUARD_PUBLIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: peer-public-key
+                  name: media-vpn
+          image: qmcgaw/gluetun:v3.41.1
+          name: gluetun
+          readinessProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /v1/openvpn/status
+              port: 8000
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
+          restartPolicy: Always
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+          volumeMounts:
+            - mountPath: /config
+              name: config
+            - mountPath: /scratch
+              name: scratch
+            - mountPath: /dev/net/tun
+              name: tun
+      serviceAccountName: qbittorrent
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: qbittorrent
+        - name: scratch
+          persistentVolumeClaim:
+            claimName: media-scratch-local
+        - hostPath:
+            path: /dev/net/tun
+            type: CharDevice
+          name: tun

--- a/generated/manifests/prod-axon/qbittorrent/HTTPRoute-qbittorrent.yaml
+++ b/generated/manifests/prod-axon/qbittorrent/HTTPRoute-qbittorrent.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: qbittorrent
+  namespace: media
+spec:
+  hostnames:
+    - torrent.json64.dev
+  parentRefs:
+    - name: default-gateway
+      namespace: gateways
+      sectionName: json64-dev-https
+  rules:
+    - backendRefs:
+        - name: qbittorrent
+          port: 8080

--- a/generated/manifests/prod-axon/qbittorrent/PersistentVolumeClaim-qbittorrent.yaml
+++ b/generated/manifests/prod-axon/qbittorrent/PersistentVolumeClaim-qbittorrent.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: qbittorrent
+    app.kubernetes.io/name: qbittorrent
+  name: qbittorrent
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: longhorn

--- a/generated/manifests/prod-axon/qbittorrent/SecurityPolicy-qbittorrent-oidc.yaml
+++ b/generated/manifests/prod-axon/qbittorrent/SecurityPolicy-qbittorrent-oidc.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: qbittorrent-oidc
+  namespace: media
+spec:
+  oidc:
+    clientID: qbittorrent
+    clientSecret:
+      name: qbittorrent-oidc-client-secret
+    forwardAccessToken: true
+    provider:
+      issuer: https://idm.json64.dev/oauth2/openid/qbittorrent
+    scopes:
+      - email
+      - openid
+      - profile
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: qbittorrent

--- a/generated/manifests/prod-axon/qbittorrent/Service-qbittorrent.yaml
+++ b/generated/manifests/prod-axon/qbittorrent/Service-qbittorrent.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: qbittorrent
+    app.kubernetes.io/name: qbittorrent
+    app.kubernetes.io/service: qbittorrent
+  name: qbittorrent
+  namespace: media
+spec:
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: qbittorrent
+    app.kubernetes.io/name: qbittorrent
+  type: ClusterIP

--- a/generated/manifests/prod-axon/qbittorrent/ServiceAccount-qbittorrent.yaml
+++ b/generated/manifests/prod-axon/qbittorrent/ServiceAccount-qbittorrent.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: qbittorrent
+    app.kubernetes.io/name: qbittorrent
+  name: qbittorrent
+  namespace: media

--- a/generated/manifests/prod-axon/qbittorrent/SopsSecret-media-vpn.yaml
+++ b/generated/manifests/prod-axon/qbittorrent/SopsSecret-media-vpn.yaml
@@ -1,0 +1,32 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: media-vpn
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: f90dc4fff75958839b6b27427979f49d1befbed5703a14b91e1bf3c23ca1cf75
+spec:
+    secretTemplates:
+        - name: media-vpn
+          stringData:
+            addresses: ENC[AES256_GCM,data:ZbHRJhz1YioSybA=,iv:iBANzyqayc5y6lanXEzB4FM8suFb6UERpnSsrtiv8U0=,tag:vllriJemUhmpsBAw3DZlsw==,type:str]
+            endpoint-ip: ENC[AES256_GCM,data:dIw6iBUjZr/+rOyhCkw=,iv:ua0zz8j06EOIWiOwjQb5Z9Oxit7m3jI7HR6INyz9gjM=,tag:rHmH1+QFVjhR2lNFDSiZNA==,type:str]
+            endpoint-port: ENC[AES256_GCM,data:ysyyQS0=,iv:glnt2nTN8Y2pfOBnkeirgl7cJEcq78TjiNxiyi9eR0Y=,tag:rG+BdAHluZ5h2hJL2W8g5g==,type:str]
+            peer-public-key: ENC[AES256_GCM,data:tuwvUD8HLkKtd2S6zvpq93jZnH3mSgd+xDmE/Ox+7Q0YEzGR4q1eepmwvZ8=,iv:HPo3VJzop9z3j+taMS5+v2vfNfUhhqIoiHKQQ4kQBNw=,tag:xi7i/FLsG2fPy6uG8o6HAA==,type:str]
+            private-key: ENC[AES256_GCM,data:0fqECashgMuu8tn/PMOJUEGHjiD/z0YZK/xHibyBm1uP1JrXFZ77ILor2Oc=,iv:JWVQbX61IX3v+zNDpd6QjBj3YnERbLc9QqgS6UcdK78=,tag:enEHUbCGMHm5Dtk8XJjNtg==,type:str]
+          type: Opaque
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoZGtUc2I0V3MvVFRXZDFC
+            YmowdDJWTFZTSDdrMThDdmFMak9CWjg2SHh3Cld4STF1OG1FczQrVmZ6MU1DMWI1
+            UXhTRTF6SEd1SDFLTUtuNVUybjd4QkEKLS0tIFZkd25pM3V3RFo3MklIdEk4cEZm
+            dGYwbS9Rb3pVSDZoNEMwWGtWVitkZUkKn3p9p8FL6a894TPULdJM+kVQTv0zw2xd
+            BRWZbVbgQ3wZqfZgbcEHgWOsE5oXx6qdCcptVHqBAqEiktxD6yIH8g==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:47Z"
+    mac: ENC[AES256_GCM,data:84AG+9tlnAz0ovNmDytUdr533vF3tokSJfN8rkxXg7DTrZHL0yenlhRa/DJeAXmQrfGV0Hq/GR5HNlHHzyq8zEnDRwtuk832NRYcI8JZ3+TzPgjTBhsVba09LxB5jWUxBww+3tX4gwaXegmW0x5yKzyP781YJx0vQxvzy8S0XAk=,iv:mUf3xqPe9hsbeuN8fp1jOPHeUjBwx5MEqz5EkXF7710=,tag:Dvs7h3fbT1G1dPzTFlPe7A==,type:str]
+    version: 3.13.1

--- a/generated/manifests/prod-axon/qbittorrent/SopsSecret-qbittorrent-oidc-client-secret.yaml
+++ b/generated/manifests/prod-axon/qbittorrent/SopsSecret-qbittorrent-oidc-client-secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: qbittorrent-oidc-client-secret
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: a2bebefa460bc679d0d139a459b197928494558942db935471c99045d52334a4
+spec:
+    secretTemplates:
+        - name: qbittorrent-oidc-client-secret
+          stringData:
+            client-secret: ENC[AES256_GCM,data:1JrPWYEywlp+yW6fgy5VkKv+qzbtIFw7NDVRrsghyhgaDICOec2Wd+8QeVqJ9sMoGKByhVvI4tZm/ZoR7WmyJnOfFlpN9l8J,iv:8Hc4tRSbT5XnVx4HF79K3/5Zpt6WwexGDyvTEBYx85g=,tag:azs1jjX0tDu+GoGh5UScdA==,type:str]
+          type: Opaque
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0bkY1bGdXM0lnUUlkS3VN
+            U3B2NEJsQ2JCQ0FxVzhjd2svTGJtOVpnZ1JNCnBqbi9LMkU1SzZ5NGgyaHBWZy9K
+            WnZLNTA5ODJPaXY0UitPTXUyanhqU0EKLS0tIHZKeDRJRFVwSHdTNjd0cFJLUzYy
+            K0xQcGs1OUNRSFV4aVhDV0lKb2lUS3cKmXHS3T61oFfRBveGBiV5/AP5ZrFU6kDt
+            8j0cwmaXfjyg5qq4O2Sw1rriKAZccXlupwTyA1iuYsof8aVqQwpxUw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:47Z"
+    mac: ENC[AES256_GCM,data:clXe48AXrbd21LTLge589cjzj+IY48pKoXJIqWVWMTMP39uGN8rTL6DTy8A6Vy2C4gk5/Y5UqkYRg/1VbaELWU6/7GCFr8mdzsg4OhdsaZFzUY8A3uvFp4A7oCB0F2jERC8RCJTek8JTOLaGe/uppGdjFEFepdBY/CE33zp3Kng=,iv:a1xUTukCo4BUlPpmHT75LPchy9FvKiJOF89a1ygKCLQ=,tag:1ys5db7hkwE9HpDb2Hb9Vg==,type:str]
+    version: 3.13.1

--- a/generated/manifests/prod-axon/radarr/CiliumNetworkPolicy-allow-dns-egress-radarr.yaml
+++ b/generated/manifests/prod-axon/radarr/CiliumNetworkPolicy-allow-dns-egress-radarr.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-dns-egress-radarr
+  namespace: media
+spec:
+  description: Allow radarr to resolve via kube-dns.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: radarr

--- a/generated/manifests/prod-axon/radarr/CiliumNetworkPolicy-allow-gateway-ingress-radarr.yaml
+++ b/generated/manifests/prod-axon/radarr/CiliumNetworkPolicy-allow-gateway-ingress-radarr.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-gateway-ingress-radarr
+  namespace: media
+spec:
+  description: Allow Envoy Gateway proxies to reach radarr.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: radarr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+      toPorts:
+        - ports:
+            - port: "7878"
+              protocol: TCP

--- a/generated/manifests/prod-axon/radarr/CiliumNetworkPolicy-allow-postgres-egress-radarr.yaml
+++ b/generated/manifests/prod-axon/radarr/CiliumNetworkPolicy-allow-postgres-egress-radarr.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-postgres-egress-radarr
+  namespace: media
+spec:
+  description: Allow radarr to reach the media-pg CNPG cluster.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/cluster: media-pg
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: radarr

--- a/generated/manifests/prod-axon/radarr/Deployment-radarr.yaml
+++ b/generated/manifests/prod-axon/radarr/Deployment-radarr.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: radarr
+    app.kubernetes.io/name: radarr
+  name: radarr
+  namespace: media
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/controller: main
+      app.kubernetes.io/instance: radarr
+      app.kubernetes.io/name: radarr
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/controller: main
+        app.kubernetes.io/instance: radarr
+        app.kubernetes.io/name: radarr
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: PGID
+              value: "65536"
+            - name: PUID
+              value: "1027"
+            - name: RADARR__AUTH__APIKEY
+              valueFrom:
+                secretKeyRef:
+                  key: radarr
+                  name: media-arr-api-keys
+            - name: RADARR__AUTH__METHOD
+              value: External
+            - name: RADARR__POSTGRES__HOST
+              value: media-pg-rw
+            - name: RADARR__POSTGRES__LOGDB
+              value: radarr-log
+            - name: RADARR__POSTGRES__MAINDB
+              value: radarr-main
+            - name: RADARR__POSTGRES__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: media-pg-radarr-password
+            - name: RADARR__POSTGRES__PORT
+              value: "5432"
+            - name: RADARR__POSTGRES__USER
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: media-pg-radarr-password
+            - name: TZ
+              value: America/Los_Angeles
+          image: lscr.io/linuxserver/radarr:6.2.1
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ping
+              port: 7878
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          name: main
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ping
+              port: 7878
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /config
+              name: config
+            - mountPath: /data
+              name: data
+            - mountPath: /scratch
+              name: scratch
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      serviceAccountName: radarr
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: radarr
+        - name: data
+          persistentVolumeClaim:
+            claimName: media-data-nfs
+        - name: scratch
+          persistentVolumeClaim:
+            claimName: media-scratch-nfs

--- a/generated/manifests/prod-axon/radarr/HTTPRoute-radarr.yaml
+++ b/generated/manifests/prod-axon/radarr/HTTPRoute-radarr.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: radarr
+  namespace: media
+spec:
+  hostnames:
+    - radarr.json64.dev
+  parentRefs:
+    - name: default-gateway
+      namespace: gateways
+      sectionName: json64-dev-https
+  rules:
+    - backendRefs:
+        - name: radarr
+          port: 7878

--- a/generated/manifests/prod-axon/radarr/PersistentVolumeClaim-radarr.yaml
+++ b/generated/manifests/prod-axon/radarr/PersistentVolumeClaim-radarr.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: radarr
+    app.kubernetes.io/name: radarr
+  name: radarr
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: longhorn

--- a/generated/manifests/prod-axon/radarr/SecurityPolicy-radarr-oidc.yaml
+++ b/generated/manifests/prod-axon/radarr/SecurityPolicy-radarr-oidc.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: radarr-oidc
+  namespace: media
+spec:
+  oidc:
+    clientID: radarr
+    clientSecret:
+      name: radarr-oidc-client-secret
+    forwardAccessToken: true
+    provider:
+      issuer: https://idm.json64.dev/oauth2/openid/radarr
+    scopes:
+      - email
+      - openid
+      - profile
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: radarr

--- a/generated/manifests/prod-axon/radarr/Service-radarr.yaml
+++ b/generated/manifests/prod-axon/radarr/Service-radarr.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: radarr
+    app.kubernetes.io/name: radarr
+    app.kubernetes.io/service: radarr
+  name: radarr
+  namespace: media
+spec:
+  ports:
+    - name: http
+      port: 7878
+      protocol: TCP
+      targetPort: 7878
+  selector:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: radarr
+    app.kubernetes.io/name: radarr
+  type: ClusterIP

--- a/generated/manifests/prod-axon/radarr/ServiceAccount-radarr.yaml
+++ b/generated/manifests/prod-axon/radarr/ServiceAccount-radarr.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: radarr
+    app.kubernetes.io/name: radarr
+  name: radarr
+  namespace: media

--- a/generated/manifests/prod-axon/radarr/SopsSecret-radarr-oidc-client-secret.yaml
+++ b/generated/manifests/prod-axon/radarr/SopsSecret-radarr-oidc-client-secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: radarr-oidc-client-secret
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: bc5800b152c11fdd25483efb1c1e5d32ebcdb924ee7bc17de3c52f9900342cbb
+spec:
+    secretTemplates:
+        - name: radarr-oidc-client-secret
+          stringData:
+            client-secret: ENC[AES256_GCM,data:fIqE6MhGn3OutG6lTpLK8RbLq7Vs3AI8JiqQpr9PGMxqxlPatlNCWhu1mQ2zQmDQ2EsWBkQQiPLWU9C2SB+NywPePbx37GEa,iv:d5I3gc2Bfqi+dWWxUN1cSHD9E/ptzm9rpX2SKMtnzU0=,tag:uvNBSHd24yBYiM9GFJ11yg==,type:str]
+          type: Opaque
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCQXFUTkdJYnZENkhMclk1
+            MUdkTktQQmdxZk5qeTd2TXVRZ25rdFZ0TVdVClBVL3lxVjlBbHh2TTBTSmlSZXBi
+            SjhxK3V0SE1NZjh3cUVzZEN0MjNocUkKLS0tIGJ5NlgweGw5Vm1oSWxWTUoyYkdZ
+            Y1QzWDdGTk85Q0M4am9ZbG9qY1Fyd0EKXs+ZgV5NHC9dD0q8FGYWU5w+Vm6lbTHP
+            64F4gUrLfaAj8eZcEuxRsjIC6/Ja9KcsvgaBc43yFLCmdchsoqKMAA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:47Z"
+    mac: ENC[AES256_GCM,data:nHBOmhw5SfE7sQQTPhiZF2R8AUQRnUDMtu/bhZWzBubBIjAQ/2YqngW+Ua+i2Bxf+JMfeidxWmFfCFM8u5w85uGnS8qx136TpN/U5D+O8CyLRGRY/Z4Cpq1zUS6I5+SPZc+wAykcD1VjIZcVkwOWi5ldH7gZwst8CxMqDzGLMPI=,iv:L/jaYeYz/UD0C4Rld4h9BT9Bm9Xbs14MQib5giNUMao=,tag:1fBfS4n4tnR+akAmn1dIRQ==,type:str]
+    version: 3.13.1

--- a/generated/manifests/prod-axon/romm/CiliumNetworkPolicy-allow-dns-egress-romm.yaml
+++ b/generated/manifests/prod-axon/romm/CiliumNetworkPolicy-allow-dns-egress-romm.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-dns-egress-romm
+  namespace: media
+spec:
+  description: Allow romm to resolve via kube-dns.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: romm

--- a/generated/manifests/prod-axon/romm/CiliumNetworkPolicy-allow-gateway-ingress-romm.yaml
+++ b/generated/manifests/prod-axon/romm/CiliumNetworkPolicy-allow-gateway-ingress-romm.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-gateway-ingress-romm
+  namespace: media
+spec:
+  description: Allow Envoy Gateway proxies to reach romm.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: romm
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/generated/manifests/prod-axon/romm/CiliumNetworkPolicy-allow-internet-egress-romm.yaml
+++ b/generated/manifests/prod-axon/romm/CiliumNetworkPolicy-allow-internet-egress-romm.yaml
@@ -1,0 +1,19 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-internet-egress-romm
+  namespace: media
+spec:
+  description: Allow romm to reach the public internet.
+  egress:
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: romm

--- a/generated/manifests/prod-axon/romm/CiliumNetworkPolicy-allow-postgres-egress-romm.yaml
+++ b/generated/manifests/prod-axon/romm/CiliumNetworkPolicy-allow-postgres-egress-romm.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-postgres-egress-romm
+  namespace: media
+spec:
+  description: Allow romm to reach the media-pg CNPG cluster.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/cluster: media-pg
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: romm

--- a/generated/manifests/prod-axon/romm/Deployment-romm.yaml
+++ b/generated/manifests/prod-axon/romm/Deployment-romm.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: romm
+    app.kubernetes.io/name: romm
+  name: romm
+  namespace: media
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/controller: main
+      app.kubernetes.io/instance: romm
+      app.kubernetes.io/name: romm
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/controller: main
+        app.kubernetes.io/instance: romm
+        app.kubernetes.io/name: romm
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: DB_DRIVER
+              value: postgresql
+            - name: DB_HOST
+              value: media-pg-rw
+            - name: DB_NAME
+              value: romm
+            - name: DB_PASSWD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: media-pg-romm-password
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: media-pg-romm-password
+            - name: PGID
+              value: "65536"
+            - name: PUID
+              value: "1027"
+            - name: ROMM_AUTH_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: auth-secret-key
+                  name: media-romm
+            - name: TZ
+              value: America/Los_Angeles
+          image: rommapp/romm:3.10.3
+          name: main
+          volumeMounts:
+            - mountPath: /romm/library
+              name: library
+              subPath: media/games
+            - mountPath: /romm/resources
+              name: state
+              subPath: resources
+            - mountPath: /romm/assets
+              name: state
+              subPath: assets
+            - mountPath: /romm/config
+              name: state
+              subPath: config
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      serviceAccountName: romm
+      volumes:
+        - name: library
+          persistentVolumeClaim:
+            claimName: media-data-nfs
+        - name: state
+          persistentVolumeClaim:
+            claimName: romm

--- a/generated/manifests/prod-axon/romm/HTTPRoute-romm.yaml
+++ b/generated/manifests/prod-axon/romm/HTTPRoute-romm.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: romm
+  namespace: media
+spec:
+  hostnames:
+    - romm.json64.dev
+  parentRefs:
+    - name: default-gateway
+      namespace: gateways
+      sectionName: json64-dev-https
+  rules:
+    - backendRefs:
+        - name: romm
+          port: 8080

--- a/generated/manifests/prod-axon/romm/PersistentVolumeClaim-romm.yaml
+++ b/generated/manifests/prod-axon/romm/PersistentVolumeClaim-romm.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: romm
+    app.kubernetes.io/name: romm
+  name: romm
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: longhorn

--- a/generated/manifests/prod-axon/romm/SecurityPolicy-romm-oidc.yaml
+++ b/generated/manifests/prod-axon/romm/SecurityPolicy-romm-oidc.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: romm-oidc
+  namespace: media
+spec:
+  oidc:
+    clientID: romm
+    clientSecret:
+      name: romm-oidc-client-secret
+    forwardAccessToken: true
+    provider:
+      issuer: https://idm.json64.dev/oauth2/openid/romm
+    scopes:
+      - email
+      - openid
+      - profile
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: romm

--- a/generated/manifests/prod-axon/romm/Service-romm.yaml
+++ b/generated/manifests/prod-axon/romm/Service-romm.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: romm
+    app.kubernetes.io/name: romm
+    app.kubernetes.io/service: romm
+  name: romm
+  namespace: media
+spec:
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: romm
+    app.kubernetes.io/name: romm
+  type: ClusterIP

--- a/generated/manifests/prod-axon/romm/ServiceAccount-romm.yaml
+++ b/generated/manifests/prod-axon/romm/ServiceAccount-romm.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: romm
+    app.kubernetes.io/name: romm
+  name: romm
+  namespace: media

--- a/generated/manifests/prod-axon/romm/SopsSecret-media-romm.yaml
+++ b/generated/manifests/prod-axon/romm/SopsSecret-media-romm.yaml
@@ -1,0 +1,28 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: media-romm
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: 98b70dc92fbd8048713e04727388f40d42dcbf68b2d1dadb44fc2c52156953a9
+spec:
+    secretTemplates:
+        - name: media-romm
+          stringData:
+            auth-secret-key: ENC[AES256_GCM,data:x6iPMEWCm6tYptiYUwtoWNlF4VvaM6Pod3fmqfG/LN3i6HCvQcwqMci9a3bNeoZ5z9+35G5qZUlo3jbI3mPO4Q==,iv:BdknFBalDS03JEMTZrd/pjxgDQEQNc+YmQDX2y2uVkQ=,tag:FtihrvKQtcE4OE6zgv+Tyw==,type:str]
+          type: Opaque
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2bWUvTURlLzlnNVJTeVFQ
+            S3h4MHoyTjkyWG9iWnJHSFhnaDdMZHdHTDJNCllCZ1lPZTBEb1FwSmVaVUZzaWR2
+            WlNjUXFkVXlMNWY3c005QjF1RlF5bGsKLS0tIDNTbmduRW9BVW5jT2Q0cWdIQXZH
+            cVU5M3N6cVZKWGx4aTdNd1NBckVreHcKpb6CqKd+3CfeC7mZURMtTHtxWSR+LZDR
+            dioR8MGxge6dz2F4rCKb/btxw0K8A0Y4P3wCO0BmQPK+J7IgoZoJig==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:47Z"
+    mac: ENC[AES256_GCM,data:CC9KIGu5DetahQJw45CF1bQA2sBbDshEoOfS6BtqAm5Fw9s0jQJ0tIGI4absygaFL1lF/ldvWtGbggQPvGxOxJ7stEz7kRUoD8IT3lFEY4uzxWvt0Guk/JgWspbDMesuUzdAK1HlFYCv6T/uC1KArmtjdVHRdu5emvzO3IH3rTU=,iv:DC3qqHIcRGzocAEzRwHt+YrGhhxgN88sIJQCp84Y6iI=,tag:uY8lNgMbwMaXZmCmf4gKlA==,type:str]
+    version: 3.13.1

--- a/generated/manifests/prod-axon/romm/SopsSecret-romm-oidc-client-secret.yaml
+++ b/generated/manifests/prod-axon/romm/SopsSecret-romm-oidc-client-secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: romm-oidc-client-secret
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: 9ba1da9c5ff96f30596d5bf237f9744d69f128bd2a4f1c77a25d2fbca1d36072
+spec:
+    secretTemplates:
+        - name: romm-oidc-client-secret
+          stringData:
+            client-secret: ENC[AES256_GCM,data:gu7M4+hHz89Y0x/IH1QpK/Btwh0wI3Uy8lPGjmgYkkehzd7kjIY/6L67tA1dKaFSyBo184BIzVKFcDy8pge8lRnIichhddcn,iv:y7ziMF0XvnmXf+0tIeSYWdC5Su6pPvShV4A9VO236bA=,tag:cBiDoXT8QAupiHjEESX/IQ==,type:str]
+          type: Opaque
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwMm1OWnNLY0I1NFF6ZmJR
+            ak10ZFl1WStRZ0JaSkFQMDNEYVJ2bDJ4Q21NClV1YWNYMkR0VnlmZUpPVUhHSnhu
+            RWxlZldyRE0wVk9XM1VHRllFSmZPTmMKLS0tIGgzd20zbWEra0dFSzROODhlQWZN
+            aW03aGJlVnJYZGE0cDM5ZHh5SXVSSjQKoyKvMTbayAZu1/ar+8LKPDSR5OkhO5n0
+            Rckjy0oHbQJq8HWvFlmJTwcf4dGrjAUzI1DnqW1XAzfveGFFsK46RA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:48Z"
+    mac: ENC[AES256_GCM,data:QKK1v2lm3Q1c6YTSEjdspzowHY50byRQBDAgAGyhKvdpay8xQ+sJQ5VCfLgt2yDaww5Ikg8H0rXo9uAeqa6Oidb4xScBLVM4CjzzX3nnpDapMRbLKS7KF2brpc5sxPqYVMPpLSAcN+z1K+Vu+LxdLpSpe92m5fPWJP3MT9JlBxo=,iv:uxJ8uxdkiQQ7UxCxjUt+OtcEt7KNeRz+o5buijdmb48=,tag:4r8P8ERpE93+5ti3k9VegA==,type:str]
+    version: 3.13.1

--- a/generated/manifests/prod-axon/sabnzbd/CiliumNetworkPolicy-allow-dns-egress-sabnzbd.yaml
+++ b/generated/manifests/prod-axon/sabnzbd/CiliumNetworkPolicy-allow-dns-egress-sabnzbd.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-dns-egress-sabnzbd
+  namespace: media
+spec:
+  description: Allow sabnzbd to resolve via kube-dns.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sabnzbd

--- a/generated/manifests/prod-axon/sabnzbd/CiliumNetworkPolicy-allow-gateway-ingress-sabnzbd.yaml
+++ b/generated/manifests/prod-axon/sabnzbd/CiliumNetworkPolicy-allow-gateway-ingress-sabnzbd.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-gateway-ingress-sabnzbd
+  namespace: media
+spec:
+  description: Allow Envoy Gateway proxies to reach sabnzbd.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sabnzbd
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/generated/manifests/prod-axon/sabnzbd/CiliumNetworkPolicy-allow-internet-egress-sabnzbd.yaml
+++ b/generated/manifests/prod-axon/sabnzbd/CiliumNetworkPolicy-allow-internet-egress-sabnzbd.yaml
@@ -1,0 +1,23 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-internet-egress-sabnzbd
+  namespace: media
+spec:
+  description: Allow sabnzbd to reach the public internet.
+  egress:
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP
+            - port: "119"
+              protocol: TCP
+            - port: "563"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sabnzbd

--- a/generated/manifests/prod-axon/sabnzbd/Deployment-sabnzbd.yaml
+++ b/generated/manifests/prod-axon/sabnzbd/Deployment-sabnzbd.yaml
@@ -1,0 +1,122 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: sabnzbd
+    app.kubernetes.io/name: sabnzbd
+  name: sabnzbd
+  namespace: media
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/controller: main
+      app.kubernetes.io/instance: sabnzbd
+      app.kubernetes.io/name: sabnzbd
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/controller: main
+        app.kubernetes.io/instance: sabnzbd
+        app.kubernetes.io/name: sabnzbd
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: PGID
+              value: "65536"
+            - name: PUID
+              value: "1027"
+            - name: TZ
+              value: America/Los_Angeles
+          image: lscr.io/linuxserver/sabnzbd:5.0.4
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          name: main
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /config
+              name: config
+            - mountPath: /scratch
+              name: scratch
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      initContainers:
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              INI=/config/sabnzbd.ini
+              WHITELIST="nzb.json64.dev, sabnzbd"
+              mkdir -p /scratch/usenet/incomplete /scratch/usenet/complete
+              if [ ! -f "$INI" ]; then
+                echo "seeding fresh $INI"
+                {
+                  printf '%s\n' '[misc]'
+                  printf '%s\n' 'host = 0.0.0.0'
+                  printf '%s\n' 'port = 8080'
+                  printf '%s\n' "api_key = $API_KEY"
+                  printf '%s\n' "host_whitelist = $WHITELIST"
+                  printf '%s\n' 'download_dir = /scratch/usenet/incomplete'
+                  printf '%s\n' 'complete_dir = /scratch/usenet/complete'
+                } > "$INI"
+              else
+                echo "reconciling existing $INI"
+                # sed "/^\[misc\]/a ..." silently no-ops if [misc] is absent (set -e can't
+                # catch it), so ensure the section exists before any append below.
+                grep -q '^\[misc\]' "$INI" || printf '[misc]\n' >> "$INI"
+                if grep -q '^api_key = ' "$INI"; then
+                  sed -i "s|^api_key = .*|api_key = $API_KEY|" "$INI"
+                else
+                  sed -i "/^\[misc\]/a api_key = $API_KEY" "$INI"
+                fi
+                if grep -q '^host_whitelist = ' "$INI"; then
+                  sed -i "s|^host_whitelist = .*|host_whitelist = $WHITELIST|" "$INI"
+                else
+                  sed -i "/^\[misc\]/a host_whitelist = $WHITELIST" "$INI"
+                fi
+              fi
+          env:
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: sabnzbd
+                  name: media-arr-api-keys
+          image: lscr.io/linuxserver/sabnzbd:5.0.4
+          name: config-seed
+          volumeMounts:
+            - mountPath: /config
+              name: config
+            - mountPath: /scratch
+              name: scratch
+      serviceAccountName: sabnzbd
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: sabnzbd
+        - name: scratch
+          persistentVolumeClaim:
+            claimName: media-scratch-local

--- a/generated/manifests/prod-axon/sabnzbd/HTTPRoute-sabnzbd.yaml
+++ b/generated/manifests/prod-axon/sabnzbd/HTTPRoute-sabnzbd.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: sabnzbd
+  namespace: media
+spec:
+  hostnames:
+    - nzb.json64.dev
+  parentRefs:
+    - name: default-gateway
+      namespace: gateways
+      sectionName: json64-dev-https
+  rules:
+    - backendRefs:
+        - name: sabnzbd
+          port: 8080

--- a/generated/manifests/prod-axon/sabnzbd/PersistentVolumeClaim-sabnzbd.yaml
+++ b/generated/manifests/prod-axon/sabnzbd/PersistentVolumeClaim-sabnzbd.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: sabnzbd
+    app.kubernetes.io/name: sabnzbd
+  name: sabnzbd
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: longhorn

--- a/generated/manifests/prod-axon/sabnzbd/SecurityPolicy-sabnzbd-oidc.yaml
+++ b/generated/manifests/prod-axon/sabnzbd/SecurityPolicy-sabnzbd-oidc.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: sabnzbd-oidc
+  namespace: media
+spec:
+  oidc:
+    clientID: sabnzbd
+    clientSecret:
+      name: sabnzbd-oidc-client-secret
+    forwardAccessToken: true
+    provider:
+      issuer: https://idm.json64.dev/oauth2/openid/sabnzbd
+    scopes:
+      - email
+      - openid
+      - profile
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: sabnzbd

--- a/generated/manifests/prod-axon/sabnzbd/Service-sabnzbd.yaml
+++ b/generated/manifests/prod-axon/sabnzbd/Service-sabnzbd.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: sabnzbd
+    app.kubernetes.io/name: sabnzbd
+    app.kubernetes.io/service: sabnzbd
+  name: sabnzbd
+  namespace: media
+spec:
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: sabnzbd
+    app.kubernetes.io/name: sabnzbd
+  type: ClusterIP

--- a/generated/manifests/prod-axon/sabnzbd/ServiceAccount-sabnzbd.yaml
+++ b/generated/manifests/prod-axon/sabnzbd/ServiceAccount-sabnzbd.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: sabnzbd
+    app.kubernetes.io/name: sabnzbd
+  name: sabnzbd
+  namespace: media

--- a/generated/manifests/prod-axon/sabnzbd/SopsSecret-sabnzbd-oidc-client-secret.yaml
+++ b/generated/manifests/prod-axon/sabnzbd/SopsSecret-sabnzbd-oidc-client-secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: sabnzbd-oidc-client-secret
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: eddec4373e30fbf264e2f3be6dc255d01f0dfede5498a723906de0691f5b1d79
+spec:
+    secretTemplates:
+        - name: sabnzbd-oidc-client-secret
+          stringData:
+            client-secret: ENC[AES256_GCM,data:bLK6SkQoDFbVTzhoo3oThHek7voWMADkdENT6ImEvjW79R8SRaCzYT+tDSV5M2MLKMTeMK4e8icY47D0YAhRO3qxZZV2BP37,iv:sPlKwygYWL7PoSZf4K5oJJ4jBgqA0EoiMkahIN2ZUio=,tag:/BtVDhKcne6NNt7asiaBNQ==,type:str]
+          type: Opaque
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSVFNkN2FJUUhWRzBiblBE
+            MVh2angxY2dpZDYvcG1rTkpxQ0ZZdHdQY1NVCmxQR1NzLzI4YnFaS3hsY1VBSDIr
+            V2tHYWxaczNnTWVNbFVtZEU2T3BNV2cKLS0tIGJ6TWo4NGwvajVkbStHcEU2RzAz
+            OW0vZ05rWXZBN3B3K3VzWjBjWko1bW8KFomQtIvigmr/41XI83Er6+vQUXZJhQa6
+            zhljPUBSzIy3R356GRXQOLuaZRl7/sGIxmZ+kROfOYYtGuE5Q8jUxA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:48Z"
+    mac: ENC[AES256_GCM,data:8k8M/uJQq0+WO39AMBrST0KKnbG1/v7Vh9LhYXqnqe7V6KzdZAAxdRCaN7rTcVRqxJob/HREmkisKMaSEqfSykkrO0AYmV3nFGXpsOeDCL1ZwVn3dOGiQo9Z+bODm9ZmH5oiDLdTJpcGQmtaRpcIcZBlMtkWlfyJVfqzzyRCyVU=,iv:v6Se1iQ0bh2jBdzZ+/3hqt9P6qXI17I3rvA/PYK7xDY=,tag:D+jFfv0zBQrFx7AfiG8kIQ==,type:str]
+    version: 3.13.1

--- a/generated/manifests/prod-axon/sonarr/CiliumNetworkPolicy-allow-dns-egress-sonarr.yaml
+++ b/generated/manifests/prod-axon/sonarr/CiliumNetworkPolicy-allow-dns-egress-sonarr.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-dns-egress-sonarr
+  namespace: media
+spec:
+  description: Allow sonarr to resolve via kube-dns.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sonarr

--- a/generated/manifests/prod-axon/sonarr/CiliumNetworkPolicy-allow-gateway-ingress-sonarr.yaml
+++ b/generated/manifests/prod-axon/sonarr/CiliumNetworkPolicy-allow-gateway-ingress-sonarr.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-gateway-ingress-sonarr
+  namespace: media
+spec:
+  description: Allow Envoy Gateway proxies to reach sonarr.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sonarr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+      toPorts:
+        - ports:
+            - port: "8989"
+              protocol: TCP

--- a/generated/manifests/prod-axon/sonarr/CiliumNetworkPolicy-allow-postgres-egress-sonarr.yaml
+++ b/generated/manifests/prod-axon/sonarr/CiliumNetworkPolicy-allow-postgres-egress-sonarr.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-postgres-egress-sonarr
+  namespace: media
+spec:
+  description: Allow sonarr to reach the media-pg CNPG cluster.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/cluster: media-pg
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sonarr

--- a/generated/manifests/prod-axon/sonarr/Deployment-sonarr.yaml
+++ b/generated/manifests/prod-axon/sonarr/Deployment-sonarr.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: sonarr
+    app.kubernetes.io/name: sonarr
+  name: sonarr
+  namespace: media
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/controller: main
+      app.kubernetes.io/instance: sonarr
+      app.kubernetes.io/name: sonarr
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/controller: main
+        app.kubernetes.io/instance: sonarr
+        app.kubernetes.io/name: sonarr
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: PGID
+              value: "65536"
+            - name: PUID
+              value: "1027"
+            - name: SONARR__AUTH__APIKEY
+              valueFrom:
+                secretKeyRef:
+                  key: sonarr
+                  name: media-arr-api-keys
+            - name: SONARR__AUTH__METHOD
+              value: External
+            - name: SONARR__POSTGRES__HOST
+              value: media-pg-rw
+            - name: SONARR__POSTGRES__LOGDB
+              value: sonarr-log
+            - name: SONARR__POSTGRES__MAINDB
+              value: sonarr-main
+            - name: SONARR__POSTGRES__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: media-pg-sonarr-password
+            - name: SONARR__POSTGRES__PORT
+              value: "5432"
+            - name: SONARR__POSTGRES__USER
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: media-pg-sonarr-password
+            - name: TZ
+              value: America/Los_Angeles
+          image: lscr.io/linuxserver/sonarr:4.0.17
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ping
+              port: 8989
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          name: main
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ping
+              port: 8989
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /config
+              name: config
+            - mountPath: /data
+              name: data
+            - mountPath: /scratch
+              name: scratch
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      serviceAccountName: sonarr
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: sonarr
+        - name: data
+          persistentVolumeClaim:
+            claimName: media-data-nfs
+        - name: scratch
+          persistentVolumeClaim:
+            claimName: media-scratch-nfs

--- a/generated/manifests/prod-axon/sonarr/HTTPRoute-sonarr.yaml
+++ b/generated/manifests/prod-axon/sonarr/HTTPRoute-sonarr.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: sonarr
+  namespace: media
+spec:
+  hostnames:
+    - sonarr.json64.dev
+  parentRefs:
+    - name: default-gateway
+      namespace: gateways
+      sectionName: json64-dev-https
+  rules:
+    - backendRefs:
+        - name: sonarr
+          port: 8989

--- a/generated/manifests/prod-axon/sonarr/PersistentVolumeClaim-sonarr.yaml
+++ b/generated/manifests/prod-axon/sonarr/PersistentVolumeClaim-sonarr.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: sonarr
+    app.kubernetes.io/name: sonarr
+  name: sonarr
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: longhorn

--- a/generated/manifests/prod-axon/sonarr/SecurityPolicy-sonarr-oidc.yaml
+++ b/generated/manifests/prod-axon/sonarr/SecurityPolicy-sonarr-oidc.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: sonarr-oidc
+  namespace: media
+spec:
+  oidc:
+    clientID: sonarr
+    clientSecret:
+      name: sonarr-oidc-client-secret
+    forwardAccessToken: true
+    provider:
+      issuer: https://idm.json64.dev/oauth2/openid/sonarr
+    scopes:
+      - email
+      - openid
+      - profile
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: sonarr

--- a/generated/manifests/prod-axon/sonarr/Service-sonarr.yaml
+++ b/generated/manifests/prod-axon/sonarr/Service-sonarr.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: sonarr
+    app.kubernetes.io/name: sonarr
+    app.kubernetes.io/service: sonarr
+  name: sonarr
+  namespace: media
+spec:
+  ports:
+    - name: http
+      port: 8989
+      protocol: TCP
+      targetPort: 8989
+  selector:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: sonarr
+    app.kubernetes.io/name: sonarr
+  type: ClusterIP

--- a/generated/manifests/prod-axon/sonarr/ServiceAccount-sonarr.yaml
+++ b/generated/manifests/prod-axon/sonarr/ServiceAccount-sonarr.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: sonarr
+    app.kubernetes.io/name: sonarr
+  name: sonarr
+  namespace: media

--- a/generated/manifests/prod-axon/sonarr/SopsSecret-sonarr-oidc-client-secret.yaml
+++ b/generated/manifests/prod-axon/sonarr/SopsSecret-sonarr-oidc-client-secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: sonarr-oidc-client-secret
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: 5eebcc68291bd6415fc9a8d768ee67368e2ed7554988aaf38db9ac1c95a915de
+spec:
+    secretTemplates:
+        - name: sonarr-oidc-client-secret
+          stringData:
+            client-secret: ENC[AES256_GCM,data:o3iJWm4u6sy85TDQlUUUZu5PwmvLN5jDALvvIIcTIjkbKpwUWLhYN8IfrcDdqjZBY1D0gspZhd4TgsF2TIdREuzC4+Oik4rv,iv:f3Vsa22osfx4tCSgjC1TzYSHTXcoMl51seWDMYuaS5g=,tag:UMDfihr2Vd8yYzdItvJfDQ==,type:str]
+          type: Opaque
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzOFlMMndNamp4MjZsTC85
+            ak5Bb2l0bjJSUnY1RmFrZnJnUjdWbkpJWm5JCnA0VEV6amNqQlJkSzJmc2o0RDBm
+            UGF2ZC9LYTg3UGtROG4vbG5vdzVQRE0KLS0tIFdKT09lbldVSVZIYno3cDBTaWhK
+            UW1OKzRXcFZlbDRIMmNyanJVQ1NIbGcKl/fc3zNjK5+MGAN8yhmIPMOfsmFMCgoH
+            V+UvkQagkuzUOu4fF8furDh/GiTHPu3aO30Z2hlM7c4pCs31sVCHvA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:48Z"
+    mac: ENC[AES256_GCM,data:j92Djeo6eQgzNAflHDQ9RFx2ww8W63Co+E8rTza6P7UF2HQjTezmRQln/sMISJycZYYzah7i9ux68yHqeXGwHNYqFTepeqhpbFaVFMqmfCXkFbnPes/i6Cn3ot2vrPZxJipd5BxGZuot1G+ng8WCBClj+fI7nQfuhRMvprMlE1k=,iv:SghkrYzRFycjIR9eClclcm5q3nk/1akbA/OKxWEezhQ=,tag:fYEjNEv3tuuVbGAGlZLgRg==,type:str]
+    version: 3.13.1

--- a/generated/manifests/prod-axon/unpackerr/CiliumNetworkPolicy-allow-arr-egress-unpackerr.yaml
+++ b/generated/manifests/prod-axon/unpackerr/CiliumNetworkPolicy-allow-arr-egress-unpackerr.yaml
@@ -1,0 +1,39 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-arr-egress-unpackerr
+  namespace: media
+spec:
+  description: Allow unpackerr to reach the *arr APIs (sonarr/radarr/lidarr/whisparr).
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: sonarr
+      toPorts:
+        - ports:
+            - port: "8989"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: radarr
+      toPorts:
+        - ports:
+            - port: "7878"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: lidarr
+      toPorts:
+        - ports:
+            - port: "8686"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: whisparr
+      toPorts:
+        - ports:
+            - port: "6969"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: unpackerr

--- a/generated/manifests/prod-axon/unpackerr/CiliumNetworkPolicy-allow-dns-egress-unpackerr.yaml
+++ b/generated/manifests/prod-axon/unpackerr/CiliumNetworkPolicy-allow-dns-egress-unpackerr.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-dns-egress-unpackerr
+  namespace: media
+spec:
+  description: Allow unpackerr to resolve via kube-dns.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: unpackerr

--- a/generated/manifests/prod-axon/unpackerr/Deployment-unpackerr.yaml
+++ b/generated/manifests/prod-axon/unpackerr/Deployment-unpackerr.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: unpackerr
+    app.kubernetes.io/name: unpackerr
+  name: unpackerr
+  namespace: media
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/controller: main
+      app.kubernetes.io/instance: unpackerr
+      app.kubernetes.io/name: unpackerr
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/controller: main
+        app.kubernetes.io/instance: unpackerr
+        app.kubernetes.io/name: unpackerr
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: PGID
+              value: "65536"
+            - name: PUID
+              value: "1027"
+            - name: TZ
+              value: America/Los_Angeles
+            - name: UN_LIDARR_0_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: lidarr
+                  name: media-arr-api-keys
+            - name: UN_LIDARR_0_PATHS_0
+              value: /scratch/torrents/complete
+            - name: UN_LIDARR_0_URL
+              value: http://lidarr:8686
+            - name: UN_LOG_QUEUES
+              value: 1m
+            - name: UN_RADARR_0_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: radarr
+                  name: media-arr-api-keys
+            - name: UN_RADARR_0_PATHS_0
+              value: /scratch/torrents/complete
+            - name: UN_RADARR_0_URL
+              value: http://radarr:7878
+            - name: UN_SONARR_0_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: sonarr
+                  name: media-arr-api-keys
+            - name: UN_SONARR_0_PATHS_0
+              value: /scratch/torrents/complete
+            - name: UN_SONARR_0_URL
+              value: http://sonarr:8989
+            - name: UN_WHISPARR_0_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: whisparr
+                  name: media-arr-api-keys
+            - name: UN_WHISPARR_0_PATHS_0
+              value: /scratch/torrents/complete
+            - name: UN_WHISPARR_0_URL
+              value: http://whisparr:6969
+          image: golift/unpackerr:0.15.2
+          name: main
+          volumeMounts:
+            - mountPath: /scratch
+              name: scratch
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      serviceAccountName: unpackerr
+      volumes:
+        - name: scratch
+          persistentVolumeClaim:
+            claimName: media-scratch-local

--- a/generated/manifests/prod-axon/unpackerr/Service-unpackerr.yaml
+++ b/generated/manifests/prod-axon/unpackerr/Service-unpackerr.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: unpackerr
+    app.kubernetes.io/name: unpackerr
+    app.kubernetes.io/service: unpackerr
+  name: unpackerr
+  namespace: media
+spec:
+  ports:
+    - name: http
+      port: 5656
+      protocol: TCP
+      targetPort: 5656
+  selector:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: unpackerr
+    app.kubernetes.io/name: unpackerr
+  type: ClusterIP

--- a/generated/manifests/prod-axon/unpackerr/ServiceAccount-unpackerr.yaml
+++ b/generated/manifests/prod-axon/unpackerr/ServiceAccount-unpackerr.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: unpackerr
+    app.kubernetes.io/name: unpackerr
+  name: unpackerr
+  namespace: media

--- a/generated/manifests/prod-axon/whisparr/CiliumNetworkPolicy-allow-dns-egress-whisparr.yaml
+++ b/generated/manifests/prod-axon/whisparr/CiliumNetworkPolicy-allow-dns-egress-whisparr.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-dns-egress-whisparr
+  namespace: media
+spec:
+  description: Allow whisparr to resolve via kube-dns.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: whisparr

--- a/generated/manifests/prod-axon/whisparr/CiliumNetworkPolicy-allow-gateway-ingress-whisparr.yaml
+++ b/generated/manifests/prod-axon/whisparr/CiliumNetworkPolicy-allow-gateway-ingress-whisparr.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-gateway-ingress-whisparr
+  namespace: media
+spec:
+  description: Allow Envoy Gateway proxies to reach whisparr.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: whisparr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+      toPorts:
+        - ports:
+            - port: "6969"
+              protocol: TCP

--- a/generated/manifests/prod-axon/whisparr/CiliumNetworkPolicy-allow-postgres-egress-whisparr.yaml
+++ b/generated/manifests/prod-axon/whisparr/CiliumNetworkPolicy-allow-postgres-egress-whisparr.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-postgres-egress-whisparr
+  namespace: media
+spec:
+  description: Allow whisparr to reach the media-pg CNPG cluster.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            cnpg.io/cluster: media-pg
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: whisparr

--- a/generated/manifests/prod-axon/whisparr/Deployment-whisparr.yaml
+++ b/generated/manifests/prod-axon/whisparr/Deployment-whisparr.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: whisparr
+    app.kubernetes.io/name: whisparr
+  name: whisparr
+  namespace: media
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/controller: main
+      app.kubernetes.io/instance: whisparr
+      app.kubernetes.io/name: whisparr
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/controller: main
+        app.kubernetes.io/instance: whisparr
+        app.kubernetes.io/name: whisparr
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: PGID
+              value: "65536"
+            - name: PUID
+              value: "1027"
+            - name: TZ
+              value: America/Los_Angeles
+            - name: WHISPARR__AUTH__APIKEY
+              valueFrom:
+                secretKeyRef:
+                  key: whisparr
+                  name: media-arr-api-keys
+            - name: WHISPARR__AUTH__METHOD
+              value: External
+            - name: WHISPARR__POSTGRES__HOST
+              value: media-pg-rw
+            - name: WHISPARR__POSTGRES__LOGDB
+              value: whisparr-log
+            - name: WHISPARR__POSTGRES__MAINDB
+              value: whisparr-main
+            - name: WHISPARR__POSTGRES__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: media-pg-whisparr-password
+            - name: WHISPARR__POSTGRES__PORT
+              value: "5432"
+            - name: WHISPARR__POSTGRES__USER
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: media-pg-whisparr-password
+          image: ghcr.io/hotio/whisparr:v2-2.2.0-release.108
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ping
+              port: 6969
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          name: main
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ping
+              port: 6969
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /config
+              name: config
+            - mountPath: /data
+              name: data
+            - mountPath: /scratch
+              name: scratch
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      serviceAccountName: whisparr
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: whisparr
+        - name: data
+          persistentVolumeClaim:
+            claimName: media-data-nfs
+        - name: scratch
+          persistentVolumeClaim:
+            claimName: media-scratch-nfs

--- a/generated/manifests/prod-axon/whisparr/HTTPRoute-whisparr.yaml
+++ b/generated/manifests/prod-axon/whisparr/HTTPRoute-whisparr.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: whisparr
+  namespace: media
+spec:
+  hostnames:
+    - whisparr.json64.dev
+  parentRefs:
+    - name: default-gateway
+      namespace: gateways
+      sectionName: json64-dev-https
+  rules:
+    - backendRefs:
+        - name: whisparr
+          port: 6969

--- a/generated/manifests/prod-axon/whisparr/PersistentVolumeClaim-whisparr.yaml
+++ b/generated/manifests/prod-axon/whisparr/PersistentVolumeClaim-whisparr.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: whisparr
+    app.kubernetes.io/name: whisparr
+  name: whisparr
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: longhorn

--- a/generated/manifests/prod-axon/whisparr/SecurityPolicy-whisparr-oidc.yaml
+++ b/generated/manifests/prod-axon/whisparr/SecurityPolicy-whisparr-oidc.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: whisparr-oidc
+  namespace: media
+spec:
+  oidc:
+    clientID: whisparr
+    clientSecret:
+      name: whisparr-oidc-client-secret
+    forwardAccessToken: true
+    provider:
+      issuer: https://idm.json64.dev/oauth2/openid/whisparr
+    scopes:
+      - email
+      - openid
+      - profile
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: whisparr

--- a/generated/manifests/prod-axon/whisparr/Service-whisparr.yaml
+++ b/generated/manifests/prod-axon/whisparr/Service-whisparr.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: whisparr
+    app.kubernetes.io/name: whisparr
+    app.kubernetes.io/service: whisparr
+  name: whisparr
+  namespace: media
+spec:
+  ports:
+    - name: http
+      port: 6969
+      protocol: TCP
+      targetPort: 6969
+  selector:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: whisparr
+    app.kubernetes.io/name: whisparr
+  type: ClusterIP

--- a/generated/manifests/prod-axon/whisparr/ServiceAccount-whisparr.yaml
+++ b/generated/manifests/prod-axon/whisparr/ServiceAccount-whisparr.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: whisparr
+    app.kubernetes.io/name: whisparr
+  name: whisparr
+  namespace: media

--- a/generated/manifests/prod-axon/whisparr/SopsSecret-whisparr-oidc-client-secret.yaml
+++ b/generated/manifests/prod-axon/whisparr/SopsSecret-whisparr-oidc-client-secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: whisparr-oidc-client-secret
+    namespace: media
+    annotations:
+        secrets.json64.dev/plaintext-sha256: 1f967f1a1a008e186a3248e9f26232ca88135f6143a3097d11e76f744db02a51
+spec:
+    secretTemplates:
+        - name: whisparr-oidc-client-secret
+          stringData:
+            client-secret: ENC[AES256_GCM,data:kxCQNXIICx4+3eEJOUsJ7iQ8W/3eCzza8yA1fynSYxxf0CsZ9EY/IdcUvyYVnvFNuACi7Stz6P3VYzOusypgUI7b7P1A4bAq,iv:kDcUdraJt4377q6JN06UvDsgxnfnfojeEz9bOr+eTrM=,tag:YtSi3uJz1b57hCO8lhNmZg==,type:str]
+          type: Opaque
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArcFdyOExOSHNoZUcybFkv
+            OHpyUmlkcUhXNERmS2ZoQ0pxbzVKNjUrQWdnCjFBYXZuTGRqQjlTalIrSlNOa291
+            ZEdKRUpoZUhvUEU4RWlIWVNxTmRZQk0KLS0tIEJaOHlWdW1GekxQQnplWm1JcW9E
+            eG52dkRDdW1ZdFJmazhUUDVVdEdXeW8KQkUVC8cfcLunf5N3guBtv3HN8VtHV79k
+            hH9TM4ERDS3b6N3vSmjXxDHbVnPl0EGSHKNnNZ+vtYJyY99mDOgSjg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-11T18:37:48Z"
+    mac: ENC[AES256_GCM,data:sn/LfqNUxPcUz9xsAeA0tOLvqWtZpv5GTjCFKoXdYFxokLd1ekaKMcYDmqzPJfrSHROu3wltP5oUhQdDcY/GBPiZoG9qySIEkNIgtibo7n4gazlFVWYdZoANm8WCup780xdwkZfpQCyu0Y9WBJEQiMTXVal21tk11mZzZh1gr6k=,iv:SUuqT4WAoB0+PDrtHnE6nKsckLaaP/XfXZUeVW9e5rE=,tag:GpkW+CFxEv3twwXHTtuO+Q==,type:str]
+    version: 3.13.1


### PR DESCRIPTION
PR #97 landed the media aspects but its commits bypassed the pre-commit hook that runs nixidy-sync, so `generated/manifests/prod-axon` (ArgoCD's source of truth) never picked up the media namespace. This is the missing render: 13 media Applications + CNPG operator/CRDs + storage/secrets/network-policy manifests, sops post-process included.

No aspect changes — pure regeneration from current main.