### PR TITLE
fix(longhorn): ignore BackupTarget drift via managedFieldsManagers

### DIFF
--- a/generated/manifests/prod-axon/apps/Application-longhorn.yaml
+++ b/generated/manifests/prod-axon/apps/Application-longhorn.yaml
@@ -11,11 +11,9 @@ spec:
     server: https://kubernetes.default.svc
   ignoreDifferences:
     - group: longhorn.io
-      jsonPointers:
-        - /status
-        - /spec/syncRequestedAt
-        - /spec/credentialSecret
       kind: BackupTarget
+      managedFieldsManagers:
+        - longhorn-manager
       name: default
       namespace: longhorn-system
   project: default

--- a/modules/den/aspects/kubernetes/services/storage/longhorn/longhorn.nix
+++ b/modules/den/aspects/kubernetes/services/storage/longhorn/longhorn.nix
@@ -59,20 +59,19 @@
           # only SEEDS a non-existent target, so the existing `default` CR is
           # managed directly here — ArgoCD owns the spec, the longhorn controller
           # owns status (ignored below). NFS needs no credential secret.
-          # The longhorn controller owns /status and periodically rewrites
-          # /spec/syncRequestedAt (and defaults /spec/credentialSecret), which
-          # otherwise flaps the app OutOfSync every poll. Git owns only the URL
-          # and pollInterval.
+          # The longhorn controller (`longhorn-manager` field manager) owns
+          # /status and periodically rewrites /spec/syncRequestedAt (+ defaults
+          # /spec/credentialSecret), flapping the app OutOfSync every poll. The
+          # app uses serverSideDiff, where jsonPointers do NOT suppress this —
+          # the SSA-native fix is managedFieldsManagers: ignore everything that
+          # field manager owns. argocd-controller still owns (and git enforces)
+          # backupTargetURL + pollInterval.
           ignoreDifferences."backup-target" = {
             group = "longhorn.io";
             kind = "BackupTarget";
             name = "default";
             namespace = "longhorn-system";
-            jsonPointers = [
-              "/status"
-              "/spec/syncRequestedAt"
-              "/spec/credentialSecret"
-            ];
+            managedFieldsManagers = [ "longhorn-manager" ];
           };
 
           objects = [


### PR DESCRIPTION
The prior `jsonPointers` ignore didn't stop the OutOfSync flapping because the longhorn app uses `serverSideDiff`, under which `jsonPointers` don't suppress controller-written fields. Field-manager inspection shows `longhorn-manager` owns `spec.syncRequestedAt`/`credentialSecret`/`status` (it bumps `syncRequestedAt` every poll), while `argocd-controller` owns `backupTargetURL`/`pollInterval`. Switches `ignoreDifferences` to `managedFieldsManagers: [longhorn-manager]` — the SSA-native mechanism — so ArgoCD ignores all controller-owned fields and stays Synced while still enforcing the URL + pollInterval.