### PR TITLE
fix(monitoring): apiserver egress for the loki rules sidecar

### DIFF
--- a/generated/manifests/prod-axon/loki/CiliumNetworkPolicy-allow-loki-kube-apiserver-egress.yaml
+++ b/generated/manifests/prod-axon/loki/CiliumNetworkPolicy-allow-loki-kube-apiserver-egress.yaml
@@ -1,0 +1,16 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-loki-kube-apiserver-egress
+  namespace: monitoring
+spec:
+  egress:
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "6443"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: loki

--- a/modules/den/aspects/kubernetes/services/monitoring/loki.nix
+++ b/modules/den/aspects/kubernetes/services/monitoring/loki.nix
@@ -70,6 +70,32 @@
               gateway.enabled = false;
             };
           };
+
+          # The rules sidecar (loki-sc-rules) watches the apiserver for
+          # rule ConfigMaps/Secrets; the cluster default-denies egress to
+          # non-endpoint entities.
+          resources.ciliumNetworkPolicies = {
+            allow-loki-kube-apiserver-egress = {
+              spec = {
+                endpointSelector.matchLabels."app.kubernetes.io/name" = "loki";
+                egress = [
+                  {
+                    toEntities = [ "kube-apiserver" ];
+                    toPorts = [
+                      {
+                        ports = [
+                          {
+                            port = "6443";
+                            protocol = "TCP";
+                          }
+                        ];
+                      }
+                    ];
+                  }
+                ];
+              };
+            };
+          };
         };
       };
   };


### PR DESCRIPTION
Follow-up to #119: the loki rules sidecar (`loki-sc-rules`) watches the apiserver for rule ConfigMaps/Secrets and crash-looped on connect timeouts — the loki app had no apiserver-egress CNP. Same entity rule as the other monitoring components. The loki container itself was unaffected (zero restarts).