### PR TITLE
feat(k3s): drain on shutdown, uncordon on startup

### DIFF
--- a/modules/den/aspects/services/k3s/k3s.nix
+++ b/modules/den/aspects/services/k3s/k3s.nix
@@ -33,6 +33,7 @@ in
       den.aspects.services.k3s.containerd
       den.aspects.services.k3s.node
       den.aspects.services.k3s.bootstrap
+      den.aspects.services.k3s.node-lifecycle
     ];
 
     settings = {

--- a/modules/den/aspects/services/k3s/node-lifecycle.nix
+++ b/modules/den/aspects/services/k3s/node-lifecycle.nix
@@ -1,0 +1,77 @@
+# K3s node lifecycle — drain on shutdown, uncordon on startup.
+#
+# Sub-aspect of k3s (which includes it). One oneshot unit whose stop path is
+# the drain: systemd stops units in reverse ordering-dependency order, so with
+# After=k3s.service the ExecStop drain runs to completion BEFORE systemd may
+# begin stopping k3s (the node-local apiserver is still serving), and
+# After=containerd.service keeps the runtime alive while evicted pods
+# terminate. Deliberately NO PartOf/BindsTo on k3s: a k3s service restart
+# (colmena activation) must not drain — with the standalone containerd a k3s
+# restart never touches running pods (KillMode=process, Delegate=yes), only
+# the control plane blips. The unit is only stopped in the same transaction
+# as k3s during system shutdown/reboot, which is exactly when draining is
+# wanted; that makes rolling reboots (colmena --reboot -p1, the toggle
+# script) stagger on PDBs — CNPG gets a clean switchover before the node
+# goes down.
+#
+# Shutdown can never deadlock on the drain: evictions that cannot proceed
+# (whole-cluster poweroff, last node standing) hit --timeout and the script
+# exits zero anyway.
+{
+  den.aspects.services.k3s.node-lifecycle = {
+    nixos =
+      {
+        config,
+        pkgs,
+        ...
+      }:
+      let
+        nodeName = config.networking.hostName;
+      in
+      {
+        systemd.services.k3s-node-lifecycle = {
+          description = "K3s node lifecycle: uncordon after startup, drain before shutdown";
+          wantedBy = [ "multi-user.target" ];
+          after = [
+            "k3s.service"
+            "containerd.service"
+          ];
+          wants = [ "k3s.service" ];
+          path = [ pkgs.kubectl ];
+          environment.KUBECONFIG = "/etc/rancher/k3s/k3s.yaml";
+
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            TimeoutStartSec = "10min";
+            # Must exceed the drain --timeout below.
+            TimeoutStopSec = "7min";
+
+            ExecStart = pkgs.writeShellScript "k3s-node-uncordon" ''
+              echo "Waiting for node ${nodeName} to be Ready..."
+              until kubectl wait --for=condition=Ready "node/${nodeName}" --timeout=30s 2>/dev/null; do
+                sleep 5
+              done
+              kubectl uncordon "${nodeName}"
+            '';
+
+            ExecStop = pkgs.writeShellScript "k3s-node-drain" ''
+              # Never block shutdown on a broken control plane.
+              if ! kubectl get node "${nodeName}" --request-timeout=10s >/dev/null 2>&1; then
+                echo "apiserver unreachable; skipping drain"
+                exit 0
+              fi
+
+              echo "Draining ${nodeName}..."
+              kubectl drain "${nodeName}" \
+                --ignore-daemonsets \
+                --delete-emptydir-data \
+                --timeout=5m \
+                || echo "drain incomplete (timeout or eviction failure); continuing shutdown"
+              exit 0
+            '';
+          };
+        };
+      };
+  };
+}


### PR DESCRIPTION
Mechanizes the drain-drill runbook: nodes drain themselves on shutdown/reboot and uncordon themselves once Ready after boot.

## How
One oneshot unit (`k3s-node-lifecycle`), `RemainAfterExit`, whose **stop path is the drain**:

- `After=k3s.service` — systemd stops in reverse ordering order, so at shutdown the `ExecStop` drain runs to completion **before** systemd may begin stopping k3s; the node-local apiserver is still serving throughout.
- `After=containerd.service` — the runtime outlives the drain, so evicted pods terminate cleanly.
- **No `PartOf`/`BindsTo` on k3s** — a k3s service restart (colmena activation) does not queue a stop for this unit, so restarts stay drain-free. Verified semantics: k3s and containerd both run `KillMode=process` (+`Delegate=yes`), so a k3s restart never touches running pods; only shutdown should drain.

## Properties
- Rolling reboots (`colmena apply --reboot -p1`, the toggle script) stagger on PDBs — CNPG gets a clean switchover before each node goes down.
- Whole-cluster poweroff cannot deadlock: evictions that cannot proceed hit `--timeout=5m` and shutdown continues (`TimeoutStopSec=7min` bounds the worst case).
- A broken control plane never blocks shutdown (10s reachability probe, then skip).
- Post-reboot the unit waits for node Ready and uncordons; on a never-drained boot that is a no-op.