### PR TITLE
feat(media): MediaCover artwork cache on NAS, not longhorn

### DIFF
--- a/generated/manifests/prod-axon/lidarr/Deployment-lidarr.yaml
+++ b/generated/manifests/prod-axon/lidarr/Deployment-lidarr.yaml
@@ -83,6 +83,9 @@ spec:
               name: config
             - mountPath: /data
               name: data
+            - mountPath: /config/MediaCover
+              name: metadata
+              subPath: media/metadata/lidarr/MediaCover
             - mountPath: /scratch
               name: scratch
       dnsPolicy: ClusterFirst
@@ -96,6 +99,9 @@ spec:
           persistentVolumeClaim:
             claimName: lidarr
         - name: data
+          persistentVolumeClaim:
+            claimName: media-data-nfs
+        - name: metadata
           persistentVolumeClaim:
             claimName: media-data-nfs
         - name: scratch

--- a/generated/manifests/prod-axon/radarr/Deployment-radarr.yaml
+++ b/generated/manifests/prod-axon/radarr/Deployment-radarr.yaml
@@ -83,6 +83,9 @@ spec:
               name: config
             - mountPath: /data
               name: data
+            - mountPath: /config/MediaCover
+              name: metadata
+              subPath: media/metadata/radarr/MediaCover
             - mountPath: /scratch
               name: scratch
       dnsPolicy: ClusterFirst
@@ -96,6 +99,9 @@ spec:
           persistentVolumeClaim:
             claimName: radarr
         - name: data
+          persistentVolumeClaim:
+            claimName: media-data-nfs
+        - name: metadata
           persistentVolumeClaim:
             claimName: media-data-nfs
         - name: scratch

--- a/generated/manifests/prod-axon/sonarr/Deployment-sonarr.yaml
+++ b/generated/manifests/prod-axon/sonarr/Deployment-sonarr.yaml
@@ -83,6 +83,9 @@ spec:
               name: config
             - mountPath: /data
               name: data
+            - mountPath: /config/MediaCover
+              name: metadata
+              subPath: media/metadata/sonarr/MediaCover
             - mountPath: /scratch
               name: scratch
       dnsPolicy: ClusterFirst
@@ -96,6 +99,9 @@ spec:
           persistentVolumeClaim:
             claimName: sonarr
         - name: data
+          persistentVolumeClaim:
+            claimName: media-data-nfs
+        - name: metadata
           persistentVolumeClaim:
             claimName: media-data-nfs
         - name: scratch

--- a/generated/manifests/prod-axon/whisparr/Deployment-whisparr.yaml
+++ b/generated/manifests/prod-axon/whisparr/Deployment-whisparr.yaml
@@ -83,6 +83,9 @@ spec:
               name: config
             - mountPath: /data
               name: data
+            - mountPath: /config/MediaCover
+              name: metadata
+              subPath: media/metadata/whisparr/MediaCover
             - mountPath: /scratch
               name: scratch
       dnsPolicy: ClusterFirst
@@ -96,6 +99,9 @@ spec:
           persistentVolumeClaim:
             claimName: whisparr
         - name: data
+          persistentVolumeClaim:
+            claimName: media-data-nfs
+        - name: metadata
           persistentVolumeClaim:
             claimName: media-data-nfs
         - name: scratch

--- a/modules/den/aspects/kubernetes/services/media/_media-app.nix
+++ b/modules/den/aspects/kubernetes/services/media/_media-app.nix
@@ -67,7 +67,7 @@ in
       postgres ? false, # wire <NAME>__POSTGRES__* env + main/log db names
       postgresCnp ? postgres, # add the media-pg egress CiliumNetworkPolicy; defaults to `postgres`. Set true with postgres=false when the app talks to media-pg via a non-Servarr env style (e.g. bazarr's POSTGRES_* vars) so the egress policy is still emitted.
       config-size ? "2Gi", # longhorn config PVC size; null = no config PVC
-      mounts ? { }, # { data?; scratch-nfs?; scratch-local?; } (bools)
+      mounts ? { }, # { data?; scratch-nfs?; scratch-local?; metadata?; } (bools)
       route ? true, # HTTPRoute on default-gateway
       oidc ? true, # SecurityPolicy + client secret (requires route)
       oidcForwardAccessToken ? true, # forward the access token as Authorization: Bearer to the upstream. qBittorrent 5.x answers 404 to ANY request carrying an Authorization: Bearer header (verified live 2026-06-11), so qbt sets this false; everything else ignores the header.
