### PR TITLE
fix(monitoring): render loki monitors, server-side apply for grafana

### DIFF
--- a/generated/manifests/prod-axon/apps/Application-grafana.yaml
+++ b/generated/manifests/prod-axon/apps/Application-grafana.yaml
@@ -16,3 +16,5 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/generated/manifests/prod-axon/loki/PrometheusRule-loki-loki-alerts.yaml
+++ b/generated/manifests/prod-axon/loki/PrometheusRule-loki-loki-alerts.yaml
@@ -1,0 +1,61 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+  name: loki-loki-alerts
+  namespace: monitoring
+spec:
+  groups:
+    - name: loki_alerts
+      rules:
+        - alert: LokiRequestErrors
+          annotations:
+            message: |
+              {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}% errors.
+          expr: |
+            100 * sum(rate(loki_request_duration_seconds_count{status_code=~"5.."}[2m])) by (namespace, job, route)
+              /
+            sum(rate(loki_request_duration_seconds_count[2m])) by (namespace, job, route)
+              > 10
+          for: 15m
+          labels:
+            severity: critical
+        - alert: LokiRequestPanics
+          annotations:
+            message: |
+              {{ $labels.job }} is experiencing {{ printf "%.2f" $value }}% increase of panics.
+          expr: |
+            sum(increase(loki_panic_total[10m])) by (namespace, job) > 0
+          labels:
+            severity: critical
+        - alert: LokiRequestLatency
+          annotations:
+            message: |
+              {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.
+          expr: |
+            namespace_job_route:loki_request_duration_seconds:99quantile{route!~"(?i).*tail.*"} > 1
+          for: 15m
+          labels:
+            severity: critical
+        - alert: LokiTooManyCompactorsRunning
+          annotations:
+            message: |
+              {{ $labels.cluster }} {{ $labels.namespace }} has had {{ printf "%.0f" $value }} compactors running for more than 5m. Only one compactor should run at a time.
+          expr: |
+            sum(loki_boltdb_shipper_compactor_running) by (cluster, namespace) > 1
+          for: 5m
+          labels:
+            severity: warning
+    - name: loki_canaries_alerts
+      rules:
+        - alert: LokiCanaryLatency
+          annotations:
+            message: |
+              {{ $labels.job }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.
+          expr: |
+            histogram_quantile(0.99, sum(rate(loki_canary_response_latency_seconds_bucket[5m])) by (le, namespace, job)) > 5
+          for: 15m
+          labels:
+            severity: warning

--- a/generated/manifests/prod-axon/loki/PrometheusRule-loki-loki-rules.yaml
+++ b/generated/manifests/prod-axon/loki/PrometheusRule-loki-loki-rules.yaml
@@ -1,0 +1,84 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+  name: loki-loki-rules
+  namespace: monitoring
+spec:
+  groups:
+    - name: loki_rules
+      rules:
+        - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, job))
+          labels:
+            cluster: loki
+          record: job:loki_request_duration_seconds:99quantile
+        - expr: histogram_quantile(0.50, sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, job))
+          labels:
+            cluster: loki
+          record: job:loki_request_duration_seconds:50quantile
+        - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (job) / sum(rate(loki_request_duration_seconds_count[1m])) by (job)
+          labels:
+            cluster: loki
+          record: job:loki_request_duration_seconds:avg
+        - expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, job)
+          labels:
+            cluster: loki
+          record: job:loki_request_duration_seconds_bucket:sum_rate
+        - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (job)
+          labels:
+            cluster: loki
+          record: job:loki_request_duration_seconds_sum:sum_rate
+        - expr: sum(rate(loki_request_duration_seconds_count[1m])) by (job)
+          labels:
+            cluster: loki
+          record: job:loki_request_duration_seconds_count:sum_rate
+        - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, job, route))
+          labels:
+            cluster: loki
+          record: job_route:loki_request_duration_seconds:99quantile
+        - expr: histogram_quantile(0.50, sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, job, route))
+          labels:
+            cluster: loki
+          record: job_route:loki_request_duration_seconds:50quantile
+        - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (job, route) / sum(rate(loki_request_duration_seconds_count[1m])) by (job, route)
+          labels:
+            cluster: loki
+          record: job_route:loki_request_duration_seconds:avg
+        - expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, job, route)
+          labels:
+            cluster: loki
+          record: job_route:loki_request_duration_seconds_bucket:sum_rate
+        - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (job, route)
+          labels:
+            cluster: loki
+          record: job_route:loki_request_duration_seconds_sum:sum_rate
+        - expr: sum(rate(loki_request_duration_seconds_count[1m])) by (job, route)
+          labels:
+            cluster: loki
+          record: job_route:loki_request_duration_seconds_count:sum_rate
+        - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, namespace, job, route))
+          labels:
+            cluster: loki
+          record: namespace_job_route:loki_request_duration_seconds:99quantile
+        - expr: histogram_quantile(0.50, sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, namespace, job, route))
+          labels:
+            cluster: loki
+          record: namespace_job_route:loki_request_duration_seconds:50quantile
+        - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (namespace, job, route) / sum(rate(loki_request_duration_seconds_count[1m])) by (namespace, job, route)
+          labels:
+            cluster: loki
+          record: namespace_job_route:loki_request_duration_seconds:avg
+        - expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, namespace, job, route)
+          labels:
+            cluster: loki
+          record: namespace_job_route:loki_request_duration_seconds_bucket:sum_rate
+        - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (namespace, job, route)
+          labels:
+            cluster: loki
+          record: namespace_job_route:loki_request_duration_seconds_sum:sum_rate
+        - expr: sum(rate(loki_request_duration_seconds_count[1m])) by (namespace, job, route)
+          labels:
+            cluster: loki
+          record: namespace_job_route:loki_request_duration_seconds_count:sum_rate

