### PR TITLE
chore(den): source schema validators from gen-schema

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1117,11 +1117,26 @@
     },
     "gen-algebra": {
       "locked": {
-        "lastModified": 1780264808,
-        "narHash": "sha256-qH90aAoCXl4I94ZviyiVZBBLa/SlwheccvFIUJlgPR8=",
+        "lastModified": 1782521734,
+        "narHash": "sha256-BU6HndNta7WDB51AKjBFYNOxFhp5rJPOumjMkQVKzSM=",
         "owner": "sini",
         "repo": "gen-algebra",
-        "rev": "49f6721bd314b38272bd6b1b26139569365c85a6",
+        "rev": "aaffd3f073715bd4ac47d3f78123a9882a328bfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sini",
+        "repo": "gen-algebra",
+        "type": "github"
+      }
+    },
+    "gen-algebra_2": {
+      "locked": {
+        "lastModified": 1782521734,
+        "narHash": "sha256-BU6HndNta7WDB51AKjBFYNOxFhp5rJPOumjMkQVKzSM=",
+        "owner": "sini",
+        "repo": "gen-algebra",
+        "rev": "aaffd3f073715bd4ac47d3f78123a9882a328bfa",
         "type": "github"
       },
       "original": {
@@ -1132,14 +1147,15 @@
     },
     "gen-schema": {
       "inputs": {
+        "gen-algebra": "gen-algebra_2",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1780016316,
-        "narHash": "sha256-JE6yIkS6Y+LG+Uu6zZGwStofDsa/BcT/9co79BY/lCE=",
+        "lastModified": 1782524366,
+        "narHash": "sha256-5ioahPWuYBLKb4MQtixVqIrzdKy9fMYkUXKCHFwTj8Q=",
         "owner": "sini",
         "repo": "gen-schema",
-        "rev": "c072f76be4164a854312b892867c2d007891575a",
+        "rev": "e789c334fed02bd39d79a6ba31d8bebcbf3ee31f",
         "type": "github"
       },
       "original": {

--- a/modules/den/schema/group.nix
+++ b/modules/den/schema/group.nix
@@ -1,11 +1,11 @@
 { lib, inputs, ... }:
 let
   inherit (lib) mkOption types;
-  gen-algebra = inputs.gen-algebra { inherit lib; };
+  schemaLib = inputs.gen-schema.lib;
 in
 {
   den.schema.group.validators = [
-    (gen-algebra.mkValidator "posix-needs-gid" (
+    (schemaLib.mkValidator "posix-needs-gid" (
       { labels, gid, ... }: !(lib.elem "posix" labels) || gid != null
     ) "groups with the 'posix' label must have a gid set")
   ];

--- a/modules/den/schema/host.nix
+++ b/modules/den/schema/host.nix
@@ -13,7 +13,7 @@
 }:
 let
   inherit (lib) mkOption types;
-  gen-algebra = inputs.gen-algebra { inherit lib; };
+  schemaLib = inputs.gen-schema.lib;
 
   interfaceType = types.submodule {
     options = {
@@ -230,7 +230,7 @@ in
   den.schema.host.isEntity = true;
 
   den.schema.host.validators = [
-    (gen-algebra.mkValidator "valid-channel" (
+    (schemaLib.mkValidator "valid-channel" (
       { channel, ... }: lib.elem channel channelNames
     ) "channel must be one of: ${lib.concatStringsSep ", " channelNames}")
   ];


### PR DESCRIPTION
Under the gen-lib root-file convention, gen-algebra dropped its `__functor` flake output and `mkValidator` relocated to gen-schema, so the den schema validators' old `inputs.gen-algebra { inherit lib; }` call no longer resolves.

- host (`valid-channel`) + group (`posix-needs-gid`) validators now use the existing `schemaLib = inputs.gen-schema.lib` convention → `schemaLib.mkValidator`.
- gen-algebra / gen-schema bumped to the convention revs; gen-algebra is now only a transitive dep (via gen-schema).

Verified: a host's `system.build.toplevel.drvPath` evaluates clean.