@@ -80,6 +80,7 @@ in
       dataMount = mounts.data or false;
       scratchNfs = mounts.scratch-nfs or false;
       scratchLocal = mounts.scratch-local or false;
+      metadataMount = mounts.metadata or false;
 
       # ENV-prefix for the Servarr __POSTGRES__ convention (PROWLARR__POSTGRES__…)
       envPrefix = lib.toUpper name;
@@ -150,6 +151,25 @@ in
             type = "persistentVolumeClaim";
             existingClaim = "media-scratch-local";
             globalMounts = [ { path = "/scratch"; } ];
+          };
+        }
+        // optionalAttrs metadataMount {
+          # Servarr MediaCover (binary artwork cache) lives on the NAS, not the
+          # longhorn config PVC: radarr's cache alone is ~5.2G (> its config
+          # PVC), it's bulk re-fetchable image data that has no business being
+          # replicated, and the archive's covers were pre-staged to the same
+          # NAS path at migration so imported libraries keep their artwork
+          # without a re-download storm (cover dirs are keyed by DB id, which
+          # the pgloader import preserved).
+          metadata = {
+            type = "persistentVolumeClaim";
+            existingClaim = "media-data-nfs";
+            globalMounts = [
+              {
+                path = "/config/MediaCover";
+                subPath = "media/metadata/${name}/MediaCover";
+              }
+            ];
           };
         };
 

--- a/modules/den/aspects/kubernetes/services/media/lidarr.nix
+++ b/modules/den/aspects/kubernetes/services/media/lidarr.nix
@@ -37,6 +37,8 @@ in
     mounts = {
       data = true;
       scratch-nfs = true;
+      # MediaCover on the NAS (pre-staged from the archive) — see _media-app.nix.
+      metadata = true;
     };
 
     # Servarr HTTP health endpoint.

--- a/modules/den/aspects/kubernetes/services/media/radarr.nix
+++ b/modules/den/aspects/kubernetes/services/media/radarr.nix
@@ -38,6 +38,8 @@ in
     mounts = {
       data = true;
       scratch-nfs = true;
+      # MediaCover on the NAS (pre-staged from the archive) — see _media-app.nix.
+      metadata = true;
     };
 
     # Servarr HTTP health endpoint.

--- a/modules/den/aspects/kubernetes/services/media/sonarr.nix
+++ b/modules/den/aspects/kubernetes/services/media/sonarr.nix
@@ -38,6 +38,8 @@ in
     mounts = {
       data = true;
       scratch-nfs = true;
+      # MediaCover on the NAS (pre-staged from the archive) — see _media-app.nix.
+      metadata = true;
     };
 
     # Servarr HTTP health endpoint.

--- a/modules/den/aspects/kubernetes/services/media/whisparr.nix
+++ b/modules/den/aspects/kubernetes/services/media/whisparr.nix
@@ -40,6 +40,8 @@ in
     mounts = {
       data = true;
       scratch-nfs = true;
+      # MediaCover on the NAS (pre-staged from the archive) — see _media-app.nix.
+      metadata = true;
     };
 
     # Servarr HTTP health endpoint.


### PR DESCRIPTION
Follow-up to the history imports: the imported libraries pointed at empty MediaCover caches, and a metadata refresh would re-download everything into longhorn config PVCs — radarr's cover cache is **5.2G against a 5G PVC**, so it would also burst the volume.

- New `mounts.metadata` option in `mkMediaApp`: mounts `media-data-nfs` subPath `media/metadata/<app>/MediaCover` at `/config/MediaCover` (same PVC the arrs already mount at /data — no new PV).
- Enabled for sonarr/radarr/lidarr/whisparr.
- Archive covers pre-staged to the NAS path (5.5G total). Cover dirs are keyed by DB id, which pgloader preserved, so the imported libraries pick their artwork up immediately instead of re-fetching ~5.5G from the metadata providers.

On merge ArgoCD rolls the four deployments; artwork should appear without any refresh storm.