### PR TITLE
fix(mesh): disable segmentation/receive offloads on the fabric links

### DIFF
--- a/modules/den/aspects/services/networking/thunderbolt-mesh-of.nix
+++ b/modules/den/aspects/services/networking/thunderbolt-mesh-of.nix
@@ -179,6 +179,22 @@
               networkConfig.LinkLocalAddressing = if loopback6 != null then "ipv6" else "no";
             };
 
+            # Segmentation/receive offloads stay OFF on the fabric: tbnet
+            # GRO/TSO superframes (2-11KB aggregates) exceed the device MTU,
+            # and cilium's legacy host-routing path checks the aggregate
+            # length rather than the GSO segment size, answering each one
+            # with ICMP frag-needed — host<->pod bulk flows across the mesh
+            # (e.g. prometheus scraping remote kubelets) stalled into
+            # retransmit crawl until these were disabled.
+            links."20-thunderbolt" = {
+              matchConfig.Driver = "thunderbolt-net";
+              linkConfig = {
+                GenericReceiveOffload = false;
+                GenericSegmentationOffload = false;
+                TCPSegmentationOffload = false;
+              };
+            };
+
             config.networkConfig = {
               IPv4Forwarding = true;
               IPv6Forwarding = true;


### PR DESCRIPTION
Final piece of the remote-scrape stall (#122/#123 fixed the MTU config; this fixes the remaining datapath trip).

With correct MTUs the frag-needed storm continued: tbnet GRO/TSO coalesces fabric traffic into 2-11KB superframes, and cilium's legacy host-routing path compares the **aggregate** length against the device MTU instead of the GSO segment size — every superframe crossing into a pod answered with ICMP frag-needed, and because those flows are masqueraded the senders could not heal. Host-to-pod bulk across the mesh crawled.

Disabling GRO/GSO/TSO on the thunderbolt-net links stops superframe formation. Verified live with ethtool before making it declarative: **all prometheus targets went green** — remote kubelet scrapes dropped from pinned-at-deadline to ~0.15s.

The `.link` unit applies at boot/device-add; the live fleet already runs with offloads off via ethtool, so this lands declaratively at the next host deploy with no behavior change.