### PR TITLE
feat(monitoring): ship kubernetes events to loki

### DIFF
--- a/generated/manifests/prod-axon/alloy/CiliumNetworkPolicy-allow-alloy-kube-apiserver-egress.yaml
+++ b/generated/manifests/prod-axon/alloy/CiliumNetworkPolicy-allow-alloy-kube-apiserver-egress.yaml
@@ -13,4 +13,4 @@ spec:
               protocol: TCP
   endpointSelector:
     matchLabels:
-      app.kubernetes.io/instance: alloy
+      app.kubernetes.io/name: alloy

--- a/generated/manifests/prod-axon/alloy/ClusterRole-alloy-events.yaml
+++ b/generated/manifests/prod-axon/alloy/ClusterRole-alloy-events.yaml
@@ -1,0 +1,123 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/instance: alloy-events
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/part-of: alloy
+  name: alloy-events
+rules:
+  - apiGroups:
+      - ""
+      - discovery.k8s.io
+      - networking.k8s.io
+    resources:
+      - endpoints
+      - endpointslices
+      - ingresses
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - monitoring.grafana.com
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - alertmanagerconfigs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - podmonitors
+      - servicemonitors
+      - probes
+      - scrapeconfigs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+      - extensions
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/metrics
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get

--- a/generated/manifests/prod-axon/alloy/ClusterRoleBinding-alloy-events.yaml
+++ b/generated/manifests/prod-axon/alloy/ClusterRoleBinding-alloy-events.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/instance: alloy-events
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/part-of: alloy
+  name: alloy-events
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: alloy-events
+subjects:
+  - kind: ServiceAccount
+    name: alloy-events
+    namespace: monitoring

