### PR TITLE
fix(monitoring): Recreate strategy for grafana, server-side diff

### DIFF
--- a/generated/manifests/prod-axon/apps/Application-grafana.yaml
+++ b/generated/manifests/prod-axon/apps/Application-grafana.yaml
@@ -1,6 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  annotations:
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
   name: grafana
   namespace: argocd
 spec:

--- a/generated/manifests/prod-axon/grafana/Deployment-grafana.yaml
+++ b/generated/manifests/prod-axon/grafana/Deployment-grafana.yaml
@@ -14,14 +14,14 @@ spec:
       app.kubernetes.io/instance: grafana
       app.kubernetes.io/name: grafana
   strategy:
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       annotations:
         checksum/config: d80d30a08ed4d9e2f48400f0680d11dc721b9a017407ea68769911cb908e41f2
         checksum/dashboards-json-config: 17554d4bfe190628c84b4440ddd019250695580f87c0ec2097b2a60c810c5147
         checksum/sc-dashboard-provider-config: e70bf6a851099d385178a76de9757bb0bef8299da6d8443602590e44f05fdf24
-        checksum/secret: e63898bd76ca84f910f1ab45f341f57f227ce36da46a839a80d916f7a7e444ee
+        checksum/secret: 14b6d85d40359bd99c374ecedb1dc8106aeaece4fca2150e0e23eb196809ab41
         kubectl.kubernetes.io/default-container: grafana
       labels:
         app.kubernetes.io/instance: grafana

--- a/generated/manifests/prod-axon/grafana/SopsSecret-grafana.yaml
+++ b/generated/manifests/prod-axon/grafana/SopsSecret-grafana.yaml
@@ -8,12 +8,12 @@ metadata:
     name: grafana
     namespace: monitoring
     annotations:
-        secrets.json64.dev/plaintext-sha256: a49e21a7787fb4d508afdbc3fc0a1b02a19397d86dbda513cbd7584d4f6d1019
+        secrets.json64.dev/plaintext-sha256: 11443d79564bcc332472c9452f00f1bdae0d187638ad21394f1db9e88a81fcfd
 spec:
     secretTemplates:
         - data:
-            admin-password: ENC[AES256_GCM,data:mwi/eqmMScERqw1NaCplhYXwkSVL8D5SYqUEYAW31hhTYd3SQXbmZnNvPkfQ2YhPohSNqmr+nUw=,iv:udfsvI7Tfq9Og/xSzr0Mmw89lmF2kJV9ATQHuHWBC9s=,tag:sGc4TXL3jdba29DI66CIaQ==,type:str]
-            admin-user: ENC[AES256_GCM,data:7RXOvuzoNq4=,iv:oKFlFXHfdMPxihRPgoaKPu42VbOYr1DJl9/xEc9gnPw=,tag:a11M5AgJPDhbfVYJh31CMg==,type:str]
+            admin-password: ENC[AES256_GCM,data:fmahtuTehplTT6yKPP3a/gFbF/9qoU6Oihjr6hdxMtmlMzaBXjL5EPVMAdHdn3QdUaNarCDi1bc=,iv:KBZRA9JHbKB0xd0Z0ou+GrunbbY5TUsQbZdSDYkQLqI=,tag:sqcrurVpH8wsPzpdWvZ9gA==,type:str]
+            admin-user: ENC[AES256_GCM,data:P3zFgNTW8rI=,iv:D+Ix+bCgZOjmSUKjOZc2UqlxY9W3R4tfeRlWHQG4qyg=,tag:S3L1S/XvDS8ftF1m94uboA==,type:str]
             ldap-toml: ""
           name: grafana
           type: Opaque
