### PR TITLE
fix: tailscale --accept-dns=false on k3s nodes — pod DNS search-domain TLS hijack

### DIFF
--- a/modules/den/aspects/services/k3s/node.nix
+++ b/modules/den/aspects/services/k3s/node.nix
@@ -131,7 +131,19 @@ in
         # the autoconnect only runs `tailscale up` on first auth — on
         # already-connected nodes only `tailscale set` re-applies the mode and
         # tears down the rules tailscale previously installed.
-        services.tailscale.extraSetFlags = [ "--netfilter-mode=off" ];
+        #
+        # --accept-dns=false: MagicDNS pushes `search ts.json64.dev` into
+        # systemd-resolved; kubelet copies node search domains into every pod
+        # sandbox, where ndots:5 search-expands ~every external hostname
+        # through the CF-proxied `*.ts.json64.dev` wildcard — hijacking pod
+        # TLS cluster-wide (SNI-mismatch handshake_failure at the CF edge,
+        # OIDC/ACME timeouts). k3s nodes must never inherit MagicDNS resolver
+        # config; tailscale0 still routes by IP. Takes effect in pods after a
+        # k3s restart (kubelet re-reads resolv.conf) + pod recreation.
+        services.tailscale.extraSetFlags = [
+          "--netfilter-mode=off"
+          "--accept-dns=false"
+        ];
       };
   };
 }


### PR DESCRIPTION
Root cause of the cluster-wide pod TLS failures (and the EG OIDC-discovery timeouts + blocked ACME renewals): tailscale MagicDNS pushes its tailnet search domain into systemd-resolved on the nodes; kubelet copies node search domains into pod sandboxes, where `ndots:5` search-expands ~every hostname through the CF-proxied tailnet wildcard. Pods then TLS-handshake a Cloudflare edge with the wrong SNI: CF-hosted destinations accidentally work, everything else gets `handshake_failure` (or timeouts for the IdP and ACME). Today's k3s restarts were the trigger — kubelet only re-reads resolv.conf on restart, so the pollution predated today but was inert.

Fix: `--accept-dns=false` alongside the existing `netfilter-mode=off` taming (k3s nodes must not inherit MagicDNS resolver config; tailscale0 still routes by IP).

Deploy: `colmena apply` on the k3s nodes, restart k3s, then recreate pods so sandboxes get clean resolv. Expected cascade once clean: EG OIDC fetches succeed → SecurityPolicies stop 500ing; cert-manager reaches LE → wildcard certs renew → gateway listeners all clean → CF 525s end.