### PR TITLE
fix(monitoring): migrate datasources to the pinned uids

### DIFF
--- a/generated/manifests/prod-axon/grafana/ConfigMap-grafana.yaml
+++ b/generated/manifests/prod-axon/grafana/ConfigMap-grafana.yaml
@@ -14,6 +14,11 @@ data:
       type: loki
       uid: loki
       url: http://loki.monitoring:3100
+    deleteDatasources:
+    - name: Prometheus
+      orgId: 1
+    - name: Loki
+      orgId: 1
   grafana.ini: |
     [analytics]
     check_for_updates = false

--- a/generated/manifests/prod-axon/grafana/Deployment-grafana.yaml
+++ b/generated/manifests/prod-axon/grafana/Deployment-grafana.yaml
@@ -18,9 +18,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7f22e82e048fb9f3b2cff635bddd76c6d680f223ce75f4f95e18f4a89e7eb9a7
+        checksum/config: 0f476b33e845a728a5842c4e8f6e98b80fc29563b8795f9bca8a9d18fdf46f3d
         checksum/sc-dashboard-provider-config: 81f722b8194d01e4a84ce12a0cbbe9b705b2d9145719c803ac264b4786c64a09
-        checksum/secret: a9fdfb1826216aa03fc9efa9356652c996fa78490f9c9683550caaedd270628a
+        checksum/secret: f3cdb5f6ba2b024ef5400c909ccd80e5eb9f7c075477d581e1b1ccc8ae887cc3
         kubectl.kubernetes.io/default-container: grafana
       labels:
         app.kubernetes.io/instance: grafana

--- a/generated/manifests/prod-axon/grafana/SopsSecret-grafana.yaml
+++ b/generated/manifests/prod-axon/grafana/SopsSecret-grafana.yaml
@@ -8,12 +8,12 @@ metadata:
     name: grafana
     namespace: monitoring
     annotations:
-        secrets.json64.dev/plaintext-sha256: f2d50aba3ec219e73f702cb7a5247fcf319570814870f6fd52bde4bf081f37c2
+        secrets.json64.dev/plaintext-sha256: cedd0366b138d50a2c3b8fb074721a09f1edc25c7add991f2afe6a81627f7cec
 spec:
     secretTemplates:
         - data:
-            admin-password: ENC[AES256_GCM,data:viZ5mziZwrRmEcsE4lW2uIAx+VTVnYoM7cMGz20OqSVGGDzJet20tmHeWoT46ZvTSwhObpuzE5o=,iv:MeLEIPW2k1cufhXNFGxW8sywZA9nrcvJkEbJpAnF/eA=,tag:wZz+GRoxG/K6Dyic0ggdHA==,type:str]
-            admin-user: ENC[AES256_GCM,data:JbRygiwCL74=,iv:oz6fM73eytSQS0ejqVFo1of3H2bep1L0b5X7gnc4X0Q=,tag:ZQTThY0P/fw4JG4lSDo1zg==,type:str]
+            admin-password: ENC[AES256_GCM,data:x4wOZtjrbk/9MC94kGFSeb/zlii1eWHMqygPqhfq0dWUKPH7t+DPtmEyVi3dKZpU4FGI6vmUmWQ=,iv:RFPQHJBP01+ipQCuE16HfPnf98NULgSi1xhxjMLX0EU=,tag:zW5YumTgrkxgDrr+wBcXHw==,type:str]
+            admin-user: ENC[AES256_GCM,data:0vOpgQZQKg0=,iv:mQ/hTRI0JRGDfEjzC5JEPvKycD8qWcNPbhYTMYThR78=,tag:26f5oOBENaQl72WBA6o+Kg==,type:str]
             ldap-toml: ""
           name: grafana
           type: Opaque
