### PR TITLE
fix(nixidy): nixidy-sync resolves the env at run time, not devshell-build time

### DIFF
--- a/modules/den/batteries/nixidy.nix
+++ b/modules/den/batteries/nixidy.nix
@@ -183,17 +183,30 @@ in
       # itself through that overlay.
       packages.nixidy-sync = pkgs.writeShellApplication {
         name = "nixidy-sync";
-        runtimeInputs = [ pkgs.git ];
+        runtimeInputs = [
+          pkgs.git
+          pkgs.nix
+        ];
         text = ''
           if [ "''${1:-}" = "--skip-secrets" ] || [ "''${1:-}" = "-s" ]; then
             export NIXIDY_SKIP_POST_PROCESS=1
           fi
           root="$(git rev-parse --show-toplevel)" || { echo "nixidy-sync: not in a git repo" >&2; exit 1; }
           cd "$root"
+          # Resolve each env's activationPackage AT RUN TIME against the current
+          # tree. Baking the activationPackage store path here would pin the
+          # repo state from whenever the CALLER's devshell was built (inputs.self
+          # at shell-eval time) — a stale direnv shell then silently syncs old
+          # manifests/secrets no matter what the working tree or HEAD contain
+          # (bit a secret rotation: the re-encrypt only landed after a fresh
+          # shell eval). Only the env NAMES are baked; their contents
+          # re-evaluate per invocation.
           ${lib.concatStringsSep "\n" (
-            lib.mapAttrsToList (env: nixidyEnv: ''
+            lib.mapAttrsToList (env: _: ''
               echo "==> Syncing nixidy env: ${env}"
-              ${nixidyEnv.activationPackage}/activate
+              out="$(nix build --no-link --print-out-paths \
+                ".#nixidyEnvs.${system}.${env}.activationPackage")"
+              "$out"/activate
             '') (inputs.self.nixidyEnvs.${system} or { })
           )}
         '';


### PR DESCRIPTION
Surfaced during a secret rotation: running `nixidy-sync` after rotating a secret did not re-encrypt the rendered SopsSecret. The script's per-env line was `${nixidyEnv.activationPackage}/activate` — the store path is resolved from `inputs.self` **when the devshell is built**, so a direnv shell that predates your change runs an activation package rendered from that older tree. Neither working-tree state nor commits matter until the shell itself re-evaluates (direnv only watches the flake files, not the rest of the repo).

Fix: bake only the env *names*; each invocation runs `nix build --no-link --print-out-paths .#nixidyEnvs.<system>.<env>.activationPackage` so the env re-evaluates against the current tree every time. Verified: a run from an unchanged tree is a clean no-op (idempotency annotation short-circuits, no re-encrypt), and the fetched source store path is fresh per invocation.

Costs one flake eval per sync — correctness over speed; the pre-commit `--skip-secrets` fast path is unchanged in behavior.