### PR TITLE
feat(images): imageRefs accessor + exporter image pins

### DIFF
--- a/images/esanchezm/prometheus-qbittorrent-exporter/default.nix
+++ b/images/esanchezm/prometheus-qbittorrent-exporter/default.nix
@@ -1,0 +1,9 @@
+{
+  imageName = "ghcr.io/esanchezm/prometheus-qbittorrent-exporter";
+  imageTag = "v1.6.0";
+  imageDigest = "sha256:b987d19693a5b2fe7314b22009c6302e084ec801fcf96afaf14065b4cdafc842";
+  imageHash = "sha256-Wb1mPE0n4giCStadWwlZrwB6E2AsqIoRQl2mqZE7FJI=";
+  arch = "amd64";
+  os = "linux";
+  pinned = false;
+}

--- a/images/grafana/alloy/default.nix
+++ b/images/grafana/alloy/default.nix
@@ -1,0 +1,9 @@
+{
+  imageName = "docker.io/grafana/alloy";
+  imageTag = "v1.10.0";
+  imageDigest = "sha256:1bc130e909116a4bf950eb5187a346007d3b796f96832b529acb14a64e41230f";
+  imageHash = "sha256-K0vm4MtpcYRfnGskSqdqr3RnVX/N5yLb7n5R4im/x2Y=";
+  arch = "amd64";
+  os = "linux";
+  pinned = false;
+}

--- a/images/onedr0p/exportarr/default.nix
+++ b/images/onedr0p/exportarr/default.nix
@@ -1,0 +1,9 @@
+{
+  imageName = "ghcr.io/onedr0p/exportarr";
+  imageTag = "v2.2.0";
+  imageDigest = "sha256:320b0ea7399f4b9af4741dcdddd7d40c05c36b0359679305d8a54df4e97065df";
+  imageHash = "sha256-aXCgjGqcfA+fmZLYRnIZkIrOqfFs2xpEuH1qXMVYomQ=";
+  arch = "amd64";
+  os = "linux";
+  pinned = false;
+}

--- a/modules/den/policies/clusters.nix
+++ b/modules/den/policies/clusters.nix
@@ -131,6 +131,11 @@ in
                     local = config.flake.chartsDerivations.${system} or { };
                   in
                   upstream // lib.mapAttrs (org: orgCharts: (upstream.${org} or { }) // orgCharts) local;
+                # Pinned OCI image refs, exposed to manifest aspects as the
+                # `images` module arg: images."<ns>/<name>" = { repository; digest; }.
+                extraSpecialArgs = {
+                  images = config.flake.imageRefs.${system};
+                };
                 # den-collected kubernetes-class modules for this cluster
                 inherit modules;
               }

--- a/modules/flake-parts/oci-images.nix
+++ b/modules/flake-parts/oci-images.nix
@@ -22,7 +22,7 @@ let
         };
     in
     inputs.haumea.lib.load {
-      src = ../../../images;
+      src = ../../images;
       loader = _: p: loadImage (import p);
       transformer = inputs.haumea.lib.transformers.liftDefault;
     };
@@ -30,11 +30,29 @@ in
 {
   flake = {
     imagesMetadata = inputs.haumea.lib.load {
-      src = ../../../images;
+      src = ../../images;
       transformer = inputs.haumea.lib.transformers.liftDefault;
     };
 
     images = mkImages;
+
+    # Flattened "<ns>/<name>" -> { repository; digest; } accessor for use as a
+    # nixidy module arg (`images`), so k8s-manifests aspects can reference a
+    # pinned image by its registry+digest without restating the version.
+    imageRefs = lib.genAttrs config.systems (
+      _system:
+      lib.foldlAttrs (
+        acc: ns: names:
+        acc
+        // lib.mapAttrs' (
+          name: meta:
+          lib.nameValuePair "${ns}/${name}" {
+            repository = meta.imageName;
+            digest = meta.imageDigest;
+          }
+        ) names
+      ) { } config.flake.imagesMetadata
+    );
 
     imagesDerivations = lib.genAttrs config.systems (
       system: mkImages { pkgs = inputs.nixpkgs-unstable.legacyPackages.${system}; }


### PR DESCRIPTION
Adds a flake-level `imageRefs` accessor exposing pinned OCI image coords (`{ repository; digest; }`) into the nixidy k8s-manifests module context via `extraSpecialArgs`, plus three pinned image entries (exportarr, qbittorrent-exporter, alloy) for upcoming media-app metrics/log sidecars. Also corrects a pre-existing image-metadata path that resolved outside the repo root (broke pure eval). No consumer yet — zero runtime change.