### PR TITLE
feat(monitoring): install metrics-server

### DIFF
--- a/generated/manifests/prod-axon/apps/Application-metrics-server.yaml
+++ b/generated/manifests/prod-axon/apps/Application-metrics-server.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: metrics-server
+  namespace: argocd
+spec:
+  destination:
+    namespace: kube-system
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/metrics-server
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/metrics-server/APIService-v1beta1-metrics-k8s-io.yaml
+++ b/generated/manifests/prod-axon/metrics-server/APIService-v1beta1-metrics-k8s-io.yaml
@@ -1,0 +1,17 @@
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    app.kubernetes.io/instance: metrics-server
+    app.kubernetes.io/name: metrics-server
+  name: v1beta1.metrics.k8s.io
+spec:
+  group: metrics.k8s.io
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: metrics-server
+    namespace: kube-system
+    port: 443
+  version: v1beta1
+  versionPriority: 100

--- a/generated/manifests/prod-axon/metrics-server/CiliumNetworkPolicy-allow-metrics-server-egress.yaml
+++ b/generated/manifests/prod-axon/metrics-server/CiliumNetworkPolicy-allow-metrics-server-egress.yaml
@@ -1,0 +1,28 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: allow-metrics-server-egress
+  namespace: kube-system
+spec:
+  description: Allow metrics-server to reach the kube-apiserver and every node's kubelet.
+  egress:
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "6443"
+              protocol: TCP
+    - toEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "10250"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: metrics-server

--- a/generated/manifests/prod-axon/metrics-server/ClusterRole-system:metrics-server-aggregated-reader.yaml
+++ b/generated/manifests/prod-axon/metrics-server/ClusterRole-system:metrics-server-aggregated-reader.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: metrics-server
+    app.kubernetes.io/name: metrics-server
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: system:metrics-server-aggregated-reader
+rules:
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch

--- a/generated/manifests/prod-axon/metrics-server/ClusterRole-system:metrics-server.yaml
+++ b/generated/manifests/prod-axon/metrics-server/ClusterRole-system:metrics-server.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: metrics-server
+    app.kubernetes.io/name: metrics-server
+  name: system:metrics-server
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - nodes
+      - namespaces
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch

--- a/generated/manifests/prod-axon/metrics-server/ClusterRoleBinding-metrics-server:system:auth-delegator.yaml
+++ b/generated/manifests/prod-axon/metrics-server/ClusterRoleBinding-metrics-server:system:auth-delegator.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: metrics-server
+    app.kubernetes.io/name: metrics-server
+  name: metrics-server:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system

--- a/generated/manifests/prod-axon/metrics-server/ClusterRoleBinding-system:metrics-server.yaml
+++ b/generated/manifests/prod-axon/metrics-server/ClusterRoleBinding-system:metrics-server.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: metrics-server
+    app.kubernetes.io/name: metrics-server
+  name: system:metrics-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system

--- a/generated/manifests/prod-axon/metrics-server/Deployment-metrics-server.yaml
+++ b/generated/manifests/prod-axon/metrics-server/Deployment-metrics-server.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: metrics-server
+    app.kubernetes.io/name: metrics-server
+  name: metrics-server
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: metrics-server
+      app.kubernetes.io/name: metrics-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: metrics-server
+        app.kubernetes.io/name: metrics-server
+    spec:
+      containers:
+        - args:
+            - --secure-port=10250
+            - --cert-dir=/tmp
+            - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+            - --kubelet-use-node-status-port
+            - --metric-resolution=15s
+          image: registry.k8s.io/metrics-server/metrics-server:v0.8.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /livez
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 0
+            periodSeconds: 10
+          name: metrics-server
+          ports:
+            - containerPort: 10250
+              name: https
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+      priorityClassName: system-cluster-critical
+      serviceAccountName: metrics-server
+      volumes:
+        - emptyDir: {}
+          name: tmp

--- a/generated/manifests/prod-axon/metrics-server/RoleBinding-metrics-server-auth-reader.yaml
+++ b/generated/manifests/prod-axon/metrics-server/RoleBinding-metrics-server-auth-reader.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: metrics-server
+    app.kubernetes.io/name: metrics-server
+  name: metrics-server-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system

