### PR TITLE
feat(monitoring): pod-logs and kubernetes-events log browsers

### DIFF
--- a/generated/manifests/prod-axon/grafana/ConfigMap-dashboard-kubernetes-events.yaml
+++ b/generated/manifests/prod-axon/grafana/ConfigMap-dashboard-kubernetes-events.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  kubernetes-events.json: '{"editable":true,"panels":[{"datasource":{"type":"loki","uid":"loki"},"fieldConfig":{"defaults":{"custom":{"drawStyle":"bars","fillOpacity":50}}},"gridPos":{"h":6,"w":24,"x":0,"y":0},"options":{"legend":{"displayMode":"list"}},"targets":[{"datasource":{"type":"loki","uid":"loki"},"expr":"sum by (namespace) (count_over_time({job=\"loki.source.kubernetes_events\", namespace=~\"$namespace\"} |= `$search` [$__auto]))","legendFormat":"{{namespace}}","refId":"A"}],"title":"Log volume","type":"timeseries"},{"datasource":{"type":"loki","uid":"loki"},"gridPos":{"h":20,"w":24,"x":0,"y":6},"options":{"dedupStrategy":"none","enableLogDetails":true,"showTime":true,"sortOrder":"Descending","wrapLogMessage":true},"targets":[{"datasource":{"type":"loki","uid":"loki"},"expr":"{job=\"loki.source.kubernetes_events\", namespace=~\"$namespace\"} |= `$search`","refId":"A"}],"title":"Logs","type":"logs"}],"schemaVersion":39,"templating":{"list":[{"allValue":".+","current":{"selected":true,"text":["All"],"value":["$__all"]},"datasource":{"type":"loki","uid":"loki"},"includeAll":true,"multi":true,"name":"namespace","query":"label_values({job=\"loki.source.kubernetes_events\"}, namespace)","refresh":2,"type":"query"},{"current":{"text":"","value":""},"label":"search","name":"search","type":"textbox"}]},"time":{"from":"now-1h","to":"now"},"title":"Kubernetes Events","uid":"k8s-events","version":1}'
+kind: ConfigMap
+metadata:
+  annotations:
+    grafana_folder: Logs
+  labels:
+    grafana_dashboard: "1"
+  name: dashboard-kubernetes-events
+  namespace: monitoring

--- a/generated/manifests/prod-axon/grafana/ConfigMap-dashboard-pod-logs.yaml
+++ b/generated/manifests/prod-axon/grafana/ConfigMap-dashboard-pod-logs.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  pod-logs.json: '{"editable":true,"panels":[{"datasource":{"type":"loki","uid":"loki"},"fieldConfig":{"defaults":{"custom":{"drawStyle":"bars","fillOpacity":50}}},"gridPos":{"h":6,"w":24,"x":0,"y":0},"options":{"legend":{"displayMode":"list"}},"targets":[{"datasource":{"type":"loki","uid":"loki"},"expr":"sum by (pod) (count_over_time({namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\"} |= `$search` [$__auto]))","legendFormat":"{{pod}}","refId":"A"}],"title":"Log volume","type":"timeseries"},{"datasource":{"type":"loki","uid":"loki"},"gridPos":{"h":20,"w":24,"x":0,"y":6},"options":{"dedupStrategy":"none","enableLogDetails":true,"showTime":true,"sortOrder":"Descending","wrapLogMessage":true},"targets":[{"datasource":{"type":"loki","uid":"loki"},"expr":"{namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\"} |= `$search`","refId":"A"}],"title":"Logs","type":"logs"}],"schemaVersion":39,"templating":{"list":[{"allValue":".+","current":{"selected":true,"text":["All"],"value":["$__all"]},"datasource":{"type":"loki","uid":"loki"},"includeAll":true,"multi":true,"name":"namespace","query":"label_values(namespace)","refresh":2,"type":"query"},{"allValue":".+","current":{"selected":true,"text":["All"],"value":["$__all"]},"datasource":{"type":"loki","uid":"loki"},"includeAll":true,"multi":true,"name":"pod","query":"label_values({namespace=~\"$namespace\"}, pod)","refresh":2,"type":"query"},{"allValue":".+","current":{"selected":true,"text":["All"],"value":["$__all"]},"datasource":{"type":"loki","uid":"loki"},"includeAll":true,"multi":true,"name":"container","query":"label_values({namespace=~\"$namespace\", pod=~\"$pod\"}, container)","refresh":2,"type":"query"},{"current":{"text":"","value":""},"label":"search","name":"search","type":"textbox"}]},"time":{"from":"now-1h","to":"now"},"title":"Pod Logs","uid":"pod-logs","version":1}'
+kind: ConfigMap
+metadata:
+  annotations:
+    grafana_folder: Logs
+  labels:
+    grafana_dashboard: "1"
+  name: dashboard-pod-logs
+  namespace: monitoring

