### PR TITLE
fix(monitoring): envoy proxies serve prometheus at /stats/prometheus

### DIFF
--- a/generated/manifests/prod-axon/kube-prometheus-stack/PodMonitor-envoy-proxies.yaml
+++ b/generated/manifests/prod-axon/kube-prometheus-stack/PodMonitor-envoy-proxies.yaml
@@ -8,7 +8,8 @@ spec:
     matchNames:
       - gateways
   podMetricsEndpoints:
-    - port: metrics
+    - path: /stats/prometheus
+      port: metrics
   selector:
     matchLabels:
       app.kubernetes.io/component: proxy

--- a/modules/den/aspects/kubernetes/services/monitoring/prometheus.nix
+++ b/modules/den/aspects/kubernetes/services/monitoring/prometheus.nix
@@ -107,7 +107,14 @@
               spec = {
                 namespaceSelector.matchNames = [ "gateways" ];
                 selector.matchLabels."app.kubernetes.io/component" = "proxy";
-                podMetricsEndpoints = [ { port = "metrics"; } ];
+                # Envoy serves prometheus on the admin-style stats path, not
+                # /metrics (the controller does use /metrics).
+                podMetricsEndpoints = [
+                  {
+                    port = "metrics";
+                    path = "/stats/prometheus";
+                  }
+                ];
               };
             }
           ];


### PR DESCRIPTION
The envoy-proxies PodMonitor from #128 scraped `/metrics` and 404ed on all three proxy pods — envoy serves prometheus on its stats path. The controller PodMonitor genuinely uses `/metrics` and is unaffected (already up).