### PR TITLE
fix(storage): deploy the external snapshot-controller (volumeSnapshot backups never worked)

### DIFF
--- a/generated/manifests/prod-axon/csi-driver-nfs/ClusterRole-snapshot-controller-runner.yaml
+++ b/generated/manifests/prod-axon/csi-driver-nfs/ClusterRole-snapshot-controller-runner.yaml
@@ -1,0 +1,79 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: csi-driver-nfs
+    app.kubernetes.io/name: csi-driver-nfs
+  name: snapshot-controller-runner
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshotclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshotcontents
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - delete
+      - patch
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshotcontents/status
+    verbs:
+      - patch
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshots
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - create
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshots/status
+    verbs:
+      - update
+      - patch

--- a/generated/manifests/prod-axon/csi-driver-nfs/ClusterRoleBinding-snapshot-controller-role.yaml
+++ b/generated/manifests/prod-axon/csi-driver-nfs/ClusterRoleBinding-snapshot-controller-role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: csi-driver-nfs
+    app.kubernetes.io/name: csi-driver-nfs
+  name: snapshot-controller-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: snapshot-controller-runner
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-controller
+    namespace: csi-nfs

--- a/generated/manifests/prod-axon/csi-driver-nfs/Deployment-snapshot-controller.yaml
+++ b/generated/manifests/prod-axon/csi-driver-nfs/Deployment-snapshot-controller.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: snapshot-controller
+    app.kubernetes.io/instance: csi-driver-nfs
+    app.kubernetes.io/name: csi-driver-nfs
+  name: snapshot-controller
+  namespace: csi-nfs
+spec:
+  minReadySeconds: 15
+  replicas: 1
+  selector:
+    matchLabels:
+      app: snapshot-controller
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: snapshot-controller
+    spec:
+      containers:
+        - args:
+            - --v=2
+            - --leader-election=true
+            - --leader-election-namespace=csi-nfs
+          image: registry.k8s.io/sig-storage/snapshot-controller:v8.4.0
+          imagePullPolicy: IfNotPresent
+          name: snapshot-controller
+          resources:
+            limits:
+              memory: 300Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: snapshot-controller
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/controlplane
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
+        - effect: NoSchedule
+          key: CriticalAddonsOnly
+          operator: Exists

--- a/generated/manifests/prod-axon/csi-driver-nfs/Role-snapshot-controller-leaderelection.yaml
+++ b/generated/manifests/prod-axon/csi-driver-nfs/Role-snapshot-controller-leaderelection.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: csi-driver-nfs
+    app.kubernetes.io/name: csi-driver-nfs
+  name: snapshot-controller-leaderelection
+  namespace: csi-nfs
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - list
+      - delete
+      - update
+      - create

--- a/generated/manifests/prod-axon/csi-driver-nfs/RoleBinding-snapshot-controller-leaderelection.yaml
+++ b/generated/manifests/prod-axon/csi-driver-nfs/RoleBinding-snapshot-controller-leaderelection.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: csi-driver-nfs
+    app.kubernetes.io/name: csi-driver-nfs
+  name: snapshot-controller-leaderelection
+  namespace: csi-nfs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: snapshot-controller-leaderelection
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-controller

--- a/generated/manifests/prod-axon/csi-driver-nfs/ServiceAccount-snapshot-controller.yaml
+++ b/generated/manifests/prod-axon/csi-driver-nfs/ServiceAccount-snapshot-controller.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: csi-driver-nfs
+    app.kubernetes.io/name: csi-driver-nfs
+  name: snapshot-controller
+  namespace: csi-nfs