--- a/generated/manifests/prod-axon/metrics-server/Service-metrics-server.yaml
+++ b/generated/manifests/prod-axon/metrics-server/Service-metrics-server.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: metrics-server
+    app.kubernetes.io/name: metrics-server
+  name: metrics-server
+  namespace: kube-system
+spec:
+  ports:
+    - appProtocol: https
+      name: https
+      port: 443
+      protocol: TCP
+      targetPort: https
+  selector:
+    app.kubernetes.io/instance: metrics-server
+    app.kubernetes.io/name: metrics-server
+  type: ClusterIP

--- a/generated/manifests/prod-axon/metrics-server/ServiceAccount-metrics-server.yaml
+++ b/generated/manifests/prod-axon/metrics-server/ServiceAccount-metrics-server.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: metrics-server
+    app.kubernetes.io/name: metrics-server
+  name: metrics-server
+  namespace: kube-system

--- a/modules/den/aspects/kubernetes/services/monitoring/metrics-server.nix
+++ b/modules/den/aspects/kubernetes/services/monitoring/metrics-server.nix
@@ -1,0 +1,70 @@
+# metrics-server — the Kubernetes Metrics API (metrics.k8s.io).
+#
+# k3s's bundled copy is disabled (--disable metrics-server, like every other
+# bundled component this cluster replaces); nothing reinstated it, so
+# `kubectl top`, HPA, and every metrics.k8s.io consumer errored — longhorn's
+# node/instance-manager CPU+memory collectors among them ("the server could
+# not find the requested resource (get nodes.metrics.k8s.io)").
+#
+# k3s signs kubelet serving certs with the cluster CA, so no
+# --kubelet-insecure-tls is needed. Ingress stays open (the aggregated-API
+# calls arrive from the host-network apiserver); egress to the kubelets is
+# host-entity traffic and needs the explicit rule below.
+{
+  den.aspects.kubernetes.services.monitoring.metrics-server = {
+    k8s-manifests =
+      { charts, ... }:
+      {
+        applications.metrics-server = {
+          namespace = "kube-system";
+
+          helm.releases.metrics-server = {
+            chart = charts.kubernetes-sigs.metrics-server;
+          };
+
+          resources.ciliumNetworkPolicies.allow-metrics-server-egress = {
+            metadata.annotations."argocd.argoproj.io/sync-wave" = "-1";
+            spec = {
+              description = "Allow metrics-server to reach the kube-apiserver and every node's kubelet.";
+              endpointSelector.matchLabels."app.kubernetes.io/name" = "metrics-server";
+              egress = [
+                {
+                  toEntities = [ "kube-apiserver" ];
+                  toPorts = [
+                    {
+                      ports = [
+                        {
+                          port = "443";
+                          protocol = "TCP";
+                        }
+                        {
+                          port = "6443";
+                          protocol = "TCP";
+                        }
+                      ];
+                    }
+                  ];
+                }
+                {
+                  toEntities = [
+                    "host"
+                    "remote-node"
+                  ];
+                  toPorts = [
+                    {
+                      ports = [
+                        {
+                          port = "10250";
+                          protocol = "TCP";
+                        }
+                      ];
+                    }
+                  ];
+                }
+              ];
+            };
+          };
+        };
+      };
+  };
+}

--- a/modules/den/clusters/axon.nix
+++ b/modules/den/clusters/axon.nix
@@ -81,6 +81,7 @@
       services.storage.volume-snapshots
       services.storage.cloudnative-pg
       services.monitoring.prometheus
+      services.monitoring.metrics-server
       services.monitoring.loki
       services.monitoring.alloy
       services.monitoring.monitoring-pg


### PR DESCRIPTION
Root cause of the longhorn dashboard's empty CPU/memory panels — and a real cluster capability gap.

longhorn-manager logs: `the server could not find the requested resource (get nodes.metrics.k8s.io)` — its node and instance-manager resource collectors read the **Kubernetes Metrics API**, not cadvisor. k3s's bundled metrics-server is disabled (`--disable metrics-server`, consistent with how this cluster replaces every bundled component) and nothing ever reinstated it, so `kubectl top`, HPA, and any metrics.k8s.io consumer have been broken since bring-up.

Installs the kubernetes-sigs chart into kube-system. k3s signs kubelet serving certs with the cluster CA, so no `--kubelet-insecure-tls` is required. CNP grants the deployment apiserver + kubelet (host-entity) egress; ingress stays open since the aggregated-API calls arrive from the host-network apiserver.

Longhorn CPU/memory panels populate on the first collector pass after metrics-server reports Available; `kubectl top nodes/pods` starts working cluster-wide.