### PR TITLE
fix(qbittorrent): port-sync steady-state log false alarm

### DIFF
--- a/generated/manifests/prod-axon/qbittorrent/Deployment-qbittorrent.yaml
+++ b/generated/manifests/prod-axon/qbittorrent/Deployment-qbittorrent.yaml
@@ -57,7 +57,11 @@ spec:
                 # object like {"port":12345}; this sed grabs the first "port":<digits>. If
                 # gluetun ever pretty-prints the response, this extraction must change.
                 port="$(wget -qO- "$GTN" 2>/dev/null | sed -n 's/.*"port":\([0-9]*\).*/\1/p' || true)"
-                if [ -n "${port:-}" ] && [ "${port}" != "0" ] && [ "${port}" != "${last}" ]; then
+                if [ -z "${port:-}" ] || [ "${port}" = "0" ]; then
+                  echo "port-sync: no forwarded port from gluetun control server"
+                elif [ "${port}" = "${last}" ]; then
+                  : # steady state: port unchanged, nothing to push — stay quiet
+                else
                   echo "port-sync: setting qBittorrent listen port to ${port}"
                   if wget -qO- --post-data "json={\"listen_port\":${port}}" \
                       "$QBT/api/v2/app/setPreferences" >/dev/null 2>&1; then
@@ -65,8 +69,6 @@ spec:
                   else
                     echo "port-sync: setPreferences failed (qBittorrent not ready?), will retry"
                   fi
-                else
-                  echo "port-sync: no forwarded port from gluetun control server"
                 fi
                 sleep 60
               done

--- a/modules/den/aspects/kubernetes/services/media/qbittorrent.nix
+++ b/modules/den/aspects/kubernetes/services/media/qbittorrent.nix
@@ -191,7 +191,11 @@ let
       # object like {"port":12345}; this sed grabs the first "port":<digits>. If
       # gluetun ever pretty-prints the response, this extraction must change.
       port="$(wget -qO- "$GTN" 2>/dev/null | sed -n 's/.*"port":\([0-9]*\).*/\1/p' || true)"
-      if [ -n "''${port:-}" ] && [ "''${port}" != "0" ] && [ "''${port}" != "''${last}" ]; then
+      if [ -z "''${port:-}" ] || [ "''${port}" = "0" ]; then
+        echo "port-sync: no forwarded port from gluetun control server"
+      elif [ "''${port}" = "''${last}" ]; then
+        : # steady state: port unchanged, nothing to push — stay quiet
+      else
         echo "port-sync: setting qBittorrent listen port to ''${port}"
         if wget -qO- --post-data "json={\"listen_port\":''${port}}" \
             "$QBT/api/v2/app/setPreferences" >/dev/null 2>&1; then
@@ -199,8 +203,6 @@ let
         else
           echo "port-sync: setPreferences failed (qBittorrent not ready?), will retry"
         fi
-      else
-        echo "port-sync: no forwarded port from gluetun control server"
       fi
       sleep 60
     done


### PR DESCRIPTION
port-sync logged `no forwarded port from gluetun control server` every 60s in steady state, because the unchanged-port case (`port == last`) fell into the same else branch as the genuinely-missing-port case. Verified live: gluetun serves the forwarded port and qbt prefs hold the matching `listen_port`, yet the log cried wolf each cycle. Split the conditions; behavior unchanged, only logging.