--- a/generated/manifests/prod-axon/grafana/ConfigMap-grafana.yaml
+++ b/generated/manifests/prod-axon/grafana/ConfigMap-grafana.yaml
@@ -7,10 +7,12 @@ data:
       isDefault: true
       name: Prometheus
       type: prometheus
+      uid: prometheus
       url: http://kube-prometheus-stack-prometheus.monitoring:9090
     - access: proxy
       name: Loki
       type: loki
+      uid: loki
       url: http://loki.monitoring:3100
   grafana.ini: |
     [analytics]

--- a/generated/manifests/prod-axon/grafana/Deployment-grafana.yaml
+++ b/generated/manifests/prod-axon/grafana/Deployment-grafana.yaml
@@ -18,9 +18,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ed04eece71a36e9b91be19e1cba7e2c6db3f172f620f9428308d4f739c9bdffc
+        checksum/config: 7f22e82e048fb9f3b2cff635bddd76c6d680f223ce75f4f95e18f4a89e7eb9a7
         checksum/sc-dashboard-provider-config: 81f722b8194d01e4a84ce12a0cbbe9b705b2d9145719c803ac264b4786c64a09
-        checksum/secret: ad8244c4cdaf669f140738cc295df8362ca6adbc68c8cb489d54de70b48b86b0
+        checksum/secret: a9fdfb1826216aa03fc9efa9356652c996fa78490f9c9683550caaedd270628a
         kubectl.kubernetes.io/default-container: grafana
       labels:
         app.kubernetes.io/instance: grafana

--- a/generated/manifests/prod-axon/grafana/SopsSecret-grafana.yaml
+++ b/generated/manifests/prod-axon/grafana/SopsSecret-grafana.yaml
@@ -8,12 +8,12 @@ metadata:
     name: grafana
     namespace: monitoring
     annotations:
-        secrets.json64.dev/plaintext-sha256: 39ac7fa21087d8c2b08b2c8b3b9cc99b950739113febcfd49c198fffd3a3c7f7
+        secrets.json64.dev/plaintext-sha256: f2d50aba3ec219e73f702cb7a5247fcf319570814870f6fd52bde4bf081f37c2
 spec:
     secretTemplates:
         - data:
-            admin-password: ENC[AES256_GCM,data:aPpBTnMl8tEC2Uimj1MSyNQgLMz8BAsP78VC5AxCyOEjUofu/5qSUU2OUV+JgEF/ZreDxwMHFnE=,iv:Z4VvBHym3hfKkepaiOP0f1QlIohjBru0YV6hZe/QC2w=,tag:fFdqtcoXjDwGOnYecfjrHw==,type:str]
-            admin-user: ENC[AES256_GCM,data:pQ5NidV0IYI=,iv:3akpYlOV01jYTaU3TbzaSP6h9A/NnTMjxauu4xxHLXI=,tag:JMELzpvSUlUyTF5HPDdCVg==,type:str]
+            admin-password: ENC[AES256_GCM,data:viZ5mziZwrRmEcsE4lW2uIAx+VTVnYoM7cMGz20OqSVGGDzJet20tmHeWoT46ZvTSwhObpuzE5o=,iv:MeLEIPW2k1cufhXNFGxW8sywZA9nrcvJkEbJpAnF/eA=,tag:wZz+GRoxG/K6Dyic0ggdHA==,type:str]
+            admin-user: ENC[AES256_GCM,data:JbRygiwCL74=,iv:oz6fM73eytSQS0ejqVFo1of3H2bep1L0b5X7gnc4X0Q=,tag:ZQTThY0P/fw4JG4lSDo1zg==,type:str]
             ldap-toml: ""
           name: grafana
           type: Opaque