--- a/generated/manifests/prod-axon/grafana/Deployment-grafana.yaml
+++ b/generated/manifests/prod-axon/grafana/Deployment-grafana.yaml
@@ -20,7 +20,7 @@ spec:
       annotations:
         checksum/config: 136f80ec3418f043afe65d5c9afeafab129e9d1c39453f1fafe9d3bb9d77897d
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
-        checksum/secret: b3d4ed11f1f7f33ce690b5de19c246f0268fab4f0ba9cf0848224bd1cc6a0ed0
+        checksum/secret: f2b488801b5d16da84a4b83cf355a72eca6daef5793f49367f275e5afc08e099
         kubectl.kubernetes.io/default-container: grafana
       labels:
         app.kubernetes.io/instance: grafana

--- a/generated/manifests/prod-axon/grafana/SopsSecret-grafana.yaml
+++ b/generated/manifests/prod-axon/grafana/SopsSecret-grafana.yaml
@@ -8,12 +8,12 @@ metadata:
     name: grafana
     namespace: monitoring
     annotations:
-        secrets.json64.dev/plaintext-sha256: 37081ca4c7e04fe4b26504b00ba3ce9643b11349283180bd8398c3a135027beb
+        secrets.json64.dev/plaintext-sha256: 8c55b4605f5fbbed081b803f851ac96ea9c494f1595e9c61cb6924d490ce6b85
 spec:
     secretTemplates:
         - data:
