### PR TITLE
fix: SNAT non-host sources egressing the thunderbolt fabric

### DIFF
--- a/modules/den/aspects/services/networking/thunderbolt-mesh-of.nix
+++ b/modules/den/aspects/services/networking/thunderbolt-mesh-of.nix
@@ -111,15 +111,41 @@
           );
 
         fabricInterfaceConfig = lib.concatMapStringsSep "\n!\n" mkFabricInterface cfg.interfaces;
+
+        loopbackIp = head (splitString "/" cfg.loopback.ipv4);
+        fabricIfSet = concatStringsSep ", " (map (i: "\"${i}\"") cfg.interfaces);
+        snatExcludeSet = concatStringsSep ", " (lib.unique ([ loopbackIp ] ++ host.ipv4));
       in
       {
         config = {
           networking.interfaces.lo.ipv4.addresses = [
             {
-              address = head (splitString "/" cfg.loopback.ipv4);
+              address = loopbackIp;
               prefixLength = lib.toInt (lib.last (splitString "/" cfg.loopback.ipv4));
             }
           ];
+
+          # The fabric interfaces are unnumbered (loopback-based OpenFabric), so
+          # nothing on the egress path can masquerade forwarded traffic — a
+          # packet leaving the fabric with a non-host source (pod CIDRs, future
+          # VM guests) reaches the peer with a source it rejects: Cilium
+          # spoof-drops raw pod-IP packets arriving outside its tunnel.
+          # Invariant: the fabric only carries host-addressed sources. Anything
+          # else is SNAT'd to this node's fabric loopback; conntrack reverses
+          # replies. Host-sourced traffic (loopback or mgmt IPs) passes
+          # untouched. IPv4 only — add an ip6 table if v6 fabric flows appear.
+          networking.nftables = lib.mkIf (cfg.interfaces != [ ]) {
+            enable = true;
+            tables.fabric-source-snat = {
+              family = "ip";
+              content = ''
+                chain postrouting {
+                  type nat hook postrouting priority srcnat; policy accept;
+                  oifname { ${fabricIfSet} } ip saddr != { ${snatExcludeSet} } snat ip to ${loopbackIp}
+                }
+              '';
+            };
+          };
 
           systemd.network = {
             networks."20-thunderbolt" = {

--- a/modules/den/aspects/services/networking/thunderbolt-mesh-of.nix
+++ b/modules/den/aspects/services/networking/thunderbolt-mesh-of.nix
@@ -113,8 +113,11 @@
         fabricInterfaceConfig = lib.concatMapStringsSep "\n!\n" mkFabricInterface cfg.interfaces;
 
         loopbackIp = head (splitString "/" cfg.loopback.ipv4);
+        loopback6 = cfg.loopback.ipv6 or null;
+        loopback6Ip = if loopback6 != null then head (splitString "/" loopback6) else null;
         fabricIfSet = concatStringsSep ", " (map (i: "\"${i}\"") cfg.interfaces);
         snatExcludeSet = concatStringsSep ", " (lib.unique ([ loopbackIp ] ++ host.ipv4));
+        snat6ExcludeSet = concatStringsSep ", " (lib.unique ([ loopback6Ip ] ++ host.ipv6));
       in
       {
         config = {
@@ -122,6 +125,13 @@
             {
               address = loopbackIp;
               prefixLength = lib.toInt (lib.last (splitString "/" cfg.loopback.ipv4));
+            }
+          ];
+
+          networking.interfaces.lo.ipv6.addresses = lib.mkIf (loopback6 != null) [
+            {
+              address = loopback6Ip;
+              prefixLength = lib.toInt (lib.last (splitString "/" loopback6));
             }
           ];
 
@@ -133,7 +143,8 @@
           # Invariant: the fabric only carries host-addressed sources. Anything
           # else is SNAT'd to this node's fabric loopback; conntrack reverses
           # replies. Host-sourced traffic (loopback or mgmt IPs) passes
-          # untouched. IPv4 only — add an ip6 table if v6 fabric flows appear.
+          # untouched. The ip6 table mirrors it when a v6 loopback is set
+          # (link-local sources are left alone — they never leave the link).
           networking.nftables = lib.mkIf (cfg.interfaces != [ ]) {
             enable = true;
             tables.fabric-source-snat = {
@@ -142,6 +153,15 @@
                 chain postrouting {
                   type nat hook postrouting priority srcnat; policy accept;
                   oifname { ${fabricIfSet} } ip saddr != { ${snatExcludeSet} } snat ip to ${loopbackIp}
+                }
+              '';
+            };
+            tables.fabric-source-snat6 = lib.mkIf (loopback6 != null) {
+              family = "ip6";
+              content = ''
+                chain postrouting {
+                  type nat hook postrouting priority srcnat; policy accept;
+                  oifname { ${fabricIfSet} } ip6 saddr != { ${snat6ExcludeSet}, fe80::/10 } snat ip6 to ${loopback6Ip}
                 }
               '';
             };
@@ -154,7 +174,9 @@
                 ActivationPolicy = "up";
                 MTUBytes = "1500";
               };
-              networkConfig.LinkLocalAddressing = "no";
+              # v6 OpenFabric needs link-local on the fabric interfaces (IS-IS
+              # v6 nexthops are link-local); without a v6 loopback, no v6 at all.
+              networkConfig.LinkLocalAddressing = if loopback6 != null then "ipv6" else "no";
             };
 
             config.networkConfig = {

--- a/modules/den/clusters/axon.nix
+++ b/modules/den/clusters/axon.nix
@@ -47,6 +47,12 @@
       };
     };
 
+    # Reserved (NOT networks entries — nothing should iterate these as cluster
+    # networks): thunderbolt fabric loopbacks, assigned per-host in
+    # hosts/axon-0N.nix (services.networking.thunderbolt-mesh-of.loopback):
+    #   172.16.255.0/24      ipv4 fabric loopbacks (axon-0N = .N/32)
+    #   fdfd:cafe:0:ff::/64  ipv6 fabric loopbacks (axon-0N = ::N/128)
+
     nfsVolumes.vault-nfs = {
       server = "10.10.10.10";
       share = "/volume2/data";

--- a/modules/den/hosts/axon-01.nix
+++ b/modules/den/hosts/axon-01.nix
@@ -25,6 +25,9 @@
           "enp199s0f6"
         ];
         loopback.ipv4 = "172.16.255.1/32";
+        # Fabric v6 loopbacks: fdfd:cafe:0:ff::/64 reserved for the mesh
+        # (pods 0:1::/96, services 0:8001::/112 — see clusters/axon.nix)
+        loopback.ipv6 = "fdfd:cafe:0:ff::1/128";
         nsap = "49.0000.0000.0001.00";
       };
       disk.zfs-disk-single.device_id = "/dev/disk/by-id/nvme-NVMe_CA6-8D1024_00230650035M";

--- a/modules/den/hosts/axon-02.nix
+++ b/modules/den/hosts/axon-02.nix
@@ -25,6 +25,9 @@
           "enp199s0f6"
         ];
         loopback.ipv4 = "172.16.255.2/32";
+        # Fabric v6 loopbacks: fdfd:cafe:0:ff::/64 reserved for the mesh
+        # (pods 0:1::/96, services 0:8001::/112 — see clusters/axon.nix)
+        loopback.ipv6 = "fdfd:cafe:0:ff::2/128";
         nsap = "49.0000.0000.0002.00";
       };
       disk.zfs-disk-single.device_id = "/dev/disk/by-id/nvme-KINGSTON_OM8PGP41024Q-A0_50026B738300BDD8";

