### PR TITLE
feat(cnpg): flip media-pg + monitoring-pg backups off-cluster

### DIFF
--- a/generated/manifests/prod-axon/longhorn/RecurringJob-db-local-snap.yaml
+++ b/generated/manifests/prod-axon/longhorn/RecurringJob-db-local-snap.yaml
@@ -1,0 +1,12 @@
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: db-local-snap
+  namespace: longhorn-system
+spec:
+  concurrency: 2
+  cron: 0 */6 * * *
+  groups:
+    - db-local-snap
+  retain: 4
+  task: snapshot

--- a/generated/manifests/prod-axon/media-pg/Cluster-media-pg.yaml
+++ b/generated/manifests/prod-axon/media-pg/Cluster-media-pg.yaml
@@ -8,7 +8,10 @@ spec:
     podAntiAffinityType: required
   backup:
     volumeSnapshot:
-      className: longhorn-snapshot
+      className: longhorn-backup-nfs
+  inheritedMetadata:
+    labels:
+      recurring-job-group.longhorn.io/db-local-snap: enabled
   instances: 2
   managed:
     roles:

--- a/generated/manifests/prod-axon/monitoring-pg/Cluster-monitoring-pg.yaml
+++ b/generated/manifests/prod-axon/monitoring-pg/Cluster-monitoring-pg.yaml
@@ -8,7 +8,10 @@ spec:
     podAntiAffinityType: required
   backup:
     volumeSnapshot:
-      className: longhorn-snapshot
+      className: longhorn-backup-nfs
+  inheritedMetadata:
+    labels:
+      recurring-job-group.longhorn.io/db-local-snap: enabled
   instances: 2
   managed:
     roles:

--- a/modules/den/aspects/kubernetes/services/media/media-pg.nix
+++ b/modules/den/aspects/kubernetes/services/media/media-pg.nix
@@ -128,7 +128,15 @@ in
                 passwordSecret.name = passwordSecretName app;
               }) roleApps;
 
-              backup.volumeSnapshot.className = snapshotClassName;
+              # Authoritative backup → off-cluster NAS (type:bak). The in-cluster
+              # longhorn-snapshot VSC stays declared below for manual CSI
+              # snapshots; local fast-rollback is the db-local-snap Longhorn
+              # RecurringJob, enrolled via inheritedMetadata.
+              backup.volumeSnapshot.className = "longhorn-backup-nfs";
+
+              # Enroll this cluster's PVCs into the db-local-snap RecurringJob
+              # group (Longhorn-native local snapshots every 6h, retain 4).
+              inheritedMetadata.labels."recurring-job-group.longhorn.io/db-local-snap" = "enabled";
             };
 
             # One Database CR per (db, owner). arrs split main/log; bazarr/romm

--- a/modules/den/aspects/kubernetes/services/monitoring/monitoring-pg.nix
+++ b/modules/den/aspects/kubernetes/services/monitoring/monitoring-pg.nix
@@ -64,7 +64,12 @@ in
                 passwordSecret.name = passwordSecretName app;
               }) roleApps;
 
-              backup.volumeSnapshot.className = "longhorn-snapshot";
+              # Authoritative backup → off-cluster NAS (type:bak). Local
+              # fast-rollback is the db-local-snap Longhorn RecurringJob,
+              # enrolled via inheritedMetadata.
+              backup.volumeSnapshot.className = "longhorn-backup-nfs";
+
+              inheritedMetadata.labels."recurring-job-group.longhorn.io/db-local-snap" = "enabled";
             };
 
             databases.grafana.spec = {

--- a/modules/den/aspects/kubernetes/services/storage/longhorn/longhorn.nix
+++ b/modules/den/aspects/kubernetes/services/storage/longhorn/longhorn.nix
@@ -87,6 +87,26 @@
                 pollInterval = "5m0s";
               };
             }
+            # Local fast-rollback snapshots for the CNPG database volumes
+            # (Longhorn-native, in-cluster — NOT a backup/upload). DB PVCs join
+            # the `db-local-snap` group via inheritedMetadata labels on the CNPG
+            # clusters. The authoritative off-cluster copy is the CNPG
+            # type:bak ScheduledBackup; this is a cheap COW rollback point.
+            {
+              apiVersion = "longhorn.io/v1beta2";
+              kind = "RecurringJob";
+              metadata = {
+                name = "db-local-snap";
+                namespace = "longhorn-system";
+              };
+              spec = {
+                task = "snapshot";
+                cron = "0 */6 * * *";
+                retain = 4;
+                concurrency = 2;
+                groups = [ "db-local-snap" ];
+              };
+            }
           ];
 
           helm.releases.longhorn = {


### PR DESCRIPTION
Tier 1 of the comprehensive backup work. Both CNPG clusters' `backup.volumeSnapshot.className` moves to `longhorn-backup-nfs` (`type:bak`), so their existing nightly ScheduledBackups now upload to the NAS BackupTarget (online/hot, from a standby). Adds a `db-local-snap` Longhorn RecurringJob (snapshot task, every 6h, retain 4) for fast in-cluster rollback between off-cluster backups; DB PVCs are enrolled into the group via CNPG `inheritedMetadata.labels`. The in-cluster `longhorn-snapshot` class stays declared for manual CSI snapshots.