### PR TITLE
feat(media): TRaSH quality profiles via configarr

### DIFF
--- a/generated/manifests/prod-axon/configarr/ConfigMap-configarr.yaml
+++ b/generated/manifests/prod-axon/configarr/ConfigMap-configarr.yaml
@@ -9,10 +9,21 @@ data:
       series:
         base_url: http://sonarr:8989
         api_key: !env SONARR_API_KEY
+        # Instance-global file-size boundaries stay on the `series` set (the
+        # TRaSH guidance for mixed regular+anime single instances).
         quality_definition:
           type: series
         include:
           - template: sonarr-quality-definition-series
+          # WEB-1080p and WEB-2160p lanes — assign per series.
+          - template: sonarr-v4-quality-profile-web-1080p
+          - template: sonarr-v4-custom-formats-web-1080p
+          - template: sonarr-v4-quality-profile-web-2160p
+          - template: sonarr-v4-custom-formats-web-2160p
+          # Anime lane in the same instance (sonarr v4 custom formats are
+          # profile-scoped; series get Series Type: Anime + this profile).
+          - template: sonarr-v4-quality-profile-anime
+          - template: sonarr-v4-custom-formats-anime
 
     radarr:
       movies:
@@ -22,6 +33,11 @@ data:
           type: movie
         include:
           - template: radarr-quality-definition-movie
+          # HD Bluray+WEB (default lane) and UHD Bluray+WEB — assign per movie.
+          - template: radarr-quality-profile-hd-bluray-web
+          - template: radarr-custom-formats-hd-bluray-web
+          - template: radarr-quality-profile-uhd-bluray-web
+          - template: radarr-custom-formats-uhd-bluray-web
 
     # experimental support (configarr Lidarr v2): conservative baseline only.
     lidarr:

--- a/generated/manifests/prod-axon/configarr/CronJob-configarr.yaml
+++ b/generated/manifests/prod-axon/configarr/CronJob-configarr.yaml
@@ -16,7 +16,7 @@ spec:
       template:
         metadata:
           annotations:
-            checksum/configMaps: 09af9ea5d26aaf4daa086abc551a18fb55edded31dcc8aa181a3238658453236
+            checksum/configMaps: f8a4e54ca437f12432a09a9e4a74e0199afe554833f365c2e5d4737235fb9b22
           labels:
             app.kubernetes.io/controller: configarr
             app.kubernetes.io/instance: configarr

--- a/modules/den/aspects/kubernetes/services/media/configarr.nix
+++ b/modules/den/aspects/kubernetes/services/media/configarr.nix
@@ -63,10 +63,21 @@ let
       series:
         base_url: http://sonarr:8989
         api_key: !env SONARR_API_KEY
+        # Instance-global file-size boundaries stay on the `series` set (the
+        # TRaSH guidance for mixed regular+anime single instances).
         quality_definition:
           type: series
         include:
           - template: sonarr-quality-definition-series
+          # WEB-1080p and WEB-2160p lanes — assign per series.
+          - template: sonarr-v4-quality-profile-web-1080p
+          - template: sonarr-v4-custom-formats-web-1080p
+          - template: sonarr-v4-quality-profile-web-2160p
+          - template: sonarr-v4-custom-formats-web-2160p
+          # Anime lane in the same instance (sonarr v4 custom formats are
+          # profile-scoped; series get Series Type: Anime + this profile).
+          - template: sonarr-v4-quality-profile-anime
+          - template: sonarr-v4-custom-formats-anime
 
     radarr:
       movies:
@@ -76,6 +87,11 @@ let
           type: movie
         include:
           - template: radarr-quality-definition-movie
+          # HD Bluray+WEB (default lane) and UHD Bluray+WEB — assign per movie.
+          - template: radarr-quality-profile-hd-bluray-web
+          - template: radarr-custom-formats-hd-bluray-web
+          - template: radarr-quality-profile-uhd-bluray-web
+          - template: radarr-custom-formats-uhd-bluray-web
 
     # experimental support (configarr Lidarr v2): conservative baseline only.
     lidarr:


### PR DESCRIPTION
Layers the real TRaSH quality-profile + custom-format templates onto the configarr starter config (which managed only quality definitions until now):

| Instance | Profiles |
|---|---|
| sonarr | WEB-1080p, WEB-2160p, Anime (all recyclarr v4 templates + matching custom formats) |
| radarr | HD Bluray+WEB, UHD Bluray+WEB |

Single-instance anime per the v4 pattern: custom formats are profile-scoped, so anime release-group tiering coexists with the regular lanes; series opt in with `Series Type: Anime` + the profile. The instance-global quality definition stays on the `series` set (TRaSH guidance for mixed instances). lidarr/whisparr remain connection-only baselines — configarr support for them is experimental with no upstream presets.

Profiles appear/sync on the next configarr run; assignment is per series/movie.