--- a/modules/den/hosts/axon-03.nix
+++ b/modules/den/hosts/axon-03.nix
@@ -25,6 +25,9 @@
           "enp199s0f6"
         ];
         loopback.ipv4 = "172.16.255.3/32";
+        # Fabric v6 loopbacks: fdfd:cafe:0:ff::/64 reserved for the mesh
+        # (pods 0:1::/96, services 0:8001::/112 — see clusters/axon.nix)
+        loopback.ipv6 = "fdfd:cafe:0:ff::3/128";
         nsap = "49.0000.0000.0003.00";
       };
       disk.zfs-disk-single.device_id = "/dev/disk/by-id/nvme-KINGSTON_OM8PGP41024Q-A0_50026B738300CCCC";


### PR DESCRIPTION
Root cause of the day's intermittent apiserver-discovery i/o timeout failures (argocd, cert-manager): pod-sourced traffic to peer node IPs rides the fabric (by design — it is the fast path), but the fabric interfaces are unnumbered, so Cilium's BPF masquerade has no address to SNAT to. Packets leave with raw pod source IPs and the receiving node's Cilium spoof-drops them (tunnel mode requires cross-node pod traffic to arrive encapsulated). Result: pod→remote apiserver backends fail 100%, pod→local succeeds — a 1-in-3 lottery per socket-LB pick. Verified end-to-end with in-pod connect tests (local 3/3, both remotes 0/3) and hubble (SYNs leave the source node `to-stack` with pod source, never seen on the peer).

Fix lives in the mesh aspect (the unnumbered design owns its consequence) and generalizes beyond k8s: **the fabric only carries host-addressed sources** — anything else (pods today, microvm guests tomorrow) is SNAT'd to the node's fabric loopback via a declarative nftables table; conntrack reverses replies; loopback/mgmt-sourced host traffic (etcd etc.) passes untouched. IPv4 only for now.

Deploy: `colmena apply` on the k3s nodes (no reboot needed). Validation: in-pod connects to all three backends 3/3, then the argo app-of-apps sync should stop tripping over discovery timeouts.