### PR TITLE
feat(longhorn): type:bak VolumeSnapshotClass for off-cluster backups

### DIFF
--- a/generated/manifests/prod-axon/longhorn/VolumeSnapshotClass-longhorn-backup-nfs.yaml
+++ b/generated/manifests/prod-axon/longhorn/VolumeSnapshotClass-longhorn-backup-nfs.yaml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1
+deletionPolicy: Delete
+driver: driver.longhorn.io
+kind: VolumeSnapshotClass
+metadata:
+  name: longhorn-backup-nfs
+parameters:
+  type: bak

--- a/modules/den/aspects/kubernetes/services/storage/longhorn/longhorn.nix
+++ b/modules/den/aspects/kubernetes/services/storage/longhorn/longhorn.nix
@@ -119,6 +119,16 @@
           };
 
           resources = {
+            # Off-cluster (type:bak) snapshot class: CNPG ScheduledBackups using
+            # it create Longhorn Backups uploaded to the NAS BackupTarget.
+            # Coexists with the in-cluster `longhorn-snapshot` (type:snap) class
+            # declared in media-pg.nix.
+            volumeSnapshotClasses.longhorn-backup-nfs = {
+              driver = "driver.longhorn.io";
+              deletionPolicy = "Delete";
+              parameters.type = "bak";
+            };
+
             httpRoutes.longhorn-dashboard.spec = {
               hostnames = [ (cluster.domainFor "longhorn") ];
               parentRefs = [


### PR DESCRIPTION
Adds the `longhorn-backup-nfs` VolumeSnapshotClass (`driver.longhorn.io`, `type: bak`) — CSI snapshots in this class create Longhorn Backups uploaded to the NAS BackupTarget, vs the existing in-cluster `longhorn-snapshot` (`type: snap`). Both coexist. Foundation for flipping the CNPG cluster backups off-cluster.