### PR TITLE
feat(media): nightly off-cluster backup of app-config volumes

### DIFF
--- a/generated/manifests/prod-axon/bazarr/PersistentVolumeClaim-bazarr.yaml
+++ b/generated/manifests/prod-axon/bazarr/PersistentVolumeClaim-bazarr.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: bazarr
     app.kubernetes.io/name: bazarr
+    recurring-job-group.longhorn.io/media-config: enabled
   name: bazarr
   namespace: media
 spec:

--- a/generated/manifests/prod-axon/komga/PersistentVolumeClaim-komga.yaml
+++ b/generated/manifests/prod-axon/komga/PersistentVolumeClaim-komga.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: komga
     app.kubernetes.io/name: komga
+    recurring-job-group.longhorn.io/media-config: enabled
   name: komga
   namespace: media
 spec:

--- a/generated/manifests/prod-axon/lidarr/PersistentVolumeClaim-lidarr.yaml
+++ b/generated/manifests/prod-axon/lidarr/PersistentVolumeClaim-lidarr.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: lidarr
     app.kubernetes.io/name: lidarr
+    recurring-job-group.longhorn.io/media-config: enabled
   name: lidarr
   namespace: media
 spec:

--- a/generated/manifests/prod-axon/longhorn/RecurringJob-media-config-backup.yaml
+++ b/generated/manifests/prod-axon/longhorn/RecurringJob-media-config-backup.yaml
@@ -1,0 +1,12 @@
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: media-config-backup
+  namespace: longhorn-system
+spec:
+  concurrency: 2
+  cron: 0 3 * * *
+  groups:
+    - media-config
+  retain: 7
+  task: backup

--- a/generated/manifests/prod-axon/prowlarr/PersistentVolumeClaim-prowlarr.yaml
+++ b/generated/manifests/prod-axon/prowlarr/PersistentVolumeClaim-prowlarr.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: prowlarr
     app.kubernetes.io/name: prowlarr
+    recurring-job-group.longhorn.io/media-config: enabled
   name: prowlarr
   namespace: media
 spec:

--- a/generated/manifests/prod-axon/qbittorrent/PersistentVolumeClaim-qbittorrent.yaml
+++ b/generated/manifests/prod-axon/qbittorrent/PersistentVolumeClaim-qbittorrent.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: qbittorrent
     app.kubernetes.io/name: qbittorrent
+    recurring-job-group.longhorn.io/media-config: enabled
   name: qbittorrent
   namespace: media
 spec:

--- a/generated/manifests/prod-axon/radarr/PersistentVolumeClaim-radarr.yaml
+++ b/generated/manifests/prod-axon/radarr/PersistentVolumeClaim-radarr.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: radarr
     app.kubernetes.io/name: radarr
+    recurring-job-group.longhorn.io/media-config: enabled
   name: radarr
   namespace: media
 spec:

--- a/generated/manifests/prod-axon/romm/PersistentVolumeClaim-romm.yaml
+++ b/generated/manifests/prod-axon/romm/PersistentVolumeClaim-romm.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: romm
     app.kubernetes.io/name: romm
+    recurring-job-group.longhorn.io/media-config: enabled
   name: romm
   namespace: media
 spec:

--- a/generated/manifests/prod-axon/sabnzbd/PersistentVolumeClaim-sabnzbd.yaml
+++ b/generated/manifests/prod-axon/sabnzbd/PersistentVolumeClaim-sabnzbd.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: sabnzbd
     app.kubernetes.io/name: sabnzbd
+    recurring-job-group.longhorn.io/media-config: enabled
   name: sabnzbd
   namespace: media
 spec:

--- a/generated/manifests/prod-axon/shoko/PersistentVolumeClaim-shoko.yaml
+++ b/generated/manifests/prod-axon/shoko/PersistentVolumeClaim-shoko.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: shoko
     app.kubernetes.io/name: shoko
+    recurring-job-group.longhorn.io/media-config: enabled
   name: shoko
   namespace: media
 spec:

--- a/generated/manifests/prod-axon/sonarr/PersistentVolumeClaim-sonarr.yaml
+++ b/generated/manifests/prod-axon/sonarr/PersistentVolumeClaim-sonarr.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: sonarr
     app.kubernetes.io/name: sonarr
+    recurring-job-group.longhorn.io/media-config: enabled
   name: sonarr
   namespace: media
 spec:

--- a/generated/manifests/prod-axon/whisparr/PersistentVolumeClaim-whisparr.yaml
+++ b/generated/manifests/prod-axon/whisparr/PersistentVolumeClaim-whisparr.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: whisparr
     app.kubernetes.io/name: whisparr
+    recurring-job-group.longhorn.io/media-config: enabled
   name: whisparr
   namespace: media
 spec:

--- a/modules/den/aspects/kubernetes/services/media/bazarr.nix
+++ b/modules/den/aspects/kubernetes/services/media/bazarr.nix
@@ -99,6 +99,7 @@
                   accessMode = "ReadWriteOnce";
                   size = "2Gi";
                   storageClass = "longhorn";
+                  labels."recurring-job-group.longhorn.io/media-config" = "enabled";
                   globalMounts = [ { path = "/config"; } ];
                 };
                 # Bazarr reads media to write sidecar subtitles; config PVC +

--- a/modules/den/aspects/kubernetes/services/media/komga.nix
+++ b/modules/den/aspects/kubernetes/services/media/komga.nix
@@ -88,6 +88,7 @@
                   accessMode = "ReadWriteOnce";
                   size = "2Gi";
                   storageClass = "longhorn";
