### PR TITLE
feat(microvm): cortex-cuda as delivered guest of cortex (fleet participation)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -443,11 +443,11 @@
     },
     "den": {
       "locked": {
-        "lastModified": 1781197965,
-        "narHash": "sha256-KzJ8WMzFAXcIBxveZVz3DypYgqy3sa8B2AWaexBc3tw=",
+        "lastModified": 1781279595,
+        "narHash": "sha256-Vb9Bkg3MxjVOjWgl4OV1PRU3flllhs7eCwEDe7UMQYQ=",
         "owner": "sini",
         "repo": "den",
-        "rev": "046589827bb217c7bb9419999fcb4cd68d1da40a",
+        "rev": "e8876f3e26f752804b483a9f3fb8e68b563c4681",
         "type": "github"
       },
       "original": {

--- a/modules/den/aspects/virtualization/guests.nix
+++ b/modules/den/aspects/virtualization/guests.nix
@@ -1,0 +1,304 @@
+# microvm guests — nest a *guest* host inside a *parent* host's instantiated
+# configuration (microvm.vms.<name>.config) instead of producing a standalone
+# nixosConfigurations.<name> output. Declared per-parent via `host.guests`.
+#
+# This is a nix-config CONSUMER policy composed entirely from den public
+# primitives — no den-core machinery lives here:
+#   - resolve.to.withIncludes      (nest the guest as an isolated child scope)
+#   - route { reinstantiate; … }   (deliver the guest's nixos into the microvm
+#                                    slot, which re-instantiates it as its own
+#                                    nixosSystem)
+#   - den.schema.<kind>.isolated   (entity isolation: keep guest content out of
+#                                    the parent's own toplevel partition)
+#
+# ===================== DESIGN (entity-isolation) ===========================
+#
+# DELIVERY = entity-isolation + a collect/append-decoupled route. The guest
+# authors honest `nixos` content; a dedicated `guest` kind marked
+# `isolated = true` keeps that content out of the parent's own toplevel nixos
+# partition (isolation-aware subtree extraction skips isolated descendants and
+# everything below them).
+#
+#   1. resolve.to.withIncludes "guest" [ deliverPolicy ]
+#        { guest = guest; host = guest; }
+#      nests the guest as an isolated child entity scope under the parent host.
+#      The `host` binding rebinds host to the guest INSIDE the guest scope so
+#      curated host-include policies (host-to-users, the standard home-manager
+#      battery, den.default) fire for the guest as if it were a host. The
+#      `guest` binding makes resolveEntityClass derive the guest's class
+#      (always nixos here).
+#
+#   2. The delivery route is registered INSIDE the guest scope (a resolve
+#      include). It collects `fromClass = "nixos"` rooted at the guest scope
+#      (the collection root is exempt from isolation) and, via
+#      `appendToParent = true`, lands the wrapped result at the PARENT scope
+#      under microvm.vms.<name>.config. `reinstantiate = true` ships the keyed
+#      module wrappers verbatim because that slot re-runs eval-config. The guest
+#      carries intoAttr = [] and gets NO policy.instantiate, so it produces NO
+#      standalone flake output.
+#
+# KIND = a DEDICATED `guest` kind whose `includes` are a CURATED subset of
+# `den.schema.host.includes`, DERIVED (not hand-copied) so it tracks
+# host.includes:
+#   INHERIT  participation/identity/collect includes (host-to-users, the
+#            standard home-manager battery, den.default).
+#   OMIT     includes producing a standalone instantiate output (colmena's
+#            host-modules-capture) — a guest must not instantiate. Named via
+#            `den.guests.omitIncludeNames`.
+#   RETARGET / OVERRIDE  agenix-style host-includes whose class lookup or key
+#            paths assume the host class: the consumer points public_key /
+#            secret sources at the parent and targets nixos. Expressed as
+#            ordinary guest-targeted includes the consumer adds.
+# ===========================================================================
+{
+  den,
+  config,
+  lib,
+  inputs,
+  ...
+}:
+let
+  inherit (den.lib.policy) resolve route mkPolicy;
+
+  guestKind = "guest";
+
+  cfg = config.den.guests;
+
+  # The parent-config path a guest's content is routed into: the microvm guest
+  # slot, whose option `merge` re-instantiates the delivered modules.
+  deliveryPath = name: [
+    "microvm"
+    "vms"
+    name
+    "config"
+  ];
+
+  # An include entry's stable identifier, used for OMIT filtering. Named
+  # policy includes carry `.name`; bare functions/attrsets have none.
+  includeName = inc: if builtins.isAttrs inc && inc ? name then inc.name else null;
+
+  # CURATED includes for the guest kind, DERIVED from host.includes so the
+  # guest tracks the host's participation surface minus the omitted entries.
+  # (Read host.includes; we never write back to it from here, so no cycle.)
+  hostIncludes = config.den.schema.host.includes or [ ];
+  curatedFromHost = builtins.filter (
+    inc:
+    let
+      n = includeName inc;
+    in
+    n == null || !(builtins.elem n cfg.omitIncludeNames)
+  ) hostIncludes;
+
+  # The guest class is always nixos, so the hardcoded `.nixosModules` accessor
+  # is correct here. Used as the home-manager module default pinned on a raw
+  # guest record (which bypasses the host submodule's option defaults — gap G6).
+  hmNixosModule = inputs.home-manager.nixosModules.home-manager;
+
+  # A nixos stateVersion default for the guest, kept as an option contract.
+  # den.default's nixos content now DOES emit at the guest scope (the guest
+  # authors honest nixos), but a guest may still want an explicit stateVersion
+  # independent of the fleet default. Plain assignment matches the historical
+  # behavior; set stateVersion to null to apply none.
+  guestDefault = lib.optional (cfg.stateVersion != null) {
+    name = "guest-default";
+    nixos.system.stateVersion = cfg.stateVersion;
+  };
+
+  # Per-user home-manager synthesis bridge for the guest.
+  #
+  # The STANDARD home-manager battery fires for the guest naturally (guest
+  # class = nixos, host.home-manager.enable defaulted true below), but it
+  # forwards each user's homeManager content from a NESTED user-under-guest
+  # resolve sub-scope via a per-scope forward-route. Simple routes (the delivery
+  # route) collect from the ORIGINAL pre-route per-scope state, so the battery's
+  # user-scope append is invisible to the delivery route's collection. Worse,
+  # the user-under-guest scope sits BELOW the isolated guest, so isolation drops
+  # that battery copy from the parent entirely.
+  #
+  # This policy bridges the gap at the GUEST HOST scope (which IS the delivery
+  # route's collection root): it RESOLVES each homeManager user's homeManager
+  # content (den.lib.aspects.resolveImports — the same resolver the battery
+  # forward uses) and emits it as nixos config under home-manager.users.<user>
+  # as a `{ imports = [...]; }` module. The guest's real home-manager module
+  # (host.home-manager.module) evaluates those imports when the microvm
+  # RE-INSTANTIATES the delivered config as the guest's own nixosSystem —
+  # exactly the standard home-manager.users.<u> submodule contract. There is no
+  # double-delivery: the battery-forward copy is dropped by isolation.
+  guestHmUserForward =
+    { host, ... }:
+    let
+      hmUsers = lib.filter (u: lib.elem "homeManager" (u.classes or [ ])) (
+        lib.attrValues (host.users or { })
+      );
+      userHmModule =
+        user:
+        den.lib.aspects.resolveImports "homeManager" (den.lib.resolveEntity "user" { inherit host user; });
+    in
+    [
+      (den.lib.policy.include {
+        nixos.home-manager.users = lib.listToAttrs (
+          map (user: lib.nameValuePair user.userName (userHmModule user)) hmUsers
+        );
+      })
+    ];
+
+  # The guest kind's includes: curated host participation + the per-user
+  # home-manager synthesis bridge + the expose policy + a stateVersion default.
+  curatedIncludes =
+    curatedFromHost
+    ++ [
+      (mkPolicy "guest-hm-user-forward" guestHmUserForward)
+      (mkPolicy "expose-guest-quirks" exposePolicy)
+    ]
+    ++ guestDefault;
+
+  # The home-manager module pinned by the raw guest record. Materialized here
+  # because a RAW guest bypasses the host submodule (gap G6), so the
+  # `home-manager.enable`/`.module` option DEFAULTS the standard battery's
+  # hostConf defines never apply to the `host` binding. We replicate those
+  # defaults on the raw guest record below (mirroring nix/lib/home-env.nix:
+  # hostOptions) so:
+  #   - mkDetectHost sees `host.home-manager.enable` = true (a homeManager user
+  #     exists) and does not short-circuit, and
+  #   - the battery's hostModule can read `host.home-manager.module`.
+  guestHmModule = hmNixosModule;
+  guestHasHmUser =
+    guest:
+    builtins.any (u: builtins.elem "homeManager" (u.classes or [ ])) (
+      builtins.attrValues (guest.users or { })
+    );
+
+  # Delivery route, registered INSIDE the guest scope (sourceScopeId = guest =
+  # collection root); appendToParent lands the wrapped result at the parent.
+  # Gated against re-fire in nested sub-scopes (user/home), where it would
+  # self-deliver the guest's content into its own nixos.
+  deliverPolicyFor =
+    name:
+    mkPolicy "deliver-guest-${name}" (
+      { ... }@args:
+      lib.optionals (!(args ? user) && !(args ? home)) [
+        (route {
+          fromClass = "nixos";
+          intoClass = "nixos";
+          collectSubtree = true;
+          appendToParent = true;
+          path = deliveryPath name;
+          # The delivery target (microvm.vms.<name>.config) RE-INSTANTIATES the
+          # collected nixos as its own NixOS system, so deliver the keyed module
+          # wrappers verbatim (base-module defaults apply at the target, keys
+          # dedup {host,user}-scope re-declarations) instead of pre-evaluating
+          # them into resolved config (which strips defaults + keys).
+          reinstantiate = true;
+        })
+      ]
+    );
+
+  # Per-guest delivery: resolve the guest as a nested isolated child entity
+  # authoring honest nixos, carrying its own delivery route into the guest
+  # scope. Rebinding `host` to the guest makes curated host-includes and the
+  # standard home-manager battery see the guest as `host`.
+  resolveGuest =
+    name: guest:
+    let
+      # Default the home-manager host option on the raw guest unless the guest
+      # already declares it (consumer override wins).
+      hmDefault = lib.optionalAttrs (!(guest ? home-manager)) {
+        home-manager = {
+          enable = guestHasHmUser guest;
+          module = guestHmModule;
+        };
+      };
+      withClass =
+        guest
+        // hmDefault
+        // {
+          class = "nixos";
+          intoAttr = [ ];
+        };
+    in
+    resolve.to.withIncludes guestKind [ (deliverPolicyFor name) ] {
+      ${guestKind} = withClass;
+      host = withClass;
+    };
+
+  resolvePolicy = { host, ... }: lib.mapAttrsToList resolveGuest (host.guests or { });
+
+  # EXPOSE policy — runs inside the GUEST scope (it is part of the guest kind's
+  # curated includes, NOT the parent's host.includes). pipe.expose must fire in
+  # the scope that EMITS the quirk so the value flows up to the parent. Only
+  # quirks registered in den.quirks are exposed; the default set is opt-in (a
+  # consumer declares ollama-endpoints / prometheus-targets in its fleet config),
+  # and referencing an undeclared quirk is a silent no-op.
+  exposePolicy =
+    { ... }:
+    map (q: den.lib.policy.pipe.from q [ den.lib.policy.pipe.expose ]) (
+      builtins.filter (q: den.quirks or { } ? ${q}) cfg.exposeQuirks
+    );
+
+  # Parent-host option: explicit, per-parent declaration of microvm guests.
+  hostConf = {
+    options.guests = lib.mkOption {
+      description = ''
+        Guest host entities delivered as nested microvm children of this host.
+        Each guest is resolved as an isolated `${guestKind}` child authoring
+        honest `nixos`, and its content is routed into this host's configuration
+        at `microvm.vms.<name>.config` instead of producing a standalone flake
+        output.
+      '';
+      type = lib.types.attrsOf lib.types.raw;
+      default = { };
+    };
+  };
+in
+{
+  config.den.schema.${guestKind} = {
+    isEntity = true;
+    isolated = true;
+    parent = "host";
+    includes = curatedIncludes;
+  };
+
+  config.den.schema.host.imports = [ hostConf ];
+
+  config.den.policies.resolve-guest-host = resolvePolicy;
+
+  # Wire the PARENT resolve policy into every host scope. GATED on host.guests
+  # so non-parent hosts pay no cost (no-op include → byte-identical toplevel).
+  # The delivery route is NOT here — it lives in the guest kind's curated
+  # includes so it fires in the guest scope (its own collection root). The
+  # expose policy likewise lives in the guest includes.
+  config.den.schema.host.includes = [
+    den.policies.resolve-guest-host
+  ];
+
+  options.den.guests = {
+    omitIncludeNames = lib.mkOption {
+      description = ''
+        Names of host-includes to OMIT from the curated guest kind. The default
+        targets colmena's `host-modules-capture` host-include (see
+        modules/den/batteries/colmena.nix), which runs a `policy.instantiate`
+        producing a standalone OS module list — a guest must not instantiate.
+      '';
+      type = lib.types.listOf lib.types.str;
+      default = [ "host-modules-capture" ];
+    };
+    exposeQuirks = lib.mkOption {
+      description = "Fleet quirks exposed from each microvm guest up to the parent.";
+      type = lib.types.listOf lib.types.str;
+      default = [
+        "ollama-endpoints"
+        "prometheus-targets"
+      ];
+    };
+    stateVersion = lib.mkOption {
+      description = ''
+        stateVersion default applied in the guest's nixos class. The guest now
+        authors honest nixos and den.default's nixos content emits at the guest
+        scope, but this provides an explicit per-guest stateVersion contract.
+        Set to null to apply none.
+      '';
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+    };
+  };
+}

