### PR TITLE
feat(monitoring): passwordless grafana, full host-config parity

### DIFF
--- a/.secrets/clusters/axon/sops/grafana-k8s.enc.yaml
+++ b/.secrets/clusters/axon/sops/grafana-k8s.enc.yaml
@@ -1,17 +1,18 @@
-admin-password: ENC[AES256_GCM,data:neY7LXyXWWGy4QJbRGS7CRbULDXYIUnAWV7OrA0LiYlt4LJmTs9U/yNutvlcN/kKiWFdUfu+R/A94S5sdPRWff1QqQyr6gjf,iv:JyNKYAVkoAnAMR9/GnTtHTBS7TbjU9z9wdmi365XcFA=,tag:LLzwB/u2rjG8uvWbWYI3rg==,type:str]
+admin-password: ENC[AES256_GCM,data:trNVgXGo/CD8QGb3J9n5f+35Zwc9Yet6sa2JyrVlUrp4yA6HkfnN/+8pGvpeiRv2iwTJJxxPcT1rJD1bjDjxaXvbCO3TGTgi,iv:4JEcfE1wLA5qyo39iF27qADiqeUvzsEuOA4YO6BZJ6w=,tag:MNTIv5PZrf0SGTO1bUuLrA==,type:str]
+secret-key: ENC[AES256_GCM,data:zDJbUKAx/euHfWhhiT7w1vl92RLlb5mgfjd5HfrrH14OGTAyNKY/MiB8rPYTF8/LGWCxT7/kur+JlsbwUihkfw==,iv:Ulhu8KiTGONdtOktlRhYf1tyvKIci06FjRznVNhuLfI=,tag:01kvw6NB7iJqlKKDEQuV0w==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHBpdi1wMjU2IElYZUZuUSBBdDJHSHlk
-            aHQ0Y1ZJd2l2R1A3MXFDOXRaUEhkZ1lSV1JuQmZzc2dqWUViegpwbGNMV0xQMmdU
-            T2xSQWxFeGFGOXNuQTZ3dy9TNVRSWFhVM0g3ZVBKMkhBCi0tLSBUeVpJY0xuTGRq
-            SzhHSDZTV0psUStCTklHclorblpuL2QwTC9mVFJlNUVZCmCtpK6fc2rd0ETlp1iN
-            Fp6rPmSyK/QvgZBZS/Nyt+RignNivOgQ4W2/2n0nK039dtGbsS8d+ASeA1WButQe
-            Z0Y=
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHBpdi1wMjU2IElYZUZuUSBBeC96TzlG
+            YXI1VmVLYUN6YjlpRHhvUU1Ra1NEdWF4MDhuQ0pYUmRoTWpnOQo1Wmg5WVJZRzVF
+            NXJnblNTanJhY25EZi9LWGkzSVo0VGFhWndGWFZTTFZFCi0tLSBGNGluZzRvZGNq
+            cHZvKytVZFRPcHlVTnh6M3pLbXY0aGZOckE4N1cxSWhNCq9wTtASK6R4BDW7MAJv
+            31gI/VeCXzoly9j6M8zvEznRP2H+C2gk117Jv33Z1La/SrQZ8Z9dJfvrG3/kvsQ6
+            kgo=
             -----END AGE ENCRYPTED FILE-----
           recipient: age1yubikey1qwq4shht6jmgpdma3t0nkueqz2w2vfmtgq4jnj06rdtcjr2chlhexm4lpl0
-    lastmodified: "2026-06-12T22:39:03Z"
-    mac: ENC[AES256_GCM,data:39b/5NlnllwVwtFrXrKp8zIk46TsnR2mbFxKJugS+dKQ35R9yHnvQEwxI00kjKi+vKZWzrLdDsfJ6UX/QK4zM8L9PyoZovT4t7umKfvJ7R8ulz/zy8M6OplBiC/WvPx83OKEue/X1xJmIxZVkv+vGCDEEhp140WJQHBZtI7eAa4=,iv:AKM2OP2aV3Wn042tacvaMN1uOPYAr0Z8LYfSB5YNt+s=,tag:puZQijpvlVYcNlCsNX4Cwg==,type:str]
+    lastmodified: "2026-06-12T22:57:51Z"
+    mac: ENC[AES256_GCM,data:wUsP9C6SwELaGlhNLhxRD6Xewzbd4doxC4sp8di6Y4G0qAoeugJeP3k/G0DWEGVnDm2bhnj3/Y60htxTnL7HlkBKT78ygaXaKw82oZjzX7gGXDjhiwymT+yBKo/buveouIPIBRSb9lIWM1SDQIMg7SyFMGEV+N9vPOgnwFUDq0o=,iv:YtXqrpV4cNpOfD6dWK2x/DGqN4a/GnYCJ0ufEen1xg8=,tag:pq5u6tzftLLwVW2YxDIQBA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.1

--- a/.secrets/env/prod/grafana-k8s/secret-key.age
+++ b/.secrets/env/prod/grafana-k8s/secret-key.age
@@ -1,0 +1,11 @@
+age-encryption.org/v1
+-> piv-p256 IXeFnQ AhDlDavSr8YcEgTp0QLTf/oHYPkoscAYMlnfluzmS4Ib
+MApP+/zLdAxNxQPNwbEXGKSmNHa7RHQ5gJrQ8byHhPU
+-> piv-p256 IXeFnQ A5DLmVZ5l5tZgjgdMdfrlLB03Qfy4lDkIV5takW/WVdJ
+On5hznfJG3rfndR0mBPpPOAGDQ/VKPhbzXqTPUjnGJY
+-> piv-p256 IXeFnQ A5vr3uJMYuCd0QF22Ss8oMrswhPSAWm6wbn3EDyYbIz0
+0+DzaTBJUWEi5Z4DkqEd5cwyY/GBe4c8mH0OdPxfN5s
+-> 4>B*Xq-grease )9Kh#%s
+vQkZgGuwAo5L1/fPeQ
+--- ULVCl5rvuiVcvTm2g8WB0nRVt7v3LnWRmpVXeYgg+i8
+‡Z¹ÓBím®€Û_Ÿú39ó°ö÷Ùƒ[¿Şo¦éÜ„KÄ‡X"Õ@E_ğ†	ÆT¦8¥Me‚ âx*9{\W Z«¸t ñšã@bÑz.JPÃM˜İµ" me<¼$Æ%øoå/

--- a/generated/manifests/prod-axon/grafana/ConfigMap-grafana.yaml
+++ b/generated/manifests/prod-axon/grafana/ConfigMap-grafana.yaml
@@ -5,11 +5,16 @@ data:
     datasources:
     - access: proxy
       isDefault: true
+      jsonData:
+        httpMethod: POST
+        timeInterval: 30s
       name: Prometheus
       type: prometheus
       uid: prometheus
       url: http://kube-prometheus-stack-prometheus.monitoring:9090
     - access: proxy
+      jsonData:
+        maxLines: 1000
       name: Loki
       type: loki
       uid: loki
@@ -23,6 +28,8 @@ data:
     [analytics]
     check_for_updates = false
     reporting_enabled = false
+    [auth]
+    oauth_auto_login = true
     [auth.generic_oauth]
     allow_assign_grafana_admin = true
     allow_sign_up = true
@@ -54,13 +61,20 @@ data:
     logs = /var/log/grafana
     plugins = /var/lib/grafana/plugins
     provisioning = /etc/grafana/provisioning
+    [security]
+    cookie_secure = true
+    disable_gravatar = true
+    disable_initial_admin_creation = true
+    hide_version = true
     [server]
     domain = grafana-k8s.json64.dev
+    enforce_domain = false
     root_url = https://grafana-k8s.json64.dev
     [unified_storage]
     index_path = /var/lib/grafana-search/bleve
     [users]
     allow_sign_up = false
+    auto_assign_org = true
     auto_assign_org_role = Viewer
 kind: ConfigMap
 metadata:

--- a/generated/manifests/prod-axon/grafana/Deployment-grafana.yaml
+++ b/generated/manifests/prod-axon/grafana/Deployment-grafana.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0f476b33e845a728a5842c4e8f6e98b80fc29563b8795f9bca8a9d18fdf46f3d
+        checksum/config: 32d5992f588ae3888375925e954c33c154a6afb36b7ed45c1c71bb4833395790
         checksum/sc-dashboard-provider-config: 81f722b8194d01e4a84ce12a0cbbe9b705b2d9145719c803ac264b4786c64a09
         kubectl.kubernetes.io/default-container: grafana
       labels:
@@ -40,20 +40,6 @@ spec:
               value: monitoring
             - name: FOLDER_ANNOTATION
               value: grafana_folder
-            - name: REQ_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  key: admin-user
-                  name: grafana-k8s-admin
-            - name: REQ_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  key: admin-password
-                  name: grafana-k8s-admin
-            - name: REQ_URL
-              value: http://localhost:3000/api/admin/provisioning/dashboards/reload
-            - name: REQ_METHOD
-              value: POST
           image: quay.io/kiwigrid/k8s-sidecar:2.5.0
           imagePullPolicy: IfNotPresent
           name: grafana-sc-dashboard
@@ -102,6 +88,11 @@ spec:
                 secretKeyRef:
                   key: password
                   name: monitoring-pg-grafana-password
+            - name: GF_SECURITY_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: secret-key
+                  name: grafana-k8s-secret-key
           image: docker.io/grafana/grafana:12.3.1
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/generated/manifests/prod-axon/grafana/SopsSecret-grafana-k8s-secret-key.yaml
+++ b/generated/manifests/prod-axon/grafana/SopsSecret-grafana-k8s-secret-key.yaml
@@ -1,0 +1,28 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: grafana-k8s-secret-key
+    namespace: monitoring
+    annotations:
+        secrets.json64.dev/plaintext-sha256: 64002e2dda8ea3681adb720762689c7386138de86dee66b06368b8a29d77d1ad
+spec:
+    secretTemplates:
+        - name: grafana-k8s-secret-key
+          stringData:
+            secret-key: ENC[AES256_GCM,data:EfW6NDyayeDj3dCAQjmmvCVZqRlwmAksKuCyzCmIgcwWysTmuGsM9tuXy35C11X1o15P9afAPvI9dCPNHW1/MQ==,iv:FKR4wa845MdGpJkMRikyrqNImKD85TB8yayEeid4Ed8=,tag:ZzSG65L4Oq6YmeeQMc+6SA==,type:str]
+          type: Opaque
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5VGtQeFVEd3ZlSnI4RFpm
+            VUpjSmdMOWJCRHpnK0w3c2ZNUGc0VENZVVI4CnlwVzl0QW9xdE1vbFpOQ3JUR0FG
+            b3htVnl4VnFRb2lWZUJQN01YRXBhOTAKLS0tIHhMOHNLbXArdnZuTE9WSk5WSDFl
+            Wjl4c2UvSmVMY1FKSlVMUmthNlNESDgKIOnI+E7IykTVtmxZPSE/37zwwX59aaXG
+            ahsyS67wW143pWwbi34ddKVE7jPPjyVARy6gc9acB/kUxsf8fgCq2g==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1702hgudfz8y5ms3m4fukvvjhll7w9yeqk4tahewuv34t09rhd9sq756enl
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-12T22:59:05Z"
+    mac: ENC[AES256_GCM,data:dEPCK0Sm888DQ7UB00+XuhovmRiSNjUYIQhirLYnBaDoasyCZk2mP7Hdn6A9Rs0rUMgJn86jeDzO7o39J0p/YWsKZG7irnJkH2vualaTNtrU6nVYxAfGFaw6K3Ej9lc6KTv9VUctdL8vWR03eMIQZlQIK3TKEosJDiQrDppU2O4=,iv:CGcpOVwfSANcn9MkJHM4a8OtlkQJL+cvCPSV1Yekaf0=,tag:4RbgGMPvYX8maNFa5A121A==,type:str]
+    version: 3.13.1

--- a/modules/den/aspects/kubernetes/services/monitoring/grafana.nix
+++ b/modules/den/aspects/kubernetes/services/monitoring/grafana.nix
@@ -302,6 +302,9 @@ in
                 searchNamespace = "monitoring";
                 folderAnnotation = "grafana_folder";
                 provider.foldersFromFilesStructure = true;
+                # No credentialed reload POSTs — there is no password-bearing
+                # account to authenticate them; the file provider polls.
+                skipReload = true;
               };
 
               # Secrets land as env vars (GF_ vars override grafana.ini),
@@ -314,6 +317,10 @@ in
                 GF_DATABASE_PASSWORD.secretKeyRef = {
                   name = "monitoring-pg-grafana-password";
                   key = "password";
+                };
+                GF_SECURITY_SECRET_KEY.secretKeyRef = {
+                  name = "grafana-k8s-secret-key";
+                  key = "secret-key";
                 };
               };
 
