### PR TITLE
fix(cilium): pin base MTU to 1500 — auto-detect takes the device minimum

### DIFF
--- a/generated/manifests/prod-axon/cilium/ConfigMap-cilium-config.yaml
+++ b/generated/manifests/prod-axon/cilium/ConfigMap-cilium-config.yaml
@@ -130,6 +130,7 @@ data:
   monitor-aggregation: medium
   monitor-aggregation-flags: all
   monitor-aggregation-interval: 5s
+  mtu: "1500"
   nat-map-stats-entries: "32"
   nat-map-stats-interval: 30s
   node-port-bind-protection: "true"

--- a/generated/manifests/prod-axon/cilium/DaemonSet-cilium.yaml
+++ b/generated/manifests/prod-axon/cilium/DaemonSet-cilium.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: bdbcef5424f70dbd22cc0debcdef5f9ef76dac7299277988af9ea5f9e47239eb
+        cilium.io/cilium-configmap-checksum: ef208dad8f6b80b7740fc2bcdff78ca1dba6e6dc73b4454c10f50a4bf789eec8
         kubectl.kubernetes.io/default-container: cilium-agent
       labels:
         app.kubernetes.io/name: cilium-agent

--- a/generated/manifests/prod-axon/cilium/Deployment-cilium-operator.yaml
+++ b/generated/manifests/prod-axon/cilium/Deployment-cilium-operator.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: bdbcef5424f70dbd22cc0debcdef5f9ef76dac7299277988af9ea5f9e47239eb
+        cilium.io/cilium-configmap-checksum: ef208dad8f6b80b7740fc2bcdff78ca1dba6e6dc73b4454c10f50a4bf789eec8
         prometheus.io/port: "9963"
         prometheus.io/scrape: "true"
       labels:

--- a/modules/den/aspects/kubernetes/services/network/cilium/cilium.nix
+++ b/modules/den/aspects/kubernetes/services/network/cilium/cilium.nix
@@ -78,16 +78,20 @@ in
                 inherit (environment) id;
               };
 
-              # Routing — geneve tunnel. MTU stays auto-detected: an explicit
-              # MTU is the BASE device MTU (cilium subtracts the geneve
-              # overhead itself), so the old `MTU = 1450` double-subtracted —
-              # pods routed at 1400 and the datapath emitted frag-needed for
-              # any >1450 host flow, stalling GRO-coalesced kubelet/apiserver
-              # replies across the thunderbolt mesh in an ICMP storm.
+              # Routing — geneve tunnel. MTU is the BASE device MTU; cilium
+              # subtracts the geneve overhead itself (pods route at 1450).
+              # It must be explicit: auto-detection takes the minimum across
+              # all managed devices and tailscale0 (1280) drags it down,
+              # while a tunnel-adjusted value like the original 1450
+              # double-subtracts — pods routed at 1400 and the datapath
+              # emitted frag-needed for any host flow above it, stalling
+              # GRO-coalesced kubelet/apiserver replies across the
+              # thunderbolt mesh in an ICMP storm.
               ipv4NativeRoutingCIDR = podNetwork.cidr;
               ipv6NativeRoutingCIDR = podNetwork.ipv6_cidr;
               routingMode = "tunnel";
               tunnelProtocol = "geneve";
+              MTU = 1500;
 
               # Stable loopback routed by BGP fabric
               k8sServiceHost = "localhost";


### PR DESCRIPTION
Follow-up to #122. With the explicit value removed, cilium auto-detected the MTU as the **minimum across all managed devices** — and tailscale0 (1280) is in the device list, so the datapath dropped to 1280: strictly worse than the original double-subtraction.

Pin `MTU` to the wire value (1500). Cilium treats it as the base device MTU and derives the tunnel route MTU itself, which is the semantics #122 established; this just stops the tailscale interface from sandbagging auto-detection. Same rollout shape as #122: ConfigMap value + config-checksum annotations roll the agents.