### PR TITLE
fix(longhorn): allow pod egress to the NAS NFS backupstore

### DIFF
--- a/generated/manifests/prod-axon/longhorn/CiliumNetworkPolicy-allow-nas-backup-egress.yaml
+++ b/generated/manifests/prod-axon/longhorn/CiliumNetworkPolicy-allow-nas-backup-egress.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: allow-nas-backup-egress
+  namespace: longhorn-system
+spec:
+  description: Allow Longhorn pods to reach the NAS NFS backupstore.
+  egress:
+    - toCIDR:
+        - 10.10.10.10/32
+      toPorts:
+        - ports:
+            - port: "2049"
+              protocol: TCP
+            - port: "111"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      k8s:io.kubernetes.pod.namespace: longhorn-system

--- a/modules/den/aspects/kubernetes/services/storage/longhorn/longhorn.nix
+++ b/modules/den/aspects/kubernetes/services/storage/longhorn/longhorn.nix
@@ -160,6 +160,38 @@
               stringData.client-secret = config.age.secrets.longhorn-oidc-client-secret.sopsRef;
             };
 
+            # Longhorn runs `longhorn system-backup`/backup mounts from the
+            # pod netns, so reaching the NAS backupstore (an external/world IP)
+            # needs an explicit egress allow — host-netns NFS (csi/kubelet)
+            # bypasses pod policy, but this does not. NFSv4 = 2049/TCP; 111/TCP
+            # (rpcbind) included for safety.
+            ciliumNetworkPolicies.allow-nas-backup-egress = {
+              metadata.annotations."argocd.argoproj.io/sync-wave" = "-1";
+              spec = {
+                description = "Allow Longhorn pods to reach the NAS NFS backupstore.";
+                endpointSelector.matchLabels."k8s:io.kubernetes.pod.namespace" = "longhorn-system";
+                egress = [
+                  {
+                    toCIDR = [ "${backupNfs.server}/32" ];
+                    toPorts = [
+                      {
+                        ports = [
+                          {
+                            port = "2049";
+                            protocol = "TCP";
+                          }
+                          {
+                            port = "111";
+                            protocol = "TCP";
+                          }
+                        ];
+                      }
+                    ];
+                  }
+                ];
+              };
+            };
+
             ciliumNetworkPolicies.allow-kube-apiserver-egress = {
               metadata.annotations."argocd.argoproj.io/sync-wave" = "-1";
               spec = {


### PR DESCRIPTION
Follow-up to the Longhorn NFS BackupTarget: the target was stuck `Unavailable` because Longhorn runs backupstore mounts from the **pod** netns, and the namespace is in cilium egress default-deny with no allow to the NAS (an external/`world` IP). Confirmed via hubble — the SYN to the NFS port was `Policy denied DROPPED`. (host-netns NFS like the CSI driver bypasses pod policy, which is why other NFS mounts worked.)

Adds a `CiliumNetworkPolicy` allowing `longhorn-system` egress to the backup NFS host on `2049/TCP` (+`111/TCP`), with the host CIDR sourced from the cluster's `backup`-typed NFS entry.

After merge the BackupTarget reconciles to `available=true` on its next poll.