@@ -342,6 +349,12 @@ in
                     access = "proxy";
                     url = "http://kube-prometheus-stack-prometheus.monitoring:9090";
                     isDefault = true;
+                    jsonData = {
+                      # min step = the kps scrape interval (the host instance
+                      # uses 5s to match its own scraper)
+                      timeInterval = "30s";
+                      httpMethod = "POST";
+                    };
                   }
                   {
                     name = "Loki";
@@ -349,6 +362,9 @@ in
                     type = "loki";
                     access = "proxy";
                     url = "http://loki.monitoring:3100";
+                    jsonData = {
+                      maxLines = 1000;
+                    };
                   }
                 ];
               };
@@ -357,6 +373,20 @@ in
                 server = {
                   inherit domain;
                   root_url = "https://${domain}";
+                  enforce_domain = false;
+                };
+
+                # Passwordless, mirroring the host-level grafana: no admin
+                # user is ever created, so the login form stays harmless and
+                # kanidm is the only authority (server-admins map to
+                # GrafanaAdmin). secret_key is pinned via env above — the
+                # stateless pod must not sign cookies with the shipped
+                # default.
+                security = {
+                  disable_initial_admin_creation = true;
+                  cookie_secure = true;
+                  disable_gravatar = true;
+                  hide_version = true;
                 };
 
                 # Backing store in monitoring-pg (password via
