### PR TITLE
fix(monitoring): server-side apply for kube-prometheus-stack

### DIFF
--- a/generated/manifests/prod-axon/apps/Application-kube-prometheus-stack.yaml
+++ b/generated/manifests/prod-axon/apps/Application-kube-prometheus-stack.yaml
@@ -16,3 +16,5 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/modules/den/aspects/kubernetes/services/monitoring/prometheus.nix
+++ b/modules/den/aspects/kubernetes/services/monitoring/prometheus.nix
@@ -13,6 +13,10 @@
         applications.kube-prometheus-stack = {
           namespace = "monitoring";
 
+          # The prometheus-operator CRDs blow past the 256KiB annotation
+          # limit under client-side apply.
+          syncPolicy.syncOptions.serverSideApply = true;
+
           helm.releases.kube-prometheus-stack = {
             chart = charts.prometheus-community.kube-prometheus-stack;
 


### PR DESCRIPTION
Follow-up to #119: the prometheus-operator CRDs exceed the 256KiB annotation limit under client-side apply (`last-applied-configuration`), so the app sync failed on `alertmanagerconfigs`/`prometheusagents` CRDs. Enable `ServerSideApply=true` on the application — same treatment cloudnative-pg already has.