### PR TITLE
fix: scratch NFS export must admit fabric loopback sources

### DIFF
--- a/modules/den/aspects/services/storage/media-scratch.nix
+++ b/modules/den/aspects/services/storage/media-scratch.nix
@@ -61,9 +61,17 @@ in
 
       services.nfs.server = {
         enable = true;
-        exports = ''
-          ${exportPath} 172.20.0.0/16(rw,no_subtree_check,all_squash,anonuid=1027,anongid=65536) 10.10.10.0/24(rw,no_subtree_check,all_squash,anonuid=1027,anongid=65536)
-        '';
+        # Client ranges: pod CIDR, management network, and the thunderbolt
+        # fabric loopbacks (172.16.255.0/24) — peer kubelets mount over the
+        # fabric and source from their loopback, as does pod traffic SNAT'd by
+        # the fabric-source-snat invariant (thunderbolt-mesh-of.nix).
+        exports =
+          let
+            opts = "(rw,no_subtree_check,all_squash,anonuid=1027,anongid=65536)";
+          in
+          ''
+            ${exportPath} 172.20.0.0/16${opts} 10.10.10.0/24${opts} 172.16.255.0/24${opts}
+          '';
       };
 
       networking.firewall.allowedTCPPorts = [ 2049 ];


### PR DESCRIPTION
Follow-on to #100: with peer mgmt IPs routed over the fabric, kubelet NFS mounts of the media-scratch export arrive sourced from the peers' fabric loopbacks — as does pod traffic SNAT'd by the fabric-source-snat invariant. The export list only admitted the pod CIDR and management network, so mounts from the other nodes failed with `mount.nfs: access denied by server`, leaving the arr pods in ContainerCreating.

Adds the fabric loopback range with identical all-squash options. Deploy: `colmena apply` on the export host only; kubelet retries the mounts automatically.