### PR TITLE
fix(longhorn): ignore controller-written BackupTarget spec fields

### DIFF
--- a/generated/manifests/prod-axon/apps/Application-longhorn.yaml
+++ b/generated/manifests/prod-axon/apps/Application-longhorn.yaml
@@ -13,6 +13,8 @@ spec:
     - group: longhorn.io
       jsonPointers:
         - /status
+        - /spec/syncRequestedAt
+        - /spec/credentialSecret
       kind: BackupTarget
       name: default
       namespace: longhorn-system

--- a/modules/den/aspects/kubernetes/services/storage/longhorn/longhorn.nix
+++ b/modules/den/aspects/kubernetes/services/storage/longhorn/longhorn.nix
@@ -59,12 +59,20 @@
           # only SEEDS a non-existent target, so the existing `default` CR is
           # managed directly here — ArgoCD owns the spec, the longhorn controller
           # owns status (ignored below). NFS needs no credential secret.
+          # The longhorn controller owns /status and periodically rewrites
+          # /spec/syncRequestedAt (and defaults /spec/credentialSecret), which
+          # otherwise flaps the app OutOfSync every poll. Git owns only the URL
+          # and pollInterval.
           ignoreDifferences."backup-target" = {
             group = "longhorn.io";
             kind = "BackupTarget";
             name = "default";
             namespace = "longhorn-system";
-            jsonPointers = [ "/status" ];
+            jsonPointers = [
+              "/status"
+              "/spec/syncRequestedAt"
+              "/spec/credentialSecret"
+            ];
           };
 
           objects = [


### PR DESCRIPTION
Follow-up: the BackupTarget became available, but the longhorn controller periodically rewrites `spec.syncRequestedAt` (and defaults `spec.credentialSecret`), flapping the ArgoCD app OutOfSync every poll cycle (~3min OutOfSync of every ~5min). Extends `ignoreDifferences` on the BackupTarget to those controller-owned paths (alongside `/status`) so ArgoCD manages only the URL + pollInterval and stays Synced.