@@ -21,14 +21,14 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQMDdGWll0dzQ0eE5FcURZ
-            N2pOdkpLVHN5WjJzUEJ3cEMxZGRuL2JwVmw0CnR0VHh4ZkY2T1NubEZScjBFVTl4
-            aWVLQW1ueDZBRThyeXlNSFdnWThBMGMKLS0tIFZCSGRiYWgvUE1EbGhTTk5leEpE
-            S0V6bGYzdE1PMDA3QzI0cjEwTStSL3cK7ZXgsMHGuptvUOpXMG8QFsl/DDlF9bO6
-            mM9xhEeYa7ghhGHWzl0XSDTX/o/u4rKdDtU3PjH9sPlo3f3tA8kaYg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5NGFUMldNTTV5WDh3YStm
+            WTB2WmE0dHpvdzQvTUc5WUE3c3JjTDRpazFNCkZTOEtQVWx4RExoRGN2Y28yejg4
+            WHFFaHhmZGpockhOb2dCSGtRVFFtNGsKLS0tIGNxMy9DNUNtbGl0T2lyemIzQkU0
+            WmcwSUljRkFZWTZTbUFIK3ZtWk0xc00K0+U35y6p6UFE3fyYafsp69cAkwL80+ls
+            nWXq3YD6R83lljk+k/lvqWuJ4v8I1lVAfm0/BKaBBJOiR/ujklVlKA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-06-12T21:45:22Z"
-    mac: ENC[AES256_GCM,data:JzGKC1cbT00kcmjUU/9D7BAHczK2MkOAHOFuwu+N7SJ0h7LsJmiTP5K+Qdmu7RTCDFwbIF6gf1TYaOmenveMDfv8PFztqSosjN6+7hxf09g7pu2gMMM9QalYHq4PAEngU/Xak05RoImRJzbkpvTrcgv+mkl1gwXEeoF2owLeNvI=,iv:5oDfW1VOKlvuK3ndAYPUGEWKl0uaTh5ExnMnMe3quFo=,tag:Y8yZtM2XP3sztNNj0aYh6Q==,type:str]
+    lastmodified: "2026-06-12T22:18:39Z"
+    mac: ENC[AES256_GCM,data:H4Xx04gmEz32d8zBY8a3hc+5ZAtsnwfjEXgaIuoX3sV2rfkS8ctPwXuAhJ88YL86W0JjCmpgWBCmYlum4IMwkZv2zwfYWfBT0o30wtNPOcy0tLlRh6b6MGbob6Zc/9xCzzFR+fI7I/vqA1seQ7+fpDMoUIho5Mj7Q1BvdF0K0f4=,iv:D4krXjnXNGJD9ZJy2jnRCfApvaMj6s7d0yYoMcRCPjA=,tag:F2bbRdbHWvyzM7QLmP3Rjg==,type:str]
     version: 3.13.1

--- a/modules/den/aspects/kubernetes/services/monitoring/grafana.nix
+++ b/modules/den/aspects/kubernetes/services/monitoring/grafana.nix
@@ -74,6 +74,140 @@ in
           name:
           "https://raw.githubusercontent.com/envoyproxy/gateway/v1.8.1/charts/gateway-addons-helm/dashboards/${name}.json";
 
