### PR TITLE
fix: gluetun v3.40+ control-server paths for port-sync

### DIFF
--- a/generated/manifests/prod-axon/qbittorrent/Deployment-qbittorrent.yaml
+++ b/generated/manifests/prod-axon/qbittorrent/Deployment-qbittorrent.yaml
@@ -49,7 +49,7 @@ spec:
             - -c
             - |
               set -eu
-              GTN=http://127.0.0.1:8000/v1/openvpn/portforwarded
+              GTN=http://127.0.0.1:8000/v1/portforward
               QBT=http://127.0.0.1:8080
               last=""
               while true; do
@@ -162,7 +162,7 @@ spec:
           readinessProbe:
             failureThreshold: 30
             httpGet:
-              path: /v1/openvpn/status
+              path: /v1/vpn/status
               port: 8000
               scheme: HTTP
             initialDelaySeconds: 5

--- a/modules/den/aspects/kubernetes/services/media/qbittorrent.nix
+++ b/modules/den/aspects/kubernetes/services/media/qbittorrent.nix
@@ -53,7 +53,7 @@
 # == Port forwarding ==
 # ProtonVPN supports incoming port forwarding; gluetun (VPN_PORT_FORWARDING=on)
 # obtains the forwarded port and exposes it on its control server at
-# 127.0.0.1:8000/v1/openvpn/portforwarded. We do NOT use gluetun's
+# 127.0.0.1:8000/v1/portforward (v3.40+ path; the old /v1/openvpn/portforwarded 301s and busybox wget will not follow). We do NOT use gluetun's
 # VPN_PORT_FORWARDING_UP_COMMAND: app-template runs every container env value
 # through Helm's `tpl`, which chokes on gluetun's {{PORTS}} placeholder
 # ("function PORTS not defined") — escaping it through two template layers is
@@ -172,7 +172,7 @@ let
   # escaped as `''${var}` so Nix leaves them for the shell.
   portSyncScript = ''
     set -eu
-    GTN=http://127.0.0.1:8000/v1/openvpn/portforwarded
+    GTN=http://127.0.0.1:8000/v1/portforward
     QBT=http://127.0.0.1:${toString webuiPort}
     last=""
     while true; do
@@ -326,7 +326,7 @@ let
           probes.readiness = {
             enabled = true;
             type = "HTTP";
-            path = "/v1/openvpn/status";
+            path = "/v1/vpn/status"; # v3.40+ path (old /v1/openvpn/* 301s)
             port = 8000;
             spec = {
               initialDelaySeconds = 5;


### PR DESCRIPTION
Deploy validation caught it (the port-sync no-port log signal): gluetun v3.41 moved the control-server routes — `/v1/openvpn/portforwarded` now 301s to `/v1/portforward`, and busybox wget doesn't follow redirects, so qbittorrent never received its forwarded port. Readiness probe also updated to `/v1/vpn/status` (it worked via 301 — kubelet counts 3xx as success — but pin the canonical path). Manifests regenerated. After merge+sync, port-sync logs should show the port PATCH within ~60s.