--- a/modules/den/aspects/virtualization/microvm-guests.nix
+++ b/modules/den/aspects/virtualization/microvm-guests.nix
@@ -12,8 +12,9 @@ let
   # The microvm.nix `microvm.vms.<name>` submodule does NOT accept a top-level
   # `imports` key — its option set is closed (pkgs/config/autostart/...). So the
   # resolved "microvm" class module (which sets host-side submodule options such
-  # as `pkgs`) is evaluated here into a flat attrset of those options, which the
-  # consumer can splice directly into the submodule definition.
+  # as `pkgs`) is evaluated here into a flat attrset of those options, which we
+  # splice directly into the submodule definition alongside the delivered
+  # `config`.
   microvmSubmoduleOpts =
     mod:
     (lib.evalModules {
@@ -25,7 +26,9 @@ let
 
   # M1: SSH keys for VM root access — collected from the den user registry
   # (wheel/admin members). Read from `den` here, where the registry lives;
-  # the class-module `config` arg is the guest's NixOS config, not den's.
+  # the class-module `config` arg is the host's NixOS config, not den's. With
+  # the guests policy core.users now also fires inside the guest, but this
+  # preserves the original root-key parity (admins/wheel keys).
   rootKeys = lib.concatMap (
     u:
     lib.optionals (builtins.any (g: g == "admins" || g == "wheel") (u.groups or [ ])) (
@@ -34,18 +37,9 @@ let
   ) (lib.attrValues (den.users.registry or { }));
 in
 {
-  # PRODUCE: host-parametric, eager. Resolve each guest to module data.
-  den.aspects.virtualization.microvm.microvm-guests =
-    { host, ... }:
-    map (vm: {
-      inherit (vm) name;
-      osModules = den.lib.aspects.resolve vm.class (den.lib.resolveEntity "host" { host = vm; });
-      microvmOpts = microvmSubmoduleOpts (den.lib.aspects.resolve "microvm" vm.aspect);
-      passthrough = vm.microvm.passthrough or [ ];
-      sharedNixStore = host.microvm.sharedNixStore;
-    }) host.microvm.guests;
-
-  # PRODUCE: a background GPU claim per guest with a non-empty passthrough.
+  # PRODUCE: a background GPU claim per guest with a non-empty
+  # passthrough intent. windows-vfio's qemu hook consumes these to preempt the
+  # microvm during interactive Windows sessions.
   den.aspects.virtualization.microvm.gpu-claims =
     { host, ... }:
     lib.concatMap (
@@ -56,44 +50,52 @@ in
         kind = "microvm";
         unit = "microvm@${vm.name}.service";
       }
-    ) host.microvm.guests;
+    ) (lib.attrValues (host.guests or { }));
 
-  # CONSUME: turn each resolved guest into a microvm.vms.<name> definition.
+  # CONSUME: layer the host-side GPU/passthrough overlay on top of the base
+  # guest configs the guests policy delivers into microvm.vms.<name>.config.
+  # The policy resolves each guest (agenix, core.users, collect, home-env) and
+  # routes its guest-os content into `.config`; here we add:
+  #   - host-side microvm submodule options (CUDA pkgs from the guest's microvm
+  #     class aspect), spliced as siblings of `.config`,
+  #   - facter-derived PCI passthrough devices + the ro-store share + root keys,
+  #     merged INTO the guest's `.config`,
+  #   - host-side systemd ExecCondition vfio gates.
   den.aspects.virtualization.microvm.nixos =
     {
-      microvm-guests,
+      host,
       config,
       pkgs,
       ...
     }:
     let
       facter = config.facter.report;
-      # Resolve each guest's passthrough intent against the host facter report.
-      withRecs = g: g // { recs = gpuLib.resolvePassthrough g.passthrough facter; };
-      guests = map withRecs microvm-guests;
+
+      children = lib.attrValues (host.guests or { });
+
+      # Per-guest overlay data: resolved microvm host-side options + the
+      # facter-resolved passthrough device records.
+      withOverlay = vm: {
+        inherit (vm) name;
+        microvmOpts = microvmSubmoduleOpts (den.lib.aspects.resolve "microvm" vm.aspect);
+        recs = gpuLib.resolvePassthrough (vm.microvm.passthrough or [ ]) facter;
+        sharedNixStore = vm.microvm.sharedNixStore or true;
+      };
+      guests = map withOverlay children;
     in
     {
-      microvm.vms = lib.listToAttrs (
-        map (
-          g:
-          lib.nameValuePair g.name (
-            # Host-side submodule options (e.g. CUDA pkgs) from the microvm class…
-            g.microvmOpts
-            // {
-              # …and the guest's full NixOS toplevel from its host pipeline.
-              config = {
-                imports = [
-                  g.osModules
-                  {
-                    microvm.devices = gpuLib.toMicrovmDevices g.recs;
-                    microvm.shares = lib.optional g.sharedNixStore roStoreShare;
-                    users.users.root.openssh.authorizedKeys.keys = rootKeys;
-                  }
-                ];
-              };
-            }
-          )
-        ) guests
+      microvm.vms = lib.mkMerge (
+        map (g: {
+          # Host-side submodule options (e.g. CUDA pkgs) from the microvm class.
+          ${g.name} = g.microvmOpts // {
+            # Layer the GPU host-side bits onto the primitive-delivered config.
+            config = {
+              microvm.devices = gpuLib.toMicrovmDevices g.recs;
+              microvm.shares = lib.optional g.sharedNixStore roStoreShare;
+              users.users.root.openssh.authorizedKeys.keys = rootKeys;
+            };
+          };
+        }) guests
       );
 
       # Host-side gate: hold the VM's start units until the passed-through PCI

--- a/modules/den/aspects/virtualization/microvm.nix
+++ b/modules/den/aspects/virtualization/microvm.nix
@@ -36,12 +36,11 @@
     (
       { ... }:
       {
-        options.microvm.guests = lib.mkOption {
-          type = lib.types.listOf lib.types.raw;
-          default = [ ];
-          defaultText = lib.literalExpression "[ ]";
-          description = "Guest MicroVMs to run on this host. List of den hosts, e.g. [ den.hosts.x86_64-linux.cortex-cuda ].";
-        };
+        # Guest MicroVMs are delivered via the guests policy
+        # (den.hosts.<sys>.<parent>.guests.<name>; see
+        # virtualization/guests.nix), not a `microvm.guests` list. These options
+        # document the per-guest entity contract read by the host-side GPU
+        # overlay (microvm-guests.nix).
         options.microvm.passthrough = lib.mkOption {
           type = lib.types.listOf lib.types.str;
           default = [ ];

--- a/modules/den/hosts/cortex-cuda.nix
+++ b/modules/den/hosts/cortex-cuda.nix
@@ -2,11 +2,29 @@
 {
   den.hosts.x86_64-linux.cortex-cuda = {
     channel = "nixpkgs-master";
-    intoAttr = [ ]; # do not emit a standalone nixosConfiguration output
+    environment = "dev";
+    intoAttr = [ ]; # do not emit a standalone nixosConfiguration output (delivered as a child)
+
+    # Delivered as a microvm guest of cortex (see cortex.nix `guests`).
+    # The guests policy resolves this as a raw entity bypassing the host
+    # submodule (gap G6), so the secretPath/public_key submodule defaults never
+    # compute.
+    # Retarget agenix at the PARENT's (cortex's) real key so the agenix battery
+    # resolves the host pubkey without a readFile throw and rekeys against
+    # cortex's identity.
+    secretPath = ./. + "/../../../.secrets/hosts/cortex";
+    public_key = ./. + "/../../../.secrets/hosts/cortex/ssh_host_ed25519_key.pub";
+
+    # The guest is a raw entity (no host-submodule `facts` default), but fleet
+    # users that participate now (e.g. shuo → roles.default → core.system.facter)
+    # read host.facts. Point it at the PARENT's facter report — the guest runs on
+    # cortex's hardware (GPU passthrough device IDs derive from it).
+    facts = ./. + "/../../../hosts/cortex/facter.json";
 
     networking.interfaces.vm-cuda.ipv4 = [ "10.9.2.2/16" ];
 
-    # B2: passthrough intent on the ENTITY (the producer reads vm.microvm.passthrough).
+    # B2: passthrough intent on the ENTITY (the host-side GPU overlay reads
+    # vm.microvm.passthrough).
     microvm.passthrough = [ "nvidia" ];
 
     # Settings on the ENTITY (cascade reads hosts.<name>.settings) → ollama-cuda.
@@ -39,7 +57,20 @@
       }:
       {
         networking.hostName = "cortex-cuda";
-        system.stateVersion = "25.05";
+        # The participating fleet baseline (core.nix.stateVersion) sets the
+        # fleet default; this guest pins its own. mkForce to win the merge.
+        system.stateVersion = lib.mkForce "25.05";
+
+        # The fleet users participating on this guest drag roles.default →
+        # core.network.tailscale in via the user scopes. This headless GPU
+        # inference VM is reached via the host on the internal bridge
+        # (10.9.2.2), not the tailnet, and the user-scope tailscale age-secret
+        # is not collected for a delivered guest. Neutralize it: mkForce the
+        # authKeyFile so the absent `age.secrets.tailscale-auth-key` reference
+        # is never forced, and disable the daemon. Fleet IDENTITY participation
+        # (agenix host key, core.users, collect/quirks) stays intact.
+        services.tailscale.enable = lib.mkForce false;
+        services.tailscale.authKeyFile = lib.mkForce "/dev/null";
 
         # The guest uses our externally-created CUDA pkgs (microvm.pkgs), so its
         # own nixpkgs.config must be empty (allowUnfree/acceptLicense are baked
@@ -110,11 +141,19 @@
           };
         };
 
+        # The fleet users participating here (shuo/sini/will) use the zsh login
+        # shell (core.users.shell) but the host-level apps.shell.zsh that backs
+        # it lives in roles.default, which this guest doesn't include. Enable it
+        # so their shells resolve.
+        programs.zsh.enable = true;
+
         services.openssh = {
           enable = true;
           settings = {
             PasswordAuthentication = false;
-            PermitRootLogin = "yes";
+            # Guest uses root key login (root authorizedKeys injected host-side);
+            # override the fleet baseline's "prohibit-password".
+            PermitRootLogin = lib.mkForce "yes";
           };
         };
       };

--- a/modules/den/hosts/cortex.nix
+++ b/modules/den/hosts/cortex.nix
@@ -11,7 +11,12 @@
       ipv6 = [ "fd64:0:1::5/64" ];
     };
 
-    microvm.guests = [ den.hosts.x86_64-linux.cortex-cuda ];
+    # cortex-cuda is delivered as a CHILD host: resolved under cortex inheriting
+    # the curated host.includes (agenix retargeted, core.users, collect pipes,
+    # guest-os home-env) and routed into microvm.vms.cortex-cuda.config. The
+    # GPU passthrough/vfio/arbitration overlay is layered host-side by
+    # virtualization/microvm-guests.nix.
+    guests.cortex-cuda = den.hosts.x86_64-linux.cortex-cuda;
 
     settings = {
       disk.zfs-disk-single.device_id = "/dev/disk/by-id/nvme-Samsung_SSD_990_PRO_4TB_S7KGNU0X704630A";


### PR DESCRIPTION
## Summary

Rewire **cortex-cuda** from an isolated-resolve guest to a **microvm guest** of cortex. cortex declares `guests.cortex-cuda`; the guest authors honest `nixos` and is routed into `cortex.microvm.vms.cortex-cuda.config` with **no standalone `nixosConfigurations.cortex-cuda` output** (`intoAttr = []`). The guest now **participates in the fleet** — agenix (host key retargeted to cortex's identity) and `core.users` fire inside it — while the GPU passthrough/vfio/arbitration overlay is layered host-side by `virtualization/microvm-guests.nix` (facter devices, vfio `ExecCondition` gates, `gpu-claims` producer, CUDA `microvm.pkgs`, root keys).

The **guests policy** (`host.guests` option, the isolated `guest` entity kind, the resolve + route + isolation delivery) lives here in nix-config (`modules/den/aspects/virtualization/guests.nix`), composed entirely from public den primitives. It is a consumer pattern with a single (microvm) use case — not den-core machinery — so it lives with its consumer rather than inflating every den user's surface.

Guest-config reconciliation with the now-participating fleet baseline:
- neutralize the tailscale the fleet users drag in via `roles.default` (this headless GPU inference VM is reached via the host on the internal bridge, not the tailnet, and the user-scope tailscale age-secret isn't collected for a delivered guest);
- `mkForce` `system.stateVersion` and openssh `PermitRootLogin` (guest pins its own vs the fleet default/baseline);
- enable `programs.zsh` so the participating users' login shells resolve.

## Dependency

Requires den **@ `e8876f3e`** (flake.lock bumped here), which carries only the genuine engine primitives:

- **route `reinstantiate` flag** — the delivery target (`microvm.vms.<n>.config`) re-instantiates the collected nixos as its own NixOS system, so the route must deliver the **keyed module wrappers verbatim** rather than pre-evaluating them into resolved config (which stripped base-module defaults + the dedup keys). Covered by a standalone route test.
- **projected hasAspect keyed by entity `id_hash`** — the per-scope path-set that backs in-context `hasAspect` is re-keyed by context-free entity identity instead of a scope-string. The set is produced by an entity's standalone resolve (no ancestors) but consumed in the fleet resolve (host nested under `environment`/`fleet`); keying by `id_hash` (kind+name, stable across both) removes the ancestor-stripping reconciliation entirely, so e.g. agenix's `hasAspect core.impermanence` resolves true on the axon/cortex hosts and `identityPaths` point at `/persist/etc/ssh`.

The delivered-child policy that previously lived in den core has been removed from den — it moved here as the guests policy.

## Test plan

- [x] agenix `age.secrets` + `core.users` fire inside the guest (no eval throw)
- [x] **GPU parity is byte-identical to the pre-refactor baseline** — `nix-diff` of the cortex toplevel shows the only delta is the flake-source store path that any repo edit rehashes; the vfio-gate derivation is identical
- [x] cortex toplevel builds; guest `microvm.vms.cortex-cuda` re-instantiates
- [x] no `nixosConfigurations.cortex-cuda` output
- [x] axon + cortex `identityPaths` = `/persist/etc/ssh`
- [x] den CI 915/915; `nix fmt` clean
