### PR TITLE
fix(media): make the ingress-lockdown CNPs importable by the agent

### DIFF
--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-deny-media-ingress-configarr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-deny-media-ingress-configarr.yaml
@@ -10,4 +10,6 @@ spec:
   endpointSelector:
     matchLabels:
       app.kubernetes.io/name: configarr
-  ingress: []
+  ingress:
+    - fromEntities:
+        - host

--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-deny-media-ingress-unpackerr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-deny-media-ingress-unpackerr.yaml
@@ -10,4 +10,6 @@ spec:
   endpointSelector:
     matchLabels:
       app.kubernetes.io/name: unpackerr
-  ingress: []
+  ingress:
+    - fromEntities:
+        - host

--- a/modules/den/aspects/kubernetes/services/media/network-policy.nix
+++ b/modules/den/aspects/kubernetes/services/media/network-policy.nix
@@ -231,10 +231,15 @@ let
             description = "Default-deny all ingress to ${name} (no inbound callers).";
             endpointSelector = podSel name;
             enableDefaultDeny.ingress = true;
-            # CRD anyOf requires one of ingress/ingressDeny/egress/egressDeny to
-            # be present; an empty list adds zero allow rules (NOT [ { } ], which
-            # would allow-all) while enableDefaultDeny above does the deny.
-            ingress = [ ];
+            # The agent-side rule sanitizer (stricter than the CRD anyOf)
+            # rejects a spec whose only section is an empty list — the policy
+            # passed the apiserver but every agent refused to import it, so
+            # these pods ran with NO ingress enforcement. One real allow rule
+            # satisfies it: the local host (kubelet probes), which cilium
+            # exempts by default anyway. enableDefaultDeny above still denies
+            # everything else, and future allows (e.g. a metrics scrape)
+            # compose instead of being trumped by a hard ingressDeny.
+            ingress = [ { fromEntities = [ "host" ]; } ];
           };
         }
       )


### PR DESCRIPTION
The route-less helper pods' default-deny policies used an empty `ingress: []` to satisfy the CRD anyOf — but the agent-side rule sanitizer is stricter and rejects a spec whose only section is an empty list. Result: the apiserver accepted the policies, ArgoCD reported Synced, and every agent refused to import them ("rule must have at least one of Ingress, IngressDeny, Egress, EgressDeny") — the lockdown pods ran with no ingress enforcement, visible only in agent logs.

Replace the empty list with one real allow rule from the `host` entity (kubelet probes — exempted by default anyway, so no behavior change), keeping `enableDefaultDeny.ingress` as the actual deny. Chosen over a hard `ingressDeny` rule so future per-flow allows (e.g. a metrics scrape) compose rather than being silently trumped by deny precedence.