--- a/generated/manifests/prod-axon/alloy/ConfigMap-alloy-events.yaml
+++ b/generated/manifests/prod-axon/alloy/ConfigMap-alloy-events.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+data:
+  config.alloy: |-
+    loki.source.kubernetes_events "cluster_events" {
+      forward_to = [loki.write.loki.receiver]
+    }
+
+    loki.write "loki" {
+      endpoint {
+        url = "http://loki.monitoring.svc:3100/loki/api/v1/push"
+      }
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: config
+    app.kubernetes.io/instance: alloy-events
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/part-of: alloy
+  name: alloy-events
+  namespace: monitoring

--- a/generated/manifests/prod-axon/alloy/CustomResourceDefinition-podlogs-monitoring-grafana-com.yaml
+++ b/generated/manifests/prod-axon/alloy/CustomResourceDefinition-podlogs-monitoring-grafana-com.yaml
@@ -10,6 +10,8 @@ spec:
     categories:
       - grafana-alloy
       - alloy
+      - grafana-alloy
+      - alloy
     kind: PodLogs
     listKind: PodLogsList
     plural: podlogs

--- a/generated/manifests/prod-axon/alloy/Deployment-alloy-events.yaml
+++ b/generated/manifests/prod-axon/alloy/Deployment-alloy-events.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: alloy-events
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/part-of: alloy
+  name: alloy-events
+  namespace: monitoring
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: alloy-events
+      app.kubernetes.io/name: alloy
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: alloy
+      labels:
+        app.kubernetes.io/instance: alloy-events
+        app.kubernetes.io/name: alloy
+    spec:
+      containers:
+        - args:
+            - run
+            - /etc/alloy/config.alloy
+            - --storage.path=/tmp/alloy
+            - --server.http.listen-addr=0.0.0.0:12345
+            - --server.http.ui-path-prefix=/
+            - --stability.level=generally-available
+          env:
+            - name: ALLOY_DEPLOY_MODE
+              value: helm
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          image: docker.io/grafana/alloy:v1.16.3
+          imagePullPolicy: IfNotPresent
+          name: alloy
+          ports:
+            - containerPort: 12345
+              name: http-metrics
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 12345
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /etc/alloy
+              name: config
+        - args:
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0@sha256:7d9e4eea5f1139e602508871f422b0116c60e87c662f3dcd234d5ab60cd0d8c1
+          imagePullPolicy: IfNotPresent
+          name: config-reloader
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+          volumeMounts:
+            - mountPath: /etc/alloy
+              name: config
+      dnsPolicy: ClusterFirst
+      serviceAccountName: alloy-events
+      volumes:
+        - configMap:
+            name: alloy-events
+          name: config

--- a/generated/manifests/prod-axon/alloy/Service-alloy-events.yaml
+++ b/generated/manifests/prod-axon/alloy/Service-alloy-events.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/instance: alloy-events
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/part-of: alloy
+  name: alloy-events
+  namespace: monitoring
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: http-metrics
+      port: 12345
+      protocol: TCP
+      targetPort: 12345
+  selector:
+    app.kubernetes.io/instance: alloy-events
+    app.kubernetes.io/name: alloy
+  type: ClusterIP

--- a/generated/manifests/prod-axon/alloy/ServiceAccount-alloy-events.yaml
+++ b/generated/manifests/prod-axon/alloy/ServiceAccount-alloy-events.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/instance: alloy-events
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/part-of: alloy
+  name: alloy-events
+  namespace: monitoring

--- a/generated/manifests/prod-axon/alloy/ServiceMonitor-alloy-events.yaml
+++ b/generated/manifests/prod-axon/alloy/ServiceMonitor-alloy-events.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: alloy-events
+    app.kubernetes.io/name: alloy
+    app.kubernetes.io/part-of: alloy
+  name: alloy-events
+  namespace: monitoring
+spec:
+  endpoints:
+    - honorLabels: true
+      port: http-metrics
+      scheme: http
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: alloy-events
+      app.kubernetes.io/name: alloy

--- a/modules/den/aspects/kubernetes/services/monitoring/alloy.nix
+++ b/modules/den/aspects/kubernetes/services/monitoring/alloy.nix
@@ -1,8 +1,13 @@
-# Alloy — Grafana Alloy DaemonSet shipping pod logs to loki.
+# Alloy — Grafana Alloy shipping cluster logs to loki.
 #
-# Tails CRI logs from /var/log/pods on every node (filtered to the local
-# node via the kubernetes API) and pushes to the loki service. Positions
-# live on a hostPath so a pod restart doesn't re-ingest every log file.
+# Two releases of the same chart:
+#   - alloy: DaemonSet tailing CRI logs from /var/log/pods on every node
+#     (filtered to the local node via the kubernetes API). Positions live
+#     on a hostPath so a pod restart doesn't re-ingest every log file.
+#   - alloy-events: single-replica Deployment turning kubernetes events
+#     into loki streams. Deliberately NOT part of the DaemonSet — the
+#     kubernetes_events source is not replica-aware and a DS would ship
+#     every event once per node.
 {
   den.aspects.kubernetes.services.monitoring.alloy = {
     k8s-manifests =
@@ -10,6 +15,31 @@
       {
         applications.alloy = {
           namespace = "monitoring";
+
+          helm.releases.alloy-events = {
+            chart = charts.grafana.alloy;
+
+            values = {
+              serviceMonitor.enabled = true;
+
+              controller = {
+                type = "deployment";
+                replicas = 1;
+              };
+
+              alloy.configMap.content = ''
+                loki.source.kubernetes_events "cluster_events" {
+                  forward_to = [loki.write.loki.receiver]
+                }
+
+                loki.write "loki" {
+                  endpoint {
+                    url = "http://loki.monitoring.svc:3100/loki/api/v1/push"
+                  }
+                }
+              '';
+            };
+          };
 
           helm.releases.alloy = {
             chart = charts.grafana.alloy;
@@ -121,12 +151,13 @@
             };
           };
 
-          # Pod discovery (node-local filter) talks to the kube-apiserver;
-          # the loki push stays inside the cluster (allow-internal-egress).
+          # Pod discovery (node-local filter) and the events watch talk to
+          # the kube-apiserver; the loki push stays inside the cluster
+          # (allow-internal-egress). The name label covers both releases.
           resources.ciliumNetworkPolicies = {
             allow-alloy-kube-apiserver-egress = {
               spec = {
-                endpointSelector.matchLabels."app.kubernetes.io/instance" = "alloy";
+                endpointSelector.matchLabels."app.kubernetes.io/name" = "alloy";
                 egress = [
                   {
                     toEntities = [ "kube-apiserver" ];


### PR DESCRIPTION
Kubernetes events become queryable loki streams — the standard missing piece for incident timelines (pod kills, scheduling failures, volume attach errors, probe flaps all land in one queryable place with timestamps).

Implementation: a second release of the alloy chart inside the existing alloy application — a **single-replica Deployment** running `loki.source.kubernetes_events`. Deliberately not folded into the log-tailing DaemonSet: the events source is not replica-aware, so a DaemonSet would ship every event once per node (this is the same reason grafana's k8s-monitoring chart isolates event collection in its singleton). The chart's default RBAC already grants events get/list/watch; the apiserver-egress CNP selector widens from the instance label to the chart name label so it covers both releases.

Query surface: `{job="loki.source.kubernetes_events"}` with namespace labels per event.