### PR TITLE
fix: sab inet_exposure + qbt stale single-instance lockfile

### DIFF
--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-deny-media-ingress-configarr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-deny-media-ingress-configarr.yaml
@@ -10,3 +10,4 @@ spec:
   endpointSelector:
     matchLabels:
       app.kubernetes.io/name: configarr
+  ingress: []

--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-deny-media-ingress-unpackerr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-deny-media-ingress-unpackerr.yaml
@@ -10,3 +10,4 @@ spec:
   endpointSelector:
     matchLabels:
       app.kubernetes.io/name: unpackerr
+  ingress: []

--- a/generated/manifests/prod-axon/qbittorrent/Deployment-qbittorrent.yaml
+++ b/generated/manifests/prod-axon/qbittorrent/Deployment-qbittorrent.yaml
@@ -90,6 +90,10 @@ spec:
               set -eu
               INI=/config/qBittorrent/qBittorrent.conf
               mkdir -p /config/qBittorrent
+              # A fresh pod can never legitimately hold the single-instance lock (RWO
+              # PVC, replicas=1). A stale lockfile from a prior pod makes qbt assume a
+              # running instance and exit 0 silently — crash-looping with zero output.
+              rm -f /config/qBittorrent/lockfile
               ensure_key() {
                 # ensure_key <key-escaped-for-sed> <full-line>
                 # NB: $line lands in sed REPLACEMENT/append contexts, where a lone

--- a/generated/manifests/prod-axon/sabnzbd/Deployment-sabnzbd.yaml
+++ b/generated/manifests/prod-axon/sabnzbd/Deployment-sabnzbd.yaml
@@ -80,6 +80,7 @@ spec:
                   printf '%s\n' 'port = 8080'
                   printf '%s\n' "api_key = $API_KEY"
                   printf '%s\n' "host_whitelist = $WHITELIST"
+                  printf '%s\n' 'inet_exposure = 4'
                   printf '%s\n' 'download_dir = /scratch/usenet/incomplete'
                   printf '%s\n' 'complete_dir = /scratch/usenet/complete'
                 } > "$INI"
@@ -97,6 +98,13 @@ spec:
                   sed -i "s|^host_whitelist = .*|host_whitelist = $WHITELIST|" "$INI"
                 else
                   sed -i "/^\[misc\]/a host_whitelist = $WHITELIST" "$INI"
+                fi
+                # inet_exposure 4 = WebUI reachable from non-local clients (the gateway's
+                # pod network); without it SAB answers "External internet access denied".
+                if grep -q '^inet_exposure = ' "$INI"; then
+                  sed -i "s|^inet_exposure = .*|inet_exposure = 4|" "$INI"
+                else
+                  sed -i "/^\[misc\]/a inet_exposure = 4" "$INI"
                 fi
               fi
           env:

--- a/modules/den/aspects/kubernetes/services/media/network-policy.nix
+++ b/modules/den/aspects/kubernetes/services/media/network-policy.nix
@@ -231,6 +231,10 @@ let
             description = "Default-deny all ingress to ${name} (no inbound callers).";
             endpointSelector = podSel name;
             enableDefaultDeny.ingress = true;
+            # CRD anyOf requires one of ingress/ingressDeny/egress/egressDeny to
+            # be present; an empty list adds zero allow rules (NOT [ { } ], which
+            # would allow-all) while enableDefaultDeny above does the deny.
+            ingress = [ ];
           };
         }
       )

--- a/modules/den/aspects/kubernetes/services/media/qbittorrent.nix
+++ b/modules/den/aspects/kubernetes/services/media/qbittorrent.nix
@@ -140,6 +140,10 @@ let
     set -eu
     INI=/config/qBittorrent/qBittorrent.conf
     mkdir -p /config/qBittorrent
+    # A fresh pod can never legitimately hold the single-instance lock (RWO
+    # PVC, replicas=1). A stale lockfile from a prior pod makes qbt assume a
+    # running instance and exit 0 silently — crash-looping with zero output.
+    rm -f /config/qBittorrent/lockfile
     ensure_key() {
       # ensure_key <key-escaped-for-sed> <full-line>
       # NB: $line lands in sed REPLACEMENT/append contexts, where a lone

--- a/modules/den/aspects/kubernetes/services/media/sabnzbd.nix
+++ b/modules/den/aspects/kubernetes/services/media/sabnzbd.nix
@@ -58,6 +58,7 @@ let
         printf '%s\n' 'port = 8080'
         printf '%s\n' "api_key = $API_KEY"
         printf '%s\n' "host_whitelist = $WHITELIST"
+        printf '%s\n' 'inet_exposure = 4'
         printf '%s\n' 'download_dir = /scratch/usenet/incomplete'
         printf '%s\n' 'complete_dir = /scratch/usenet/complete'
       } > "$INI"
@@ -75,6 +76,13 @@ let
         sed -i "s|^host_whitelist = .*|host_whitelist = $WHITELIST|" "$INI"
       else
         sed -i "/^\[misc\]/a host_whitelist = $WHITELIST" "$INI"
+      fi
+      # inet_exposure 4 = WebUI reachable from non-local clients (the gateway's
+      # pod network); without it SAB answers "External internet access denied".
+      if grep -q '^inet_exposure = ' "$INI"; then
+        sed -i "s|^inet_exposure = .*|inet_exposure = 4|" "$INI"
+      else
+        sed -i "/^\[misc\]/a inet_exposure = 4" "$INI"
       fi
     fi
   '';


### PR DESCRIPTION
Two live-validation findings from the new session:

1. **sabnzbd `External internet access denied`**: the seeded minimal ini never set `inet_exposure`; SAB's default denies non-local clients, which includes the gateway's pod network. Seed/reconcile `inet_exposure = 4` (external WebUI access — real auth stays at envoy OIDC, API via api_key).
2. **qbt UI upstream timeout / port-sync 'not ready' forever**: qbt 5.2.1 was silently crash-looping (exit 0, zero output, s6 'up 0 seconds') because a stale `/config/qBittorrent/lockfile` from the previous (5.1.2) pod survived on the RWO PVC — qbt's single-instance check collides with a recycled PID and exits as if forwarding to a live instance. config-seed now removes the lockfile every pod start (a fresh pod can never legitimately hold it; replicas=1). Live-verified: after lockfile removal the WebUI answered `v5.2.1` immediately.

Manifests regenerated.