### PR TITLE
chore(den): bump to feat/entity-gen-schema-port — hasAspect projected-scope fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -443,16 +443,16 @@
     },
     "den": {
       "locked": {
-        "lastModified": 1781197965,
-        "narHash": "sha256-KzJ8WMzFAXcIBxveZVz3DypYgqy3sa8B2AWaexBc3tw=",
+        "lastModified": 1781224082,
+        "narHash": "sha256-XKhNHyFYhRdON8dEKcW1MfGeZsvmBYLOCLYDqwMY+qY=",
         "owner": "sini",
         "repo": "den",
-        "rev": "046589827bb217c7bb9419999fcb4cd68d1da40a",
+        "rev": "160ac4452374e319f6ee81828aca1076c7d24914",
         "type": "github"
       },
       "original": {
         "owner": "sini",
-        "ref": "feat/delivered-child-host-lazy",
+        "ref": "feat/entity-gen-schema-port",
         "repo": "den",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@
       url = "github:Sveske-Juice/declarative-jellyfin";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
     };
-    den.url = "github:sini/den/feat/delivered-child-host-lazy";
+    den.url = "github:sini/den/feat/entity-gen-schema-port";
     den-diagram = {
       url = "github:denful/den-diagram";
       inputs.nixpkgs.follows = "nixpkgs-unstable";


### PR DESCRIPTION
Bumps the den input to sini/den `feat/entity-gen-schema-port` HEAD, which carries `fix(hasAspect): drop ancestor entity-kinds from projected scopeId` plus everything from the previous pin line (entity-isolation fix, delivered-child re-instantiation work).

This resolves the CRITICAL agenix initrd identity bug from the ops queue: battery-scope `hasAspect` on multi-tier hosts always read false because the projected scopeId lookup key included ancestor entity-kind bindings, so the impermanence persist prefix never applied to `identityPaths` — every impermanence-host reboot came up secretless until re-activation.

Verified against this lock:
- impermanence k3s node `age.identityPaths` regains the persist prefix (was bare `/etc/ssh` on the old pin)
- full fleet (7 hosts) evaluates; server + workstation toplevels instantiate
- the den commit ships a multi-tier regression test (`hasaspect-ancestor-scope.nix`), closing the ops-queue test item

Deploy note: after merge, `colmena apply` across the impermanence hosts re-renders identityPaths; no rekey needed (same keys, corrected path).