@@ -21,14 +21,14 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaaEptVkpXUmE5eTRBUG9Q
-            NHVZcDhzMnk0MUpFd1Q1UU5zWHc5VUNmOTBZCjFlV1pQZ0ptd2hBQ1ZqRTlDTXdr
-            MEpnWHFPWkgvQW5LblhOZGJZZUtPQUEKLS0tIDE4MjhhN2J6WXQ4bXVWMFF5MlA0
-            V3Vpb3ZhcElnVVBUR2ozcm1QeC9SRUUKkIOTHa8/pt6rKxl+UMLqK5pDsLyxAYMZ
-            Wq34I2oZ3K4JBftDSJS0I02HSCQzEuY3x+oJsDIycpOssod9mSQ1Gg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKSVVrVWRKbmxMZDR0dGI1
+            NERCZ1pZNlJmVlFNWjU3aExiSk9yY0tPNUIwCk10MjNXb09OQ05XTDVSN0hhUkNp
+            VkpKSmx5MFdiTG5CaDFDbzh4Ty85NHcKLS0tIFpnNUM3ZnlJdVRicnc3cHJyQjFw
+            TWwyV3JMRnBCYXN3bW41dkZBUVVZRU0KM1ECWIypcX3EZPO73Io4va0M24kbmNas
+            s8T2W/GGE48cfPwSSrNswQwKaCyBgsWuJss9RUAnR3owcZ8uoKaFag==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-06-12T20:39:40Z"
-    mac: ENC[AES256_GCM,data:ZN9Oj5Ct9jANlc2fJ6sAjS8VWcM6nv6oYR3AYfo3kM8XsoOnmjsHytQyA/4KsvHvTtqVXQN7dNzNSwdk04ICjzGMkvpg9xKVCf3LoMGHv9jtjmLyUK1aWkbiNsnUZLdJD4ruI5d67Sb3DQk8JHH5cEqTHmb1AEatXLedeTmwIgA=,iv:KLaQxgiHrEooHEQR1x6H2pOj2VLo0/ZSLv+gQjmbT0E=,tag:y4qost6iZVVxnFgSA4O2jQ==,type:str]
+    lastmodified: "2026-06-12T21:02:53Z"
+    mac: ENC[AES256_GCM,data:G7DqEBHSUlNAaxfKzM2Ju62rBbU2JSI+tbZi7E2j5cY9pJr+I96TFrk5P86JPD5E0tf1386lsm3PxSwv3uF4GASJgm/fbN/8LuiqRv7aO+1SLw9WrTU3lOJvGicLdj6KZGdWK2RSXdznuob7sEtKImZcjtcg76SVnAFMKqr/Bws=,iv:sF1HLjU506VcI+aCQklS7x0CAqLP/W6QrAXiT0ph1eM=,tag:7tKT+JV0u/zlVwj+dkSlsg==,type:str]
     version: 3.13.1

--- a/modules/den/aspects/kubernetes/services/monitoring/grafana.nix
+++ b/modules/den/aspects/kubernetes/services/monitoring/grafana.nix
@@ -44,6 +44,7 @@ in
           # Dashboard ConfigMaps (the CNPG one is ~250KiB) blow past the
           # 256KiB last-applied annotation limit under client-side apply.
           syncPolicy.syncOptions.serverSideApply = true;
+          compareOptions.serverSideDiff = true;
 
           # CNPG cluster dashboard — rendered as a labeled ConfigMap the
           # sidecar picks up. The operator chart's grafanaDashboard.create is
@@ -62,6 +63,10 @@ in
                 storageClassName = "longhorn";
                 size = "10Gi";
               };
+
+              # RWO volume: a rolling update deadlocks on multi-attach (the
+              # new pod cannot mount while the old one holds the PVC).
+              deploymentStrategy.type = "Recreate";
 
               serviceMonitor.enabled = true;
 


### PR DESCRIPTION
Follow-up to #130, found live: the grafana Deployment rollout deadlocked — `Multi-Attach error for volume` — because the PVC is RWO and the default RollingUpdate strategy schedules the replacement pod while the old one still holds the volume. `Recreate` is the chart-documented strategy when persistence is enabled; brief downtime per rollout is inherent to a single-replica RWO grafana.

Also enables `serverSideDiff` (the app already uses ServerSideApply): without it the HTTPRoute reports perpetual OutOfSync on controller-defaulted fields.