### PR TITLE
fix(romm): ROMM_DB_DRIVER env name + bump to 4.9.0-beta.3

### DIFF
--- a/generated/manifests/prod-axon/romm/Deployment-romm.yaml
+++ b/generated/manifests/prod-axon/romm/Deployment-romm.yaml
@@ -27,8 +27,6 @@ spec:
       automountServiceAccountToken: false
       containers:
         - env:
-            - name: DB_DRIVER
-              value: postgresql
             - name: DB_HOST
               value: media-pg-rw
             - name: DB_NAME
@@ -54,9 +52,11 @@ spec:
                 secretKeyRef:
                   key: auth-secret-key
                   name: media-romm
+            - name: ROMM_DB_DRIVER
+              value: postgresql
             - name: TZ
               value: America/Los_Angeles
-          image: rommapp/romm:3.10.3
+          image: rommapp/romm:4.9.0-beta.3
           name: main
           volumeMounts:
             - mountPath: /romm/library

--- a/modules/den/aspects/kubernetes/services/media/romm.nix
+++ b/modules/den/aspects/kubernetes/services/media/romm.nix
@@ -5,8 +5,10 @@
 # "romm" client already targets), clientID "romm".
 #
 # == DATABASE DECISION: PostgreSQL (media-pg) — confidence HIGH ==
-# RomM 3.x officially supports PostgreSQL alongside MariaDB. The backend driver is
-# selected with DB_DRIVER ("postgresql" | "mariadb") and the connection is given
+# RomM officially supports PostgreSQL alongside MariaDB. The backend driver is
+# selected with ROMM_DB_DRIVER ("postgresql" | "mariadb", default mariadb — a bare
+# DB_DRIVER is silently ignored, so RomM speaks mariadb protocol to media-pg and
+# crash-loops on the handshake) and the connection is given
 # via DB_HOST / DB_PORT / DB_NAME / DB_USER / DB_PASSWD. We wire RomM to the shared
 # media-pg CNPG cluster: the `romm` login role and `romm` database are already
 # provisioned in media-pg.nix (roleApps + singleDatabases), and a generated
@@ -77,7 +79,7 @@ let
     port = rommPort;
     image = {
       repository = "rommapp/romm";
-      tag = "3.10.3";
+      tag = "4.9.0-beta.3";
     };
     inherit (config.den) environments;
 
@@ -100,7 +102,7 @@ let
 
     env = {
       # --- database (media-pg, postgresql driver) ---
-      DB_DRIVER = "postgresql";
+      ROMM_DB_DRIVER = "postgresql";
       DB_HOST = "media-pg-rw";
       DB_PORT = "5432";
       DB_NAME = "romm";


### PR DESCRIPTION
RomM ignores a bare `DB_DRIVER` — its driver selector is `ROMM_DB_DRIVER` (default `mariadb`). With the wrong name it spoke mariadb protocol to media-pg and crash-looped on the postgres handshake (`mariadb.InterfaceError: Lost connection ... reading initial communication packet`, 11+ restarts).

- Rename env to `ROMM_DB_DRIVER=postgresql` (per https://docs.romm.app/latest/Getting-Started/Environment-Variables/)
- Bump image `rommapp/romm` 3.10.3 → 4.9.0-beta.3 (user-requested; latest stable is 4.8.1, beta preferred). DB is effectively fresh — romm never completed a boot against media-pg — so the 4.x migrations run on an empty schema.
- Manifests re-rendered via nixidy-sync.