### PR TITLE
feat(longhorn): off-cluster backups to NAS via NFS BackupTarget

### DIFF
--- a/generated/manifests/prod-axon/apps/Application-longhorn.yaml
+++ b/generated/manifests/prod-axon/apps/Application-longhorn.yaml
@@ -9,6 +9,13 @@ spec:
   destination:
     namespace: longhorn-system
     server: https://kubernetes.default.svc
+  ignoreDifferences:
+    - group: longhorn.io
+      jsonPointers:
+        - /status
+      kind: BackupTarget
+      name: default
+      namespace: longhorn-system
   project: default
   source:
     path: ./generated/manifests/prod-axon/longhorn

--- a/generated/manifests/prod-axon/longhorn/BackupTarget-default.yaml
+++ b/generated/manifests/prod-axon/longhorn/BackupTarget-default.yaml
@@ -1,0 +1,8 @@
+apiVersion: longhorn.io/v1beta2
+kind: BackupTarget
+metadata:
+  name: default
+  namespace: longhorn-system
+spec:
+  backupTargetURL: nfs://10.10.10.10:/volume2/longhorn-backups
+  pollInterval: 5m0s

--- a/modules/den/aspects/kubernetes/services/storage/csi-driver-nfs/csi-driver-nfs.nix
+++ b/modules/den/aspects/kubernetes/services/storage/csi-driver-nfs/csi-driver-nfs.nix
@@ -41,6 +41,8 @@
           };
 
           resources = {
+            # Only type="storageclass" NFS targets become StorageClasses;
+            # type="backup" (e.g. the Longhorn backupstore) is filtered out.
             storageClasses = lib.mapAttrs (_volumeName: volumeConfig: {
               provisioner = "nfs.csi.k8s.io";
               reclaimPolicy = "Retain";
@@ -60,7 +62,7 @@
                 "noauto"
                 "noatime"
               ];
-            }) nfsVolumes;
+            }) (lib.filterAttrs (_: v: v.type == "storageclass") nfsVolumes);
 
             ciliumNetworkPolicies.allow-kube-apiserver-egress = {
               metadata.annotations."argocd.argoproj.io/sync-wave" = "-1";

--- a/modules/den/aspects/kubernetes/services/storage/longhorn/longhorn.nix
+++ b/modules/den/aspects/kubernetes/services/storage/longhorn/longhorn.nix
@@ -38,6 +38,10 @@
         charts,
         ...
       }:
+      let
+        # Off-cluster backup target declared on the cluster (type="backup").
+        backupNfs = cluster.nfsVolumes."longhorn-backups";
+      in
       {
         applications.longhorn = {
           namespace = "longhorn-system";
@@ -49,6 +53,34 @@
           };
 
           compareOptions.serverSideDiff = true;
+
+          # Off-cluster backups: point the longhorn-created `default` BackupTarget
+          # at the NAS NFS export. The chart's longhorn-default-resource ConfigMap
+          # only SEEDS a non-existent target, so the existing `default` CR is
+          # managed directly here — ArgoCD owns the spec, the longhorn controller
+          # owns status (ignored below). NFS needs no credential secret.
+          ignoreDifferences."backup-target" = {
+            group = "longhorn.io";
+            kind = "BackupTarget";
+            name = "default";
+            namespace = "longhorn-system";
+            jsonPointers = [ "/status" ];
+          };
+
+          objects = [
+            {
+              apiVersion = "longhorn.io/v1beta2";
+              kind = "BackupTarget";
+              metadata = {
+                name = "default";
+                namespace = "longhorn-system";
+              };
+              spec = {
+                backupTargetURL = "nfs://${backupNfs.server}:${backupNfs.share}";
+                pollInterval = "5m0s";
+              };
+            }
+          ];
 
           helm.releases.longhorn = {
             chart = charts.longhorn.longhorn;

--- a/modules/den/clusters/axon.nix
+++ b/modules/den/clusters/axon.nix
@@ -57,6 +57,15 @@
       server = "10.10.10.10";
       share = "/volume2/data";
     };
+
+    # Off-cluster backup target for the Longhorn backupstore (NOT a
+    # StorageClass — csi-driver-nfs filters type="backup" out). Consumed by
+    # the longhorn aspect's BackupTarget.
+    nfsVolumes.longhorn-backups = {
+      server = "10.10.10.10";
+      share = "/volume2/longhorn-backups";
+      type = "backup";
+    };
   };
 
   # Cluster aspect — k8s services included at cluster scope

--- a/modules/den/schema/cluster.nix
+++ b/modules/den/schema/cluster.nix
@@ -19,6 +19,31 @@ let
       lib.reverseList (lib.take 2 (lib.reverseList (lib.splitString "." domain)))
     );
 
+  # An NFS endpoint declared on the cluster. `type` discriminates consumers:
+  # "storageclass" entries become CSI StorageClasses (csi-driver-nfs);
+  # "backup" entries are off-cluster backup targets (e.g. the Longhorn
+  # backupstore) and are filtered OUT of StorageClass generation.
+  nfsVolumeType = types.submodule {
+    options = {
+      server = mkOption {
+        type = types.str;
+        description = "NFS server address";
+      };
+      share = mkOption {
+        type = types.str;
+        description = "NFS share path";
+      };
+      type = mkOption {
+        type = types.enum [
+          "storageclass"
+          "backup"
+        ];
+        default = "storageclass";
+        description = "Consumer of this NFS target: \"storageclass\" → a CSI StorageClass; \"backup\" → an off-cluster backup target (no StorageClass generated).";
+      };
+    };
+  };
+
   networkType = types.submodule {
     options = {
       cidr = mkOption {
@@ -200,22 +225,9 @@ in
           };
 
           nfsVolumes = mkOption {
-            type = types.attrsOf (
-              types.submodule {
-                options = {
-                  server = mkOption {
-                    type = types.str;
-                    description = "NFS server address";
-                  };
-                  share = mkOption {
-                    type = types.str;
-                    description = "NFS share path";
-                  };
-                };
-              }
-            );
+            type = types.attrsOf nfsVolumeType;
             default = { };
-            description = "NFS volumes for CSI driver StorageClass generation";
+            description = "Cluster NFS targets. type=\"storageclass\" → CSI StorageClass; type=\"backup\" → off-cluster backup target.";
           };
         };
       })


### PR DESCRIPTION
Configures the Longhorn `default` BackupTarget so cluster volume backups land off-cluster on the NAS over NFS — closing the off-cluster half of the backup gap (previously snapshots lived only in-cluster).

**Changes**
- Cluster schema: `nfsVolumes` entries gain a `type` discriminator (`storageclass` | `backup`, default `storageclass`). `storageclass` entries become CSI StorageClasses; `backup` entries are off-cluster backup targets.
- `csi-driver-nfs` filters to `type="storageclass"` so a backup target never generates a StorageClass.
- The longhorn aspect sets the `default` BackupTarget's URL from the cluster's `backup`-typed NFS entry (managed directly because the chart's default-resource ConfigMap only seeds a non-existent target). ArgoCD `ignoreDifferences` on the controller-managed `/status`.

**Verification**
- Env builds; `BackupTarget-default` renders with the cluster-sourced URL.
- csi-driver-nfs renders the existing StorageClass only — no spurious backup-target StorageClass.

Foundation for off-cluster CNPG (`type:bak`) and app-volume RecurringJob backups in follow-ups.