### PR TITLE
fix(cilium): drop explicit MTU — it is the base MTU, not the pod MTU

### DIFF
--- a/generated/manifests/prod-axon/cilium/ConfigMap-cilium-config.yaml
+++ b/generated/manifests/prod-axon/cilium/ConfigMap-cilium-config.yaml
@@ -130,7 +130,6 @@ data:
   monitor-aggregation: medium
   monitor-aggregation-flags: all
   monitor-aggregation-interval: 5s
-  mtu: "1450"
   nat-map-stats-entries: "32"
   nat-map-stats-interval: 30s
   node-port-bind-protection: "true"

--- a/generated/manifests/prod-axon/cilium/DaemonSet-cilium.yaml
+++ b/generated/manifests/prod-axon/cilium/DaemonSet-cilium.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 526cccd4fb84a42e5d1599d2fdb1ee81be2c44a5782dd32a71781dc71be98564
+        cilium.io/cilium-configmap-checksum: bdbcef5424f70dbd22cc0debcdef5f9ef76dac7299277988af9ea5f9e47239eb
         kubectl.kubernetes.io/default-container: cilium-agent
       labels:
         app.kubernetes.io/name: cilium-agent

--- a/generated/manifests/prod-axon/cilium/Deployment-cilium-operator.yaml
+++ b/generated/manifests/prod-axon/cilium/Deployment-cilium-operator.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 526cccd4fb84a42e5d1599d2fdb1ee81be2c44a5782dd32a71781dc71be98564
+        cilium.io/cilium-configmap-checksum: bdbcef5424f70dbd22cc0debcdef5f9ef76dac7299277988af9ea5f9e47239eb
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:

--- a/modules/den/aspects/kubernetes/services/network/cilium/cilium.nix
+++ b/modules/den/aspects/kubernetes/services/network/cilium/cilium.nix
@@ -78,12 +78,16 @@ in
                 inherit (environment) id;
               };
 
-              # Routing — geneve tunnel with 1450 MTU (50-byte overhead)
+              # Routing — geneve tunnel. MTU stays auto-detected: an explicit
+              # MTU is the BASE device MTU (cilium subtracts the geneve
+              # overhead itself), so the old `MTU = 1450` double-subtracted —
+              # pods routed at 1400 and the datapath emitted frag-needed for
+              # any >1450 host flow, stalling GRO-coalesced kubelet/apiserver
+              # replies across the thunderbolt mesh in an ICMP storm.
               ipv4NativeRoutingCIDR = podNetwork.cidr;
               ipv6NativeRoutingCIDR = podNetwork.ipv6_cidr;
               routingMode = "tunnel";
               tunnelProtocol = "geneve";
-              MTU = 1450;
 
               # Stable loopback routed by BGP fabric
               k8sServiceHost = "localhost";


### PR DESCRIPTION
Root cause of the remote-node scrape stalls found while finishing the monitoring stack (#119/#120/#121).

## Symptom
Prometheus scrapes of kubelet and apiserver metrics on any node other than its own pinned at the scrape deadline; small endpoints on the same sockets responded instantly. Hosts accumulated kernel PMTU cache entries 50 bytes (and pods 100 bytes) below the device MTU, and tcpdump showed a continuous ICMP frag-needed storm whose embedded packets were GRO-coalesced kubelet/apiserver reply superframes crossing the thunderbolt mesh.

## Cause
`MTU = 1450` in the cilium values was written to account for geneve overhead — but cilium treats the helm MTU value as the **base device MTU** and subtracts tunnel overhead itself. Result: double subtraction (pods routed 100 below the wire MTU) and, worse, the datapath enforcing the reduced value against host traffic on every managed device, emitting frag-needed for GRO aggregates that the stack would otherwise resegment fine. Because these flows are masqueraded, the ICMPs could not reliably heal the senders, so bulk host-to-pod transfers collapsed into retransmit crawl.

The wire itself is clean — full-MTU DF probes pass between nodes whose PMTU caches are not poisoned.

## Fix
Remove the explicit value; cilium auto-detects the device MTU and derives the tunnel route MTU. Manifest diff is the `mtu` key leaving the cilium ConfigMap plus the config-checksum annotations — **syncing this rolls the cilium agents** (the deliberate restart that picks the new MTU up).

## Rollout note
Existing pod interfaces keep their old MTU until the endpoints are regenerated; agents apply the corrected MTU to new endpoints and host datapath immediately. Expect remote kubelet/apiserver scrape targets to go green and the frag-needed storm to stop after the rollout; stale PMTU cache entries expire on their own within minutes.