--- a/generated/manifests/prod-axon/loki/ServiceMonitor-loki.yaml
+++ b/generated/manifests/prod-axon/loki/ServiceMonitor-loki.yaml
@@ -1,0 +1,32 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+  name: loki
+  namespace: monitoring
+spec:
+  endpoints:
+    - interval: 15s
+      path: /metrics
+      port: http-metrics
+      relabelings:
+        - action: replace
+          replacement: monitoring/$1
+          sourceLabels:
+            - job
+          targetLabel: job
+        - action: replace
+          replacement: loki
+          targetLabel: cluster
+      scheme: http
+  selector:
+    matchExpressions:
+      - key: prometheus.io/service-monitor
+        operator: NotIn
+        values:
+          - "false"
+    matchLabels:
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/name: loki

--- a/modules/den/aspects/kubernetes/services/monitoring/grafana.nix
+++ b/modules/den/aspects/kubernetes/services/monitoring/grafana.nix
@@ -41,6 +41,10 @@ in
         applications.grafana = {
           namespace = "monitoring";
 
+          # Dashboard ConfigMaps (the CNPG one is ~250KiB) blow past the
+          # 256KiB last-applied annotation limit under client-side apply.
+          syncPolicy.syncOptions.serverSideApply = true;
+
           # CNPG cluster dashboard — rendered as a labeled ConfigMap the
           # sidecar picks up. The operator chart's grafanaDashboard.create is
           # a stub (the JSON moved to the dedicated dashboards repo this

--- a/modules/den/aspects/kubernetes/services/monitoring/loki.nix
+++ b/modules/den/aspects/kubernetes/services/monitoring/loki.nix
@@ -15,6 +15,16 @@
           helm.releases.loki = {
             chart = charts.grafana.loki;
 
+            # The chart gates its ServiceMonitor/PrometheusRule on cluster
+            # capabilities, which offline helm template never satisfies —
+            # declare the live CRDs explicitly so monitoring.* renders.
+            extraOpts = [
+              "--api-versions"
+              "monitoring.coreos.com/v1/ServiceMonitor"
+              "--api-versions"
+              "monitoring.coreos.com/v1/PrometheusRule"
+            ];
+
             values = {
               # Without this the chart renders SimpleScalable and, with
               # read/write/backend at 0, no loki pods at all.


### PR DESCRIPTION
Two data-flow fixes found after #128 deployed:

**loki dashboards had no data** — the loki chart gates its ServiceMonitor *and* its PrometheusRule set on `.Capabilities.APIVersions`, which offline `helm template` never satisfies, so neither rendered: nothing scraped loki and the recording rules its dashboards read did not exist. nixidy already passes `extraOpts` through to `helm template`, so the release now declares `--api-versions` for the live monitoring CRDs and both render from the chart natively. (Cleaner than the raw-object route used for argo-cd — that chart needed label corrections anyway; loki's render verbatim.)

**grafana app stuck retrying** — `ConfigMap "cnpg-grafana-dashboard" is invalid: metadata.annotations: Too long`: the CNPG dashboard JSON is ~250KiB and client-side apply pushes it over the 256KiB last-applied annotation limit. `ServerSideApply=true` on the application, same as kube-prometheus-stack and cloudnative-pg.