### PR TITLE
fix(qbittorrent): stop forwarding OIDC access token (qbt 404s on Bearer)

### DIFF
--- a/generated/manifests/prod-axon/qbittorrent/SecurityPolicy-qbittorrent-oidc.yaml
+++ b/generated/manifests/prod-axon/qbittorrent/SecurityPolicy-qbittorrent-oidc.yaml
@@ -8,7 +8,7 @@ spec:
     clientID: qbittorrent
     clientSecret:
       name: qbittorrent-oidc-client-secret
-    forwardAccessToken: true
+    forwardAccessToken: false
     provider:
       issuer: https://idm.json64.dev/oauth2/openid/qbittorrent
     scopes:

--- a/modules/den/aspects/kubernetes/services/media/_media-app.nix
+++ b/modules/den/aspects/kubernetes/services/media/_media-app.nix
@@ -70,6 +70,7 @@ in
       mounts ? { }, # { data?; scratch-nfs?; scratch-local?; } (bools)
       route ? true, # HTTPRoute on default-gateway
       oidc ? true, # SecurityPolicy + client secret (requires route)
+      oidcForwardAccessToken ? true, # forward the access token as Authorization: Bearer to the upstream. qBittorrent 5.x answers 404 to ANY request carrying an Authorization: Bearer header (verified live 2026-06-11), so qbt sets this false; everything else ignores the header.
       internetEgress ? false, # add world egress on 80/443 (flaresolverr et al)
       extraEgressPorts ? [ ], # extra TCP ports added to the world-egress policy alongside 80/443 (only meaningful with internetEgress=true). Used by sabnzbd for NNTP 119/563. Minimal helper extension for the media-stack Usenet task.
       extraCnps ? { }, # additional CiliumNetworkPolicies merged into the app's resources.ciliumNetworkPolicies. Keys colliding with a baseline policy are a build error (asserted below), not a silent clobber. Used by unpackerr for its own *arr-egress edges. Minimal helper extension.
@@ -392,7 +393,7 @@ in
                     "openid"
                     "profile"
                   ];
-                  forwardAccessToken = true;
+                  forwardAccessToken = oidcForwardAccessToken;
                 };
               };
 

--- a/modules/den/aspects/kubernetes/services/media/qbittorrent.nix
+++ b/modules/den/aspects/kubernetes/services/media/qbittorrent.nix
@@ -220,6 +220,11 @@ let
     };
     inherit (config.den) environments;
 
+    # qBittorrent 5.x answers 404 "Not Found" to ANY request carrying an
+    # Authorization: Bearer header (verified live 2026-06-11), and nothing in
+    # qbt consumes the forwarded token — keep it off the upstream request.
+    oidcForwardAccessToken = false;
+
     # qBittorrent stores nothing in postgres.
     postgres = false;
 


### PR DESCRIPTION
After #108 fixed the network path, the qbt UI returned plain `Not Found` post-login. Envoy access logs show OIDC passing and the qbt upstream itself answering 404 (`response_code_details: via_upstream`, 9-byte body) on `GET /`.

Bisected the request headers in-cluster against the live pod:
- `Authorization: Bearer junktoken` → **404**
- OIDC cookies only → 200
- plain → 200

qBittorrent 5.x rejects any request with an `Authorization: Bearer` header as 404. `forwardAccessToken: true` (hardcoded in `_media-app.nix`) injects exactly that after auth. The other apps ignore the header, and nothing in qbt consumes the token — so this makes `forwardAccessToken` a per-app knob (default unchanged: true) and disables it for qbittorrent only. Rendered diff is a single line in the qbt SecurityPolicy.