@@ -377,8 +407,11 @@ in
 
                 users = {
                   allow_sign_up = false;
+                  auto_assign_org = true;
                   auto_assign_org_role = "Viewer";
                 };
+
+                auth.oauth_auto_login = true;
 
                 # Mirrors the host-level grafana OIDC config (same kanidm
                 # ACL groups: grafana.{editors,admins,server-admins}).
@@ -466,6 +499,11 @@ in
                   admin-password = config.age.secrets.grafana-k8s-admin-password.sopsRef;
                 };
               };
+
+              grafana-k8s-secret-key = {
+                type = "Opaque";
+                stringData.secret-key = config.age.secrets.grafana-k8s-secret-key.sopsRef;
+              };
             };
 
             ciliumNetworkPolicies = {
@@ -534,12 +572,26 @@ in
           };
         };
 
+        # The admin secret stays pinned but is inert: with
+        # disable_initial_admin_creation no account exists to use it, and
+        # removing it would regress the chart to render-time random
+        # passwords (diff churn).
         age.secrets.grafana-k8s-admin-password = {
           rekeyFile = env.secretPath + "/grafana-k8s/admin-password.age";
           generator.script = "rfc3986-secret";
           sopsOutput = {
             file = "grafana-k8s";
             key = "admin-password";
+          };
+        };
+
+        age.secrets.grafana-k8s-secret-key = {
+          rekeyFile = env.secretPath + "/grafana-k8s/secret-key.age";
+          settings.length = "32";
+          generator.script = "hex";
+          sopsOutput = {
+            file = "grafana-k8s";
+            key = "secret-key";
           };
         };
       };


### PR DESCRIPTION
Removes password authentication from the cluster grafana by mirroring the host instance's posture — the mechanism is `disable_initial_admin_creation`: no password-bearing account ever exists, so the login form is harmless and kanidm (same group→role mapping, `server-admins` → GrafanaAdmin) is the only authority.

Also ported for parity: `security.{cookie_secure,disable_gravatar,hide_version}`, `users.auto_assign_org`, `auth.oauth_auto_login`, `server.enforce_domain`, datasource `jsonData` (POST + min-step matched to the kps scrape interval, loki maxLines), and a sops-pinned 32-byte-hex cookie signing key (`GF_SECURITY_SECRET_KEY`) — the stateless pod was signing cookies with grafana's publicly-known default on every restart.

K8s-specific: the dashboard sidecar sets `skipReload` (its reload POSTs have nothing to authenticate as; the file provider polls), and the pinned admin secret remains as an inert anti-churn measure (without `admin.existingSecret` the chart regresses to render-time random passwords).

Post-rollout one-time step: delete the legacy `admin` row (predates `disable_initial_admin_creation`); fresh installs never create it.