### PR TITLE
fix: media gateway-ingress CNPs target ns gateways (data plane), not envoy-gateway-system

### DIFF
--- a/generated/manifests/prod-axon/bazarr/CiliumNetworkPolicy-allow-gateway-ingress-bazarr.yaml
+++ b/generated/manifests/prod-axon/bazarr/CiliumNetworkPolicy-allow-gateway-ingress-bazarr.yaml
@@ -11,7 +11,7 @@ spec:
   ingress:
     - fromEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+            k8s:io.kubernetes.pod.namespace: gateways
       toPorts:
         - ports:
             - port: "6767"

--- a/generated/manifests/prod-axon/dash/CiliumNetworkPolicy-allow-gateway-ingress-dash.yaml
+++ b/generated/manifests/prod-axon/dash/CiliumNetworkPolicy-allow-gateway-ingress-dash.yaml
@@ -11,7 +11,7 @@ spec:
   ingress:
     - fromEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+            k8s:io.kubernetes.pod.namespace: gateways
       toPorts:
         - ports:
             - port: "3000"

--- a/generated/manifests/prod-axon/glance/CiliumNetworkPolicy-allow-gateway-ingress-glance.yaml
+++ b/generated/manifests/prod-axon/glance/CiliumNetworkPolicy-allow-gateway-ingress-glance.yaml
@@ -11,7 +11,7 @@ spec:
   ingress:
     - fromEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+            k8s:io.kubernetes.pod.namespace: gateways
       toPorts:
         - ports:
             - port: "8080"

--- a/generated/manifests/prod-axon/komga/CiliumNetworkPolicy-allow-gateway-ingress-komga.yaml
+++ b/generated/manifests/prod-axon/komga/CiliumNetworkPolicy-allow-gateway-ingress-komga.yaml
@@ -11,7 +11,7 @@ spec:
   ingress:
     - fromEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+            k8s:io.kubernetes.pod.namespace: gateways
       toPorts:
         - ports:
             - port: "25600"

--- a/generated/manifests/prod-axon/lidarr/CiliumNetworkPolicy-allow-gateway-ingress-lidarr.yaml
+++ b/generated/manifests/prod-axon/lidarr/CiliumNetworkPolicy-allow-gateway-ingress-lidarr.yaml
@@ -11,7 +11,7 @@ spec:
   ingress:
     - fromEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+            k8s:io.kubernetes.pod.namespace: gateways
       toPorts:
         - ports:
             - port: "8686"

--- a/generated/manifests/prod-axon/prowlarr/CiliumNetworkPolicy-allow-gateway-ingress-prowlarr.yaml
+++ b/generated/manifests/prod-axon/prowlarr/CiliumNetworkPolicy-allow-gateway-ingress-prowlarr.yaml
@@ -11,7 +11,7 @@ spec:
   ingress:
     - fromEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+            k8s:io.kubernetes.pod.namespace: gateways
       toPorts:
         - ports:
             - port: "9696"

--- a/generated/manifests/prod-axon/qbittorrent/CiliumNetworkPolicy-allow-gateway-ingress-qbittorrent.yaml
+++ b/generated/manifests/prod-axon/qbittorrent/CiliumNetworkPolicy-allow-gateway-ingress-qbittorrent.yaml
@@ -11,7 +11,7 @@ spec:
   ingress:
     - fromEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+            k8s:io.kubernetes.pod.namespace: gateways
       toPorts:
         - ports:
             - port: "8080"

--- a/generated/manifests/prod-axon/radarr/CiliumNetworkPolicy-allow-gateway-ingress-radarr.yaml
+++ b/generated/manifests/prod-axon/radarr/CiliumNetworkPolicy-allow-gateway-ingress-radarr.yaml
@@ -11,7 +11,7 @@ spec:
   ingress:
     - fromEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+            k8s:io.kubernetes.pod.namespace: gateways
       toPorts:
         - ports:
             - port: "7878"

--- a/generated/manifests/prod-axon/romm/CiliumNetworkPolicy-allow-gateway-ingress-romm.yaml
+++ b/generated/manifests/prod-axon/romm/CiliumNetworkPolicy-allow-gateway-ingress-romm.yaml
@@ -11,7 +11,7 @@ spec:
   ingress:
     - fromEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+            k8s:io.kubernetes.pod.namespace: gateways
       toPorts:
         - ports:
             - port: "8080"

--- a/generated/manifests/prod-axon/sabnzbd/CiliumNetworkPolicy-allow-gateway-ingress-sabnzbd.yaml
+++ b/generated/manifests/prod-axon/sabnzbd/CiliumNetworkPolicy-allow-gateway-ingress-sabnzbd.yaml
@@ -11,7 +11,7 @@ spec:
   ingress:
     - fromEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+            k8s:io.kubernetes.pod.namespace: gateways
       toPorts:
         - ports:
             - port: "8080"

--- a/generated/manifests/prod-axon/sonarr/CiliumNetworkPolicy-allow-gateway-ingress-sonarr.yaml
+++ b/generated/manifests/prod-axon/sonarr/CiliumNetworkPolicy-allow-gateway-ingress-sonarr.yaml
@@ -11,7 +11,7 @@ spec:
   ingress:
     - fromEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+            k8s:io.kubernetes.pod.namespace: gateways
       toPorts:
         - ports:
             - port: "8989"

--- a/generated/manifests/prod-axon/whisparr/CiliumNetworkPolicy-allow-gateway-ingress-whisparr.yaml
+++ b/generated/manifests/prod-axon/whisparr/CiliumNetworkPolicy-allow-gateway-ingress-whisparr.yaml
@@ -11,7 +11,7 @@ spec:
   ingress:
     - fromEndpoints:
         - matchLabels:
-            k8s:io.kubernetes.pod.namespace: envoy-gateway-system
+            k8s:io.kubernetes.pod.namespace: gateways
       toPorts:
         - ports:
             - port: "6969"

--- a/modules/den/aspects/kubernetes/services/media/_media-app.nix
+++ b/modules/den/aspects/kubernetes/services/media/_media-app.nix
@@ -50,7 +50,10 @@ let
   # Namespace the Envoy Gateway data-plane (proxy) pods run in — they originate
   # ingress to the app pods. (envoy-gateway.nix deploys the controller and the
   # managed Envoy deployments in envoy-gateway-system.)
-  gatewayNamespace = "envoy-gateway-system";
+  # The DATA-PLANE proxy pods (EG-managed default-gateway deployment) live in
+  # ns "gateways" — not envoy-gateway-system (that's only the controller).
+  # The ingress allow must match the pods that actually dial the backends.
+  gatewayNamespace = "gateways";
 in
 {
   mkMediaApp =


### PR DESCRIPTION
Found in live validation: after a successful kanidm OIDC exchange, every media UI returned `upstream connect error or disconnect/reset before headers. reset reason: connection timeout` — envoy's dial to the backend was CNP-dropped. The helper's gateway-ingress allow matched namespace `envoy-gateway-system` (the controller), but the EG-managed data-plane pods (`default-gateway-*`) run in namespace `gateways`. The earlier 302 probes masked this: envoy issues the OIDC redirect without contacting the backend.

One-line fix in `_media-app.nix` + manifest regen — applies to all 13 media UIs at once. After merge+sync, authenticated requests should land in the apps.