### PR TITLE
fix(monitoring): recategorize coredns and self-monitoring dashboards

### DIFF
--- a/generated/manifests/prod-axon/kube-prometheus-stack/ConfigMap-kube-prometheus-stack-alertmanager-overview.yaml
+++ b/generated/manifests/prod-axon/kube-prometheus-stack/ConfigMap-kube-prometheus-stack-alertmanager-overview.yaml
@@ -4,7 +4,7 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    grafana_folder: Kubernetes
+    grafana_folder: Monitoring
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack

--- a/generated/manifests/prod-axon/kube-prometheus-stack/ConfigMap-kube-prometheus-stack-grafana-overview.yaml
+++ b/generated/manifests/prod-axon/kube-prometheus-stack/ConfigMap-kube-prometheus-stack-grafana-overview.yaml
@@ -4,7 +4,7 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    grafana_folder: Kubernetes
+    grafana_folder: Monitoring
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack

--- a/generated/manifests/prod-axon/kube-prometheus-stack/ConfigMap-kube-prometheus-stack-k8s-coredns.yaml
+++ b/generated/manifests/prod-axon/kube-prometheus-stack/ConfigMap-kube-prometheus-stack-k8s-coredns.yaml
@@ -4,7 +4,7 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    grafana_folder: Kubernetes
+    grafana_folder: Networking
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack

--- a/generated/manifests/prod-axon/kube-prometheus-stack/ConfigMap-kube-prometheus-stack-prometheus.yaml
+++ b/generated/manifests/prod-axon/kube-prometheus-stack/ConfigMap-kube-prometheus-stack-prometheus.yaml
@@ -4,7 +4,7 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    grafana_folder: Kubernetes
+    grafana_folder: Monitoring
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack

--- a/modules/den/aspects/kubernetes/services/monitoring/prometheus.nix
+++ b/modules/den/aspects/kubernetes/services/monitoring/prometheus.nix
@@ -8,10 +8,35 @@
 {
   den.aspects.kubernetes.services.monitoring.prometheus = {
     k8s-manifests =
-      { charts, ... }:
+      { charts, lib, ... }:
       {
         applications.kube-prometheus-stack = {
           namespace = "monitoring";
+
+          # The chart annotates ALL of its dashboards into the Kubernetes
+          # folder (grafana.sidecar.dashboards.annotations is global); a few
+          # belong elsewhere.
+          objectTransforms = [
+            {
+              name = "dashboard-folder-overrides";
+              match.kind = "ConfigMap";
+              rewrite =
+                cm:
+                let
+                  folders = {
+                    "kube-prometheus-stack-k8s-coredns" = "Networking";
+                    "kube-prometheus-stack-alertmanager-overview" = "Monitoring";
+                    "kube-prometheus-stack-prometheus" = "Monitoring";
+                    "kube-prometheus-stack-grafana-overview" = "Monitoring";
+                  };
+                  folder = folders.${cm.metadata.name} or null;
+                in
+                if folder == null then
+                  cm
+                else
+                  lib.recursiveUpdate cm { metadata.annotations.grafana_folder = folder; };
+            }
+          ];
 
           # The prometheus-operator CRDs blow past the 256KiB annotation
           # limit under client-side apply.


### PR DESCRIPTION
The kps chart can only annotate its dashboard ConfigMaps globally, so #134 put all of them in the Kubernetes folder. A per-application objectTransform now reassigns the misfits: **coredns → Networking**, **alertmanager-overview / prometheus / grafana-overview → Monitoring** (the self-monitoring trio belongs with loki). Everything else in the kps set genuinely is Kubernetes-the-platform and stays put.