### PR TITLE
fix(cluster): stat cluster secret via path concat, not string interpolation

### DIFF
--- a/modules/den/schema/cluster.nix
+++ b/modules/den/schema/cluster.nix
@@ -97,9 +97,13 @@ in
       lib.mapAttrs (
         _: c:
         lib.optionalAttrs
-          (c.secretPath != null && builtins.pathExists "${c.secretPath}/cluster-sops-age-key.pub")
+          # Path concatenation (NOT string interpolation): interpolating `c.secretPath`
+          # coerces the whole secret DIRECTORY into the store just to stat one file —
+          # which, for a non-existent secretPath, makes Nix emit an empty-NAR addToStore
+          # that deadlocks the nix-daemon worker protocol. `+ "/..."` stats/reads directly.
+          (c.secretPath != null && builtins.pathExists (c.secretPath + "/cluster-sops-age-key.pub"))
           {
-            sopsAgeRecipient = builtins.readFile "${c.secretPath}/cluster-sops-age-key.pub";
+            sopsAgeRecipient = builtins.readFile (c.secretPath + "/cluster-sops-age-key.pub");
           }
       ) clusters;
     extraModules = [


### PR DESCRIPTION
## Problem
`schema/cluster.nix` reads the cluster SOPS recipient via **string interpolation** of the
path-typed `secretPath`: `"${c.secretPath}/cluster-sops-age-key.pub"`. Interpolating a path
value coerces it into the store — copying the **entire cluster secret directory** — just to
stat/read one file inside it.

For a cluster whose `secretPath` does not exist on disk, this makes Nix emit an `addToStore`
with an **empty NAR**; the nix-daemon worker protocol can't parse that, the connection desyncs,
and eval **hangs indefinitely** (only through the daemon store — a local/root store sidesteps
it). It also silently copies every cluster's secret directory into the world-readable store on
every eval.

## Fix
Use **path concatenation** (`secretPath + "/..."`) for the `pathExists`/`readFile`, which
stats/reads the file directly with no store coercion. A repo-wide audit confirms this was the
only occurrence of the pattern (other path-like interpolations are store paths or runtime
strings).

## Verification
- A real cluster host's `system.build.toplevel.drvPath` is **byte-identical** before/after.
- Derived `sopsAgeRecipient` unchanged (same `.pub` content); `nixidy-sync` reports no manifest
  changes.
- The previously-hanging daemon eval now completes.