@@ -21,14 +21,14 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5NGFUMldNTTV5WDh3YStm
-            WTB2WmE0dHpvdzQvTUc5WUE3c3JjTDRpazFNCkZTOEtQVWx4RExoRGN2Y28yejg4
-            WHFFaHhmZGpockhOb2dCSGtRVFFtNGsKLS0tIGNxMy9DNUNtbGl0T2lyemIzQkU0
-            WmcwSUljRkFZWTZTbUFIK3ZtWk0xc00K0+U35y6p6UFE3fyYafsp69cAkwL80+ls
-            nWXq3YD6R83lljk+k/lvqWuJ4v8I1lVAfm0/BKaBBJOiR/ujklVlKA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6YnY4VFo0Z2JkZEVKZkpS
+            UnBXQk5lOGpQY2xRMndyMjIrWWVrcGNuYlhrCnBFV0xVb1B5N2RmRTBlN0x6RzB6
+            M2lCc3BJckR4bkFRa2I2Z3crRnZmdU0KLS0tIGI2Z3pYSTYxS3B1elRYWmVNWEJP
+            WWoyRmdpRlo1ZWN5NjRCdGFHUHlIR1EK2cPBJjikTH1pqcYa4NlQHrhYWAmxQipI
+            jNgsunImTqVivg37EtpPigoFdWjroWq+3meb652vH10NDAljoZSSDw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-06-12T22:18:39Z"
-    mac: ENC[AES256_GCM,data:H4Xx04gmEz32d8zBY8a3hc+5ZAtsnwfjEXgaIuoX3sV2rfkS8ctPwXuAhJ88YL86W0JjCmpgWBCmYlum4IMwkZv2zwfYWfBT0o30wtNPOcy0tLlRh6b6MGbob6Zc/9xCzzFR+fI7I/vqA1seQ7+fpDMoUIho5Mj7Q1BvdF0K0f4=,iv:D4krXjnXNGJD9ZJy2jnRCfApvaMj6s7d0yYoMcRCPjA=,tag:F2bbRdbHWvyzM7QLmP3Rjg==,type:str]
+    lastmodified: "2026-06-12T22:29:12Z"
+    mac: ENC[AES256_GCM,data:+UNNkpPYE3KZsd9ijbPq6PUziQR2GWvZ4ciCflwAItPg/WJPQ6M0Rtw4up12mrStjTMfKTple890e7UCP+CvVxiCPoy5qrWHKZu3vh5Mi2FpjVyT4kPmi6ZGsGcorDRGPVyqqjBKJK+iZWEaCjdjjuVJqEPosZzK6ClKjLsGtFo=,iv:zGpLl1cgphndDomOYCqF2+AVfxEGetGGgSVEppyvhqs=,tag:8zzBw6iVyiRevTg4GojVlg==,type:str]
     version: 3.13.1

--- a/modules/den/aspects/kubernetes/services/monitoring/grafana.nix
+++ b/modules/den/aspects/kubernetes/services/monitoring/grafana.nix
@@ -309,6 +309,21 @@ in
 
               datasources."datasources.yaml" = {
                 apiVersion = 1;
+                # The original records were created without explicit uids;
+                # provisioning matches BY uid once one is specified and
+                # hard-fails on the lookup miss. Deleting by name first makes
+                # the pinned-uid recreate idempotent (provisioned datasources
+                # carry no state worth keeping).
+                deleteDatasources = [
+                  {
+                    name = "Prometheus";
+                    orgId = 1;
+                  }
+                  {
+                    name = "Loki";
+                    orgId = 1;
+                  }
+                ];
                 datasources = [
                   {
                     name = "Prometheus";
@@ -381,30 +396,31 @@ in
           };
 
           resources = {
-            configMaps = lib.mapAttrs' (
-              name: d:
-              lib.nameValuePair "dashboard-${name}" {
-                metadata = {
-                  labels.grafana_dashboard = "1";
-                  annotations.grafana_folder = d.folder;
-                };
-                data."${name}.json" = mkDashboardJson {
-                  inherit name;
-                  inherit (d) title url sha256;
-                  fixDatasource = d.fixDatasource or false;
-                };
-              }
-            ) importedDashboards
-            // lib.mapAttrs' (
-              name: d:
-              lib.nameValuePair "dashboard-${name}" {
-                metadata = {
-                  labels.grafana_dashboard = "1";
-                  annotations.grafana_folder = d.folder;
-                };
-                data."${name}.json" = builtins.toJSON d.dashboard;
-              }
-            ) localDashboards;
+            configMaps =
+              lib.mapAttrs' (
+                name: d:
+                lib.nameValuePair "dashboard-${name}" {
+                  metadata = {
+                    labels.grafana_dashboard = "1";
+                    annotations.grafana_folder = d.folder;
+                  };
+                  data."${name}.json" = mkDashboardJson {
+                    inherit name;
+                    inherit (d) title url sha256;
+                    fixDatasource = d.fixDatasource or false;
+                  };
+                }
+              ) importedDashboards
+              // lib.mapAttrs' (
+                name: d:
+                lib.nameValuePair "dashboard-${name}" {
+                  metadata = {
+                    labels.grafana_dashboard = "1";
+                    annotations.grafana_folder = d.folder;
+                  };
+                  data."${name}.json" = builtins.toJSON d.dashboard;
+                }
+              ) localDashboards;
 
             httpRoutes.grafana.spec = {
               parentRefs = [


### PR DESCRIPTION
The #138 rollout crash-looped: grafana's datasource provisioner matches **by uid** once one is declared in the YAML, and hard-fails the provisioning service when the lookup misses — the live records predate the pinning and carry auto-generated uids. RollingUpdate kept the old pod serving, which is why the new Logs dashboards appeared (sidecar reads ConfigMaps live) but pointed at a `loki` uid that does not exist yet → exclamation icon, no data.

`deleteDatasources` (by name) ahead of the datasource list makes the pinned-uid recreate idempotent; provisioned datasources hold no state worth preserving.