### PR TITLE
fix(media): world egress for prowlarr, the arrs, and bazarr

### DIFF
--- a/generated/manifests/prod-axon/bazarr/CiliumNetworkPolicy-allow-internet-egress-bazarr.yaml
+++ b/generated/manifests/prod-axon/bazarr/CiliumNetworkPolicy-allow-internet-egress-bazarr.yaml
@@ -1,0 +1,19 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-internet-egress-bazarr
+  namespace: media
+spec:
+  description: Allow bazarr to reach the public internet.
+  egress:
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: bazarr

--- a/generated/manifests/prod-axon/lidarr/CiliumNetworkPolicy-allow-internet-egress-lidarr.yaml
+++ b/generated/manifests/prod-axon/lidarr/CiliumNetworkPolicy-allow-internet-egress-lidarr.yaml
@@ -1,0 +1,19 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-internet-egress-lidarr
+  namespace: media
+spec:
+  description: Allow lidarr to reach the public internet.
+  egress:
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: lidarr

--- a/generated/manifests/prod-axon/prowlarr/CiliumNetworkPolicy-allow-internet-egress-prowlarr.yaml
+++ b/generated/manifests/prod-axon/prowlarr/CiliumNetworkPolicy-allow-internet-egress-prowlarr.yaml
@@ -1,0 +1,19 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-internet-egress-prowlarr
+  namespace: media
+spec:
+  description: Allow prowlarr to reach the public internet.
+  egress:
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: prowlarr

--- a/generated/manifests/prod-axon/radarr/CiliumNetworkPolicy-allow-internet-egress-radarr.yaml
+++ b/generated/manifests/prod-axon/radarr/CiliumNetworkPolicy-allow-internet-egress-radarr.yaml
@@ -1,0 +1,19 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-internet-egress-radarr
+  namespace: media
+spec:
+  description: Allow radarr to reach the public internet.
+  egress:
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: radarr

--- a/generated/manifests/prod-axon/sonarr/CiliumNetworkPolicy-allow-internet-egress-sonarr.yaml
+++ b/generated/manifests/prod-axon/sonarr/CiliumNetworkPolicy-allow-internet-egress-sonarr.yaml
@@ -1,0 +1,19 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-internet-egress-sonarr
+  namespace: media
+spec:
+  description: Allow sonarr to reach the public internet.
+  egress:
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sonarr

--- a/generated/manifests/prod-axon/whisparr/CiliumNetworkPolicy-allow-internet-egress-whisparr.yaml
+++ b/generated/manifests/prod-axon/whisparr/CiliumNetworkPolicy-allow-internet-egress-whisparr.yaml
@@ -1,0 +1,19 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-internet-egress-whisparr
+  namespace: media
+spec:
+  description: Allow whisparr to reach the public internet.
+  egress:
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+            - port: "443"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: whisparr

--- a/modules/den/aspects/kubernetes/services/media/bazarr.nix
+++ b/modules/den/aspects/kubernetes/services/media/bazarr.nix
@@ -60,6 +60,10 @@ in
       data = true;
     };
 
+    # World egress (80/443): subtitle providers (opensubtitles et al) are direct world calls
+    # (core function).
+    internetEgress = true;
+
     # Bazarr serves its health/UI on the web port; no Servarr /ping endpoint.
   };
 }

--- a/modules/den/aspects/kubernetes/services/media/lidarr.nix
+++ b/modules/den/aspects/kubernetes/services/media/lidarr.nix
@@ -41,6 +41,10 @@ in
       metadata = true;
     };
 
+    # World egress (80/443): artist/album metadata + artwork come from the Servarr metadata
+    # proxy (MusicBrainz front), a direct world call.
+    internetEgress = true;
+
     # Servarr HTTP health endpoint.
     extraValues.controllers.main.containers.main.probes = {
       liveness = {

--- a/modules/den/aspects/kubernetes/services/media/prowlarr.nix
+++ b/modules/den/aspects/kubernetes/services/media/prowlarr.nix
@@ -37,6 +37,11 @@ in
     # Prowlarr stores nothing on shared media/scratch — config PVC only.
     mounts = { };
 
+    # World egress (80/443): indexer searches + the Cardigann definitions fetch are world-facing
+    # (core function; without this the indexer API hangs on the definitions
+    # download and every search fails).
+    internetEgress = true;
+
     # Servarr HTTP health endpoint.
     extraValues.controllers.main.containers.main.probes = {
       liveness = {

--- a/modules/den/aspects/kubernetes/services/media/radarr.nix
+++ b/modules/den/aspects/kubernetes/services/media/radarr.nix
@@ -42,6 +42,10 @@ in
       metadata = true;
     };
 
+    # World egress (80/443): movie metadata + artwork come from the Servarr metadata API, a
+    # direct world call.
+    internetEgress = true;
+
     # Servarr HTTP health endpoint.
     extraValues.controllers.main.containers.main.probes = {
       liveness = {

--- a/modules/den/aspects/kubernetes/services/media/sonarr.nix
+++ b/modules/den/aspects/kubernetes/services/media/sonarr.nix
@@ -42,6 +42,10 @@ in
       metadata = true;
     };
 
+    # World egress (80/443): series metadata + artwork come from the Servarr metadata API
+    # (skyhook), a direct world call.
+    internetEgress = true;
+
     # Servarr HTTP health endpoint.
     extraValues.controllers.main.containers.main.probes = {
       liveness = {

--- a/modules/den/aspects/kubernetes/services/media/whisparr.nix
+++ b/modules/den/aspects/kubernetes/services/media/whisparr.nix
@@ -44,6 +44,10 @@ in
       metadata = true;
     };
 
+    # World egress (80/443): site/scene metadata + artwork come from its metadata API, a
+    # direct world call.
+    internetEgress = true;
+
     # Servarr HTTP health endpoint.
     extraValues.controllers.main.containers.main.probes = {
       liveness = {


### PR DESCRIPTION
Found starting the validation walkthrough: prowlarr's UI failed to load its indexer list. Root cause chain, verified live:

- the indexer API **hangs** (not 500s): a fresh config PVC has no Cardigann definitions cache, prowlarr fetches it on demand, and that world call is CNP-dropped — the blocked fetch stalls every API call that needs definitions
- null `IndexerCapabilities` from the same cause produced the NRE storm in app-sync to sonarr/radarr
- every indexer search has silently failed since cutover (the ">6h unavailable" health warnings)

Same-class sweep: raw world :443 timed out from **all six** of prowlarr/sonarr/radarr/lidarr/whisparr/bazarr. The CNP matrix only flagged flaresolverr/sab/dashboards for world egress, assuming arr traffic rides through prowlarr and the downloaders — but Servarr metadata APIs, artwork fetches, and subtitle providers are direct world calls (and for prowlarr/bazarr it's the core function).

Fix: `internetEgress = true` (the existing 80/443 world-egress policy) on the six apps, each with its justification inline. komga's deliberate egress-off stance is untouched. Indexers on nonstandard ports would need `extraEgressPorts` — none of the current set does.