-            admin-password: ENC[AES256_GCM,data:YeeDnD8977rHUDwcf+4jyPNutxqxAw4wun6EWVcq40wXr8ioYXfVH3LrQxGmBuRYJtcnRVJ0gG4=,iv:5/M/pEleRKyZpVOMOIaDughhZ2ejinyq3EN10yuh7nA=,tag:jmOp73E1WmtLLSIuS28+wA==,type:str]
-            admin-user: ENC[AES256_GCM,data:EA/KumKnZAU=,iv:Y6iWP1bRwAi6rtLniLy3163QPXcM6dew+SNB4Vbseok=,tag:FnYVMVqCJNSDwN6PiuNfAQ==,type:str]
+            admin-password: ENC[AES256_GCM,data:I7nrItLpRkGm1+5p4mVkqv/5s0G/tUCxUKKLGYGokHoT/jbXSI//YP/ZMslRqfnb+feSr5vHiGU=,iv:RRy68G+/kc8qT2oB9M4X9vCdPVSj33qm8ePAUV/jNek=,tag:KZ7UvA88CLSUMZnMTxOubw==,type:str]
+            admin-user: ENC[AES256_GCM,data:l85m1gF31do=,iv:S+FR47gQ6vILhe+d7gvhQpq/HMjpjUoW6ALX34K8FCY=,tag:IjFSM1cv8FEl6b1SEuC1uw==,type:str]
             ldap-toml: ""
           name: grafana
           type: Opaque
@@ -21,14 +21,14 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKN3RFdFo4eDJlYXpxRG4r
-            VllSYTJpVzFjWWRiTnhZSjhvSmhPZEVpZGhvClpmd2ppa0V1RndYNzNjQjFRblV2
-            SlRUU0oyRjVBdjIzaDRJY08xUFZYa1EKLS0tIGVlT0JEaWlta3Vqa0w0eU9PaDdJ
-            NmoxVnNoY1czRzREMG1PUGhRYkV5L0EK1Jld1CcJqeXugD4zrKq8L/HQz62HCGqc
-            qJYz4BDdArOdDjAZOftAThYdzrawkm+AggWX7gKRV1LEi6MeYue2+A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlVG5zRVk5dlJTcFpVR1BF
+            K2p2TWsvQk1xSm13d0VqeENzczUvTGpFaDFFCmtzVk9SOUtGMWgzc2pTWGxUSVY5
+            UFlQQ0xINzV6aXpHOS9aL2thOFhQcWsKLS0tIHlhbVZaNGZTN0lPMW1aYVYwUWk3
+            VUNoYWtTcFJheVE2K2l1andFOW4ySk0KnL8rCpcxg+ITclJG4o4xL/u+01Ab66rV
+            MeAcu/YrhjW7xBvnK5UtOMvbqj1jJwAtJXTE6ITnzQsy3N+SUo9zBQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-06-11T18:37:45Z"
-    mac: ENC[AES256_GCM,data:aZNChcBKu2mGBXf2+haGk9hfcMdN6xQw3kw/vxmRS2Esr8dRD/iy7yvTqssalmE7Y9fnJQwju2aUrd1jL4j7cSi7hzyQP9RcoK4q0EeaFfKRIsezd5a2sJ9hyaSsWiuJRVtVBSy7zeZXnqUOYg22OnAuyla5u+kc22qk7hFB4H8=,iv:pqPOczcVq6+FC9taQtGwKaaVVkF0cIoxcqL4WN3OTvw=,tag:w8aC9z6ItgSUE3GdTvpjoQ==,type:str]
+    lastmodified: "2026-06-12T15:16:05Z"
+    mac: ENC[AES256_GCM,data:6jisb961qae9HUvZqiqFewuPE7UIwTaHB+AXi6QpDcQNUzdpAoRIu8bv0uchKfXfidKmYYh9fTK3xKM7KfeSZWS+lBmR1rTMGQkiCuP1EqA+d8vrx7xfjL3yl1VkxG3PYaayvOYN5I6y8Bkuwqtwwi2ZwtMX5qqhdw/+g3+XWAg=,iv:f3jY53zhdjtYSBEr8a441AzC/SgooPovRQHylBkvO30=,tag:mRhr97k1EQtSwCnzoPkscA==,type:str]
     version: 3.13.1

--- a/modules/den/aspects/kubernetes/services/storage/csi-driver-nfs/csi-driver-nfs.nix
+++ b/modules/den/aspects/kubernetes/services/storage/csi-driver-nfs/csi-driver-nfs.nix
@@ -28,6 +28,18 @@
 
           helm.releases.csi-driver-nfs = {
             chart = charts.kubernetes-csi.csi-driver-nfs;
+            # external-snapshotter: the cluster-wide snapshot-controller that
+            # binds VolumeSnapshot -> VolumeSnapshotContent. Nothing else
+            # deploys it (longhorn only ships the CSI sidecar), so without it
+            # every volumeSnapshot Backup hangs in `started` with the
+            # VolumeSnapshot unbound and event-less — bit the media-pg nightly.
+            # The matching apiserver-egress CNP below predates this enable.
+            values.externalSnapshotter = {
+              enabled = true;
+              # VolumeSnapshot CRDs already live on-cluster; a second emission
+              # sync-blocks argo with RepeatedResourceWarning (the #99 trap).
+              customResourceDefinitions.enabled = false;
+            };
           };
 
           resources = {


### PR DESCRIPTION
Found in the validation walkthrough's CNPG backup check: the media-pg nightly ScheduledBackup has never completed — its Backup sits in `started` and the VolumeSnapshot stays unbound with zero events, because **no snapshot-controller exists on the cluster**. The VolumeSnapshot CRDs landed in March and longhorn ships its CSI sidecar, but the cluster-wide controller that binds VolumeSnapshot → VolumeSnapshotContent was never deployed; volumeSnapshot backups have been silently dead the whole time.

- Enable `externalSnapshotter` in the csi-driver-nfs chart values (deploys `snapshot-controller` into the csi-nfs app; the matching apiserver-egress CNP already existed in the aspect, clearly anticipating this).
- `customResourceDefinitions.enabled = false` — the CRDs already live on-cluster, and a second emission sync-blocks argo with `RepeatedResourceWarning` (the #99 trap).
- Second commit: grafana SopsSecret re-encryption catch-up — the secret rotation changed grafana's plaintext too, but the rotation-era syncs ran from a stale devshell (pre-#116) and missed it; the first runtime-eval'd sync caught the drift.

After merge+sync: the controller should bind the pending nightly snapshot (or the next nightly proves it); the manual Backup CR drill from VALIDATION.md follows that.