### PR TITLE
fix(media): grant configarr/unpackerr the arr-side ingress allows

### DIFF
--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-lidarr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-lidarr.yaml
@@ -16,6 +16,10 @@ spec:
             app.kubernetes.io/name: glance
         - matchLabels:
             app.kubernetes.io/name: dash
+        - matchLabels:
+            app.kubernetes.io/name: unpackerr
+        - matchLabels:
+            app.kubernetes.io/name: configarr
       toPorts:
         - ports:
             - port: "8686"

--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-radarr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-radarr.yaml
@@ -18,6 +18,10 @@ spec:
             app.kubernetes.io/name: glance
         - matchLabels:
             app.kubernetes.io/name: dash
+        - matchLabels:
+            app.kubernetes.io/name: unpackerr
+        - matchLabels:
+            app.kubernetes.io/name: configarr
       toPorts:
         - ports:
             - port: "7878"

--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-sonarr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-sonarr.yaml
@@ -18,6 +18,10 @@ spec:
             app.kubernetes.io/name: glance
         - matchLabels:
             app.kubernetes.io/name: dash
+        - matchLabels:
+            app.kubernetes.io/name: unpackerr
+        - matchLabels:
+            app.kubernetes.io/name: configarr
       toPorts:
         - ports:
             - port: "8989"

--- a/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-whisparr.yaml
+++ b/generated/manifests/prod-axon/media-network-policy/CiliumNetworkPolicy-allow-media-ingress-whisparr.yaml
@@ -16,6 +16,10 @@ spec:
             app.kubernetes.io/name: glance
         - matchLabels:
             app.kubernetes.io/name: dash
+        - matchLabels:
+            app.kubernetes.io/name: unpackerr
+        - matchLabels:
+            app.kubernetes.io/name: configarr
       toPorts:
         - ports:
             - port: "6969"

--- a/modules/den/aspects/kubernetes/services/media/network-policy.nix
+++ b/modules/den/aspects/kubernetes/services/media/network-policy.nix
@@ -193,13 +193,23 @@ let
   # prowlarr as a caller (internal), no dashboard reads it.
   dashboardConsumes = arrs ++ [ "sabnzbd" ];
 
+  # Helper pods whose EGRESS half lives in their owning app file (see header)
+  # still need the arr-side ingress allow HERE — the owning files only carry
+  # the source-side policy, and with only an egress half the arrs' ingress
+  # default-deny silently dropped configarr/unpackerr API calls.
+  arrHelperSources = [
+    "unpackerr"
+    "configarr"
+  ];
+
   ingressPolicies = builtins.listToAttrs (
     map (
       tgt:
       let
         appSources = uniq (map (e: e.from) (builtins.filter (e: e.to == tgt) edges));
         dashSources = lib.optionals (builtins.elem tgt dashboardConsumes) dashboards;
-        allSources = appSources ++ dashSources;
+        helperSources = lib.optionals (builtins.elem tgt arrs) arrHelperSources;
+        allSources = appSources ++ dashSources ++ helperSources;
       in
       lib.nameValuePair "allow-media-ingress-${tgt}" {
         spec = {


### PR DESCRIPTION
Companion to #124, and the actual cause of the configarr run failures (timeouts against all four arr health endpoints).

The network-policy header excludes edges "already declared in an owning app file" from the edge graph — but the owning files (configarr.nix, unpackerr.nix) only declare the **egress half**. Nothing ever granted the matching ingress on the arr pods, whose aggregated ingress policy default-denies unlisted sources. configarr API calls timed out; unpackerr polling has the same gap (consistent with it never being verified end-to-end).

Adds the two helper sources to every arr ingress aggregate. Ports unchanged — same per-target API ports as the other callers.