+        # Log-browsing dashboards authored here (community ones key off a
+        # job-based label schema; ours is namespace/pod/container). Stable
+        # uids give stable URLs; the loki datasource uid is pinned above.
+        lokiDs = {
+          type = "loki";
+          uid = "loki";
+        };
+
+        mkLabelVar = name: query: {
+          inherit name;
+          type = "query";
+          datasource = lokiDs;
+          inherit query;
+          refresh = 2;
+          includeAll = true;
+          multi = true;
+          allValue = ".+";
+          current = {
+            selected = true;
+            text = [ "All" ];
+            value = [ "$__all" ];
+          };
+        };
+
+        searchVar = {
+          name = "search";
+          type = "textbox";
+          label = "search";
+          current = {
+            text = "";
+            value = "";
+          };
+        };
+
+        mkLogsDashboard =
+          {
+            uid,
+            title,
+            variables,
+            selector,
+            volumeBy,
+          }:
+          {
+            inherit uid title;
+            schemaVersion = 39;
+            version = 1;
+            editable = true;
+            time = {
+              from = "now-1h";
+              to = "now";
+            };
+            templating.list = variables ++ [ searchVar ];
+            panels = [
+              {
+                title = "Log volume";
+                type = "timeseries";
+                datasource = lokiDs;
+                gridPos = {
+                  h = 6;
+                  w = 24;
+                  x = 0;
+                  y = 0;
+                };
+                options.legend.displayMode = "list";
+                fieldConfig.defaults.custom = {
+                  drawStyle = "bars";
+                  fillOpacity = 50;
+                };
+                targets = [
+                  {
+                    refId = "A";
+                    datasource = lokiDs;
+                    expr = "sum by (${volumeBy}) (count_over_time(${selector} |= `$search` [$__auto]))";
+                    legendFormat = "{{${volumeBy}}}";
+                  }
+                ];
+              }
+              {
+                title = "Logs";
+                type = "logs";
+                datasource = lokiDs;
+                gridPos = {
+                  h = 20;
+                  w = 24;
+                  x = 0;
+                  y = 6;
+                };
+                options = {
+                  showTime = true;
+                  wrapLogMessage = true;
+                  enableLogDetails = true;
+                  sortOrder = "Descending";
+                  dedupStrategy = "none";
+                };
+                targets = [
+                  {
+                    refId = "A";
+                    datasource = lokiDs;
+                    expr = "${selector} |= `$search`";
+                  }
+                ];
+              }
+            ];
+          };
+
+        localDashboards = {
+          pod-logs = {
+            folder = "Logs";
+            dashboard = mkLogsDashboard {
+              uid = "pod-logs";
+              title = "Pod Logs";
+              variables = [
+                (mkLabelVar "namespace" "label_values(namespace)")
+                (mkLabelVar "pod" "label_values({namespace=~\"$namespace\"}, pod)")
+                (mkLabelVar "container" "label_values({namespace=~\"$namespace\", pod=~\"$pod\"}, container)")
+              ];
+              selector = "{namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\"}";
+              volumeBy = "pod";
+            };
+          };
+          kubernetes-events = {
+            folder = "Logs";
+            dashboard = mkLogsDashboard {
+              uid = "k8s-events";
+              title = "Kubernetes Events";
+              variables = [
+                (mkLabelVar "namespace" "label_values({job=\"loki.source.kubernetes_events\"}, namespace)")
+              ];
+              selector = "{job=\"loki.source.kubernetes_events\", namespace=~\"$namespace\"}";
+              volumeBy = "namespace";
+            };
+          };
+        };
+
         importedDashboards = {
           argocd = {
             title = "ArgoCD";
@@ -178,6 +312,7 @@ in
                 datasources = [
                   {
                     name = "Prometheus";
+                    uid = "prometheus";
                     type = "prometheus";
                     access = "proxy";
                     url = "http://kube-prometheus-stack-prometheus.monitoring:9090";
@@ -185,6 +320,7 @@ in
                   }
                   {
                     name = "Loki";
+                    uid = "loki";
                     type = "loki";
                     access = "proxy";
                     url = "http://loki.monitoring:3100";
@@ -258,7 +394,17 @@ in
                   fixDatasource = d.fixDatasource or false;
                 };
               }
-            ) importedDashboards;
+            ) importedDashboards
+            // lib.mapAttrs' (
+              name: d:
+              lib.nameValuePair "dashboard-${name}" {
+                metadata = {
+                  labels.grafana_dashboard = "1";
+                  annotations.grafana_folder = d.folder;
+                };
+                data."${name}.json" = builtins.toJSON d.dashboard;
+              }
+            ) localDashboards;
 
             httpRoutes.grafana.spec = {
               parentRefs = [


### PR DESCRIPTION
Log *viewing* dashboards — everything so far was loki self-monitoring, and Explore is the only way to read logs.

Two dashboards authored in-repo rather than imported: the canonical community log browsers (e.g. gnetId 13639) select on a `job`-based label schema that does not match ours (`namespace`/`pod`/`container`/`app` from the alloy pipeline).

- **Pod Logs** (`/d/pod-logs`): cascading namespace → pod → container variables (loki `label_values` queries, multi + All), free-text search box (`|= \\`$search\\``), log-volume bar graph by pod, full logs panel.
- **Kubernetes Events** (`/d/k8s-events`): namespace variable + search over the `loki.source.kubernetes_events` stream, volume by namespace.

Both land in a new **Logs** folder. Datasources get pinned uids (`prometheus`, `loki`) so dashboard references are deterministic — provisioning reconciles the uid on the existing entries at rollout.