+                  labels."recurring-job-group.longhorn.io/media-config" = "enabled";
                   globalMounts = [ { path = "/config"; } ];
                 };
                 data = {

--- a/modules/den/aspects/kubernetes/services/media/lidarr.nix
+++ b/modules/den/aspects/kubernetes/services/media/lidarr.nix
@@ -103,6 +103,7 @@
                   accessMode = "ReadWriteOnce";
                   size = "2Gi";
                   storageClass = "longhorn";
+                  labels."recurring-job-group.longhorn.io/media-config" = "enabled";
                   globalMounts = [ { path = "/config"; } ];
                 };
                 data = {

--- a/modules/den/aspects/kubernetes/services/media/prowlarr.nix
+++ b/modules/den/aspects/kubernetes/services/media/prowlarr.nix
@@ -109,6 +109,7 @@
                 accessMode = "ReadWriteOnce";
                 size = "2Gi";
                 storageClass = "longhorn";
+                labels."recurring-job-group.longhorn.io/media-config" = "enabled";
                 globalMounts = [ { path = "/config"; } ];
               };
             };

--- a/modules/den/aspects/kubernetes/services/media/qbittorrent.nix
+++ b/modules/den/aspects/kubernetes/services/media/qbittorrent.nix
@@ -398,6 +398,7 @@
                   accessMode = "ReadWriteOnce";
                   size = "1Gi";
                   storageClass = "longhorn";
+                  labels."recurring-job-group.longhorn.io/media-config" = "enabled";
                   globalMounts = [ { path = "/config"; } ];
                 };
 

--- a/modules/den/aspects/kubernetes/services/media/radarr.nix
+++ b/modules/den/aspects/kubernetes/services/media/radarr.nix
@@ -104,6 +104,7 @@
                   accessMode = "ReadWriteOnce";
                   size = "5Gi";
                   storageClass = "longhorn";
+                  labels."recurring-job-group.longhorn.io/media-config" = "enabled";
                   globalMounts = [ { path = "/config"; } ];
                 };
                 data = {

--- a/modules/den/aspects/kubernetes/services/media/romm.nix
+++ b/modules/den/aspects/kubernetes/services/media/romm.nix
@@ -173,6 +173,7 @@
                   accessMode = "ReadWriteOnce";
                   size = "10Gi";
                   storageClass = "longhorn";
+                  labels."recurring-job-group.longhorn.io/media-config" = "enabled";
                   globalMounts = [
                     {
                       path = "/romm/resources";

--- a/modules/den/aspects/kubernetes/services/media/sabnzbd.nix
+++ b/modules/den/aspects/kubernetes/services/media/sabnzbd.nix
@@ -179,6 +179,7 @@
                   accessMode = "ReadWriteOnce";
                   size = "1Gi";
                   storageClass = "longhorn";
+                  labels."recurring-job-group.longhorn.io/media-config" = "enabled";
                   globalMounts = [ { path = "/config"; } ];
                 };
                 # scratch-local RWO → /scratch (pins pod to the scratch node).

--- a/modules/den/aspects/kubernetes/services/media/shoko.nix
+++ b/modules/den/aspects/kubernetes/services/media/shoko.nix
@@ -89,6 +89,7 @@
                   accessMode = "ReadWriteOnce";
                   size = "10Gi";
                   storageClass = "longhorn";
+                  labels."recurring-job-group.longhorn.io/media-config" = "enabled";
                   globalMounts = [ { path = "/home/shoko/.shoko"; } ];
                 };
                 data = {

--- a/modules/den/aspects/kubernetes/services/media/sonarr.nix
+++ b/modules/den/aspects/kubernetes/services/media/sonarr.nix
@@ -104,6 +104,7 @@
                   accessMode = "ReadWriteOnce";
                   size = "5Gi";
                   storageClass = "longhorn";
+                  labels."recurring-job-group.longhorn.io/media-config" = "enabled";
                   globalMounts = [ { path = "/config"; } ];
                 };
                 data = {

--- a/modules/den/aspects/kubernetes/services/media/whisparr.nix
+++ b/modules/den/aspects/kubernetes/services/media/whisparr.nix
@@ -106,6 +106,7 @@
                   accessMode = "ReadWriteOnce";
                   size = "2Gi";
                   storageClass = "longhorn";
+                  labels."recurring-job-group.longhorn.io/media-config" = "enabled";
                   globalMounts = [ { path = "/config"; } ];
                 };
                 data = {

--- a/modules/den/aspects/kubernetes/services/storage/longhorn/longhorn.nix
+++ b/modules/den/aspects/kubernetes/services/storage/longhorn/longhorn.nix
@@ -107,6 +107,25 @@
                 groups = [ "db-local-snap" ];
               };
             }
+            # Nightly off-cluster backup of the app-config volumes (the media app
+            # PVCs enrolled via the media-config group label on their config PVC).
+            # loki/prometheus are intentionally unlabeled (observability TSDB is
+            # treated as ephemeral), and never join via a default-group job.
+            {
+              apiVersion = "longhorn.io/v1beta2";
+              kind = "RecurringJob";
+              metadata = {
+                name = "media-config-backup";
+                namespace = "longhorn-system";
+              };
+              spec = {
+                task = "backup";
+                cron = "0 3 * * *";
+                retain = 7;
+                concurrency = 2;
+                groups = [ "media-config" ];
+              };
+            }
           ];
 
           helm.releases.longhorn = {


### PR DESCRIPTION
Tier 2 of the comprehensive backup work. Adds a `media-config-backup` Longhorn RecurringJob (backup task, nightly 03:00, retain 7, group `media-config`) and enrolls the 11 media app config PVCs via a `recurring-job-group.longhorn.io/media-config` label on each app's longhorn config PVC (romm's is its `state` PVC). loki/prometheus are intentionally left unlabeled — observability TSDB is treated as ephemeral, and no default-group job exists to sweep them in.