### PR TITLE
feat(k8s): operator-managed Garage S3 object storage

### DIFF
--- a/charts/emberstack/reflector/default.nix
+++ b/charts/emberstack/reflector/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://emberstack.github.io/helm-charts";
+  chart = "reflector";
+  version = "10.0.54";
+  chartHash = "sha256-FIxAHYYunGU9SJZ0TrxK/+Z7W6lV8Y9a7o14VKdDrbU=";
+}

--- a/charts/noooste/garage-ui/default.nix
+++ b/charts/noooste/garage-ui/default.nix
@@ -1,0 +1,9 @@
+# Garage admin UI (OIDC + team access). Published as an OCI Helm chart:
+#   helm install garage-ui oci://ghcr.io/noooste/charts/garage-ui
+# Source: https://github.com/Noooste/garage-ui
+{
+  repo = "oci://ghcr.io/noooste/charts";
+  chart = "garage-ui";
+  version = "0.8.4";
+  chartHash = "sha256-xAocMDCxaG/OyNikNAqhet/DH1/HvUKyUlmPTleVA9U=";
+}

--- a/charts/rajsinghtech/garage-operator/default.nix
+++ b/charts/rajsinghtech/garage-operator/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "oci://ghcr.io/rajsinghtech/charts";
+  chart = "garage-operator";
+  version = "0.6.2";
+  chartHash = "sha256-stNqgMDWCL/I3ja2fkYg6etOTdN1bMSt6/9R2nj8UY4=";
+}

--- a/generated/manifests/prod-axon/apps/Application-garage-operator.yaml
+++ b/generated/manifests/prod-axon/apps/Application-garage-operator.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: garage-operator
+  namespace: argocd
+spec:
+  destination:
+    namespace: garage
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/garage-operator
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/apps/Application-garage.yaml
+++ b/generated/manifests/prod-axon/apps/Application-garage.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: garage
+  namespace: argocd
+spec:
+  destination:
+    namespace: garage
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/garage
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/apps/Application-reflector.yaml
+++ b/generated/manifests/prod-axon/apps/Application-reflector.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: reflector
+  namespace: argocd
+spec:
+  destination:
+    namespace: reflector
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/reflector
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-garageadmintokens-garage-rajsingh-info.yaml
+++ b/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-garageadmintokens-garage-rajsingh-info.yaml
@@ -1,0 +1,279 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/instance: garage-operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: garage-operator
+    app.kubernetes.io/version: 0.6.2
+    control-plane: controller-manager
+    helm.sh/chart: garage-operator-0.6.2
+  name: garageadmintokens.garage.rajsingh.info
+spec:
+  group: garage.rajsingh.info
+  names:
+    kind: GarageAdminToken
+    listKind: GarageAdminTokenList
+    plural: garageadmintokens
+    shortNames:
+      - gat
+    singular: garageadmintoken
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: false
+      storage: false
+    - additionalPrinterColumns:
+        - jsonPath: .spec.clusterRef.name
+          name: Cluster
+          type: string
+        - jsonPath: .status.tokenId
+          name: TokenID
+          type: string
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            GarageAdminToken is the Schema for the garageadmintokens API
+            It manages admin API tokens for Garage clusters
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                GarageAdminTokenSpec defines the desired state of GarageAdminToken.
+
+                GarageAdminToken provisions secrets for accessing the Garage Admin HTTP API.
+                Admin tokens authenticate differently from S3 keys (GarageKey) — they use
+                Bearer token auth against the admin port (default 3903) instead of HMAC-SHA256.
+
+                The operator writes the token as an admin_token_file in Garage's TOML config.
+                File-based tokens always have full admin access; there is no scope restriction.
+                To create scoped tokens, use Garage's Admin API (CreateAdminToken) directly —
+                this resource is for provisioning the full-access operator/tooling token.
+              properties:
+                clusterRef:
+                  description: ClusterRef references the GarageCluster this token belongs to
+                  properties:
+                    kubeConfigSecretRef:
+                      description: |-
+                        KubeConfigSecretRef references a secret containing a kubeconfig for a remote Kubernetes cluster.
+                        Only needed for multi-cluster federation where the GarageCluster lives in a different
+                        Kubernetes cluster entirely (not just a different namespace).
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    name:
+                      description: Name of the GarageCluster resource.
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the GarageCluster. Defaults to the referencing resource's namespace.
+                        Cross-namespace references require a GarageReferenceGrant in the target namespace.
+                        Not supported on GarageNode.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                expiresAt:
+                  description: |-
+                    ExpiresAt sets when this token should be rotated.
+                    The operator tracks this and sets the TokenExpired condition when the date passes,
+                    but does NOT automatically rotate or revoke the token — rotation requires manual action
+                    (update or delete the GarageAdminToken resource). Use NeverExpires to suppress expiry tracking.
+                    Mutually exclusive with NeverExpires.
+                  format: date-time
+                  type: string
+                name:
+                  description: |-
+                    Name is a friendly name for this admin token
+                    If not set, metadata.name is used
+                  type: string
+                neverExpires:
+                  description: |-
+                    NeverExpires sets the token to never expire.
+                    Mutually exclusive with ExpiresAt.
+                  type: boolean
+                secretTemplate:
+                  description: SecretTemplate configures how the secret containing the token is generated
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations to add to the secret
+                      type: object
+                    endpointKey:
+                      default: admin-endpoint
+                      description: EndpointKey is the key name for the admin endpoint
+                      type: string
+                    includeEndpoint:
+                      description: |-
+                        IncludeEndpoint includes the admin API endpoint in the secret
+                        Defaults to true if not specified
+                      type: boolean
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels to add to the secret
+                      type: object
+                    name:
+                      description: |-
+                        Name is the name of the secret to create
+                        Defaults to the GarageAdminToken name
+                      type: string
+                    tokenKey:
+                      default: admin-token
+                      description: TokenKey is the key name for the admin token in the secret
+                      type: string
+                  type: object
+              required:
+                - clusterRef
+              type: object
+            status:
+              description: GarageAdminTokenStatus defines the observed state of GarageAdminToken
+              properties:
+                conditions:
+                  description: Conditions represent the current state
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                expiresAt:
+                  description: ExpiresAt is when this token expires (if set)
+                  format: date-time
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation
+                  format: int64
+                  type: integer
+                phase:
+                  description: Phase represents the current phase
+                  enum:
+                    - Pending
+                    - Creating
+                    - Ready
+                    - Deleting
+                    - Failed
+                    - Expired
+                    - Unknown
+                  type: string
+                secretRef:
+                  description: SecretRef references the created secret
+                  properties:
+                    name:
+                      description: name is unique within a namespace to reference a secret resource.
+                      type: string
+                    namespace:
+                      description: namespace defines the space within which the secret name must be unique.
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                tokenId:
+                  description: TokenID is the Garage-assigned token ID (first 8 chars)
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-garagebuckets-garage-rajsingh-info.yaml
+++ b/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-garagebuckets-garage-rajsingh-info.yaml
@@ -1,0 +1,892 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/instance: garage-operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: garage-operator
+    app.kubernetes.io/version: 0.6.2
+    control-plane: controller-manager
+    helm.sh/chart: garage-operator-0.6.2
+  name: garagebuckets.garage.rajsingh.info
+spec:
+  group: garage.rajsingh.info
+  names:
+    kind: GarageBucket
+    listKind: GarageBucketList
+    plural: garagebuckets
+    shortNames:
+      - gb
+    singular: garagebucket
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.clusterRef.name
+          name: Cluster
+          type: string
+        - jsonPath: .status.globalAlias
+          name: Alias
+          type: string
+        - jsonPath: .status.size
+          name: Size
+          type: string
+        - jsonPath: .status.objectCount
+          name: Objects
+          type: integer
+        - jsonPath: .status.websiteEnabled
+          name: Website
+          type: boolean
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: GarageBucket is the Schema for the garagebuckets API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: GarageBucketSpec defines the desired state of GarageBucket
+              properties:
+                clusterRef:
+                  description: ClusterRef references the GarageCluster this bucket belongs to
+                  properties:
+                    kubeConfigSecretRef:
+                      description: |-
+                        KubeConfigSecretRef references a secret containing kubeconfig for a remote cluster.
+                        Only used for cross-cluster references in multi-cluster federation scenarios.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    name:
+                      description: Name of the GarageCluster
+                      type: string
+                    namespace:
+                      description: Namespace of the GarageCluster (defaults to the same namespace as the referencing resource)
+                      type: string
+                  required:
+                    - name
+                  type: object
+                globalAlias:
+                  description: |-
+                    GlobalAlias is the global alias for this bucket (optional)
+                    If not set, the bucket name from metadata.name is used
+                  type: string
+                keyPermissions:
+                  description: |-
+                    KeyPermissions grants access to specific GarageKeys.
+
+                    Note: Permissions can be granted from either direction:
+                    - Here (GarageBucket.keyPermissions): Grant keys access to this bucket
+                    - On GarageKey (GarageKey.bucketPermissions): Grant the key access to buckets
+
+                    Both approaches are equivalent and result in the same Garage API calls.
+                    Use whichever is more convenient for your workflow:
+                    - Bucket-centric: Define all key access on the bucket
+                    - Key-centric: Define all bucket access on the key
+
+                    If the same permission is defined in both places, they are merged (not conflicting).
+                  items:
+                    description: KeyPermission grants access to a key
+                    properties:
+                      keyRef:
+                        description: KeyRef references the GarageKey by name
+                        type: string
+                      owner:
+                        description: Owner allows bucket owner operations
+                        type: boolean
+                      read:
+                        description: Read allows reading objects
+                        type: boolean
+                      write:
+                        description: Write allows writing objects
+                        type: boolean
+                    required:
+                      - keyRef
+                    type: object
+                  type: array
+                localAliases:
+                  description: LocalAliases are per-key local aliases for this bucket
+                  items:
+                    description: LocalAlias represents a per-key local alias for a bucket
+                    properties:
+                      alias:
+                        description: Alias is the local alias name
+                        type: string
+                      keyRef:
+                        description: KeyRef references the GarageKey
+                        type: string
+                    required:
+                      - alias
+                      - keyRef
+                    type: object
+                  type: array
+                quotas:
+                  description: Quotas configures bucket quotas
+                  properties:
+                    maxObjects:
+                      description: MaxObjects is the maximum number of objects
+                      format: int64
+                      type: integer
+                    maxSize:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: MaxSize is the maximum bucket size in bytes
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                website:
+                  description: |-
+                    Website configures static website hosting for this bucket.
+                    Note: Only indexDocument and errorDocument are supported via the Admin API.
+                    For advanced features (routing rules, redirectAll), use S3 PutBucketWebsite API directly.
+                  properties:
+                    enabled:
+                      description: Enabled enables static website hosting
+                      type: boolean
+                    errorDocument:
+                      description: ErrorDocument is the error document to serve for 404s
+                      type: string
+                    indexDocument:
+                      default: index.html
+                      description: 'IndexDocument is the default index document (default: index.html)'
+                      type: string
+                  type: object
+              required:
+                - clusterRef
+              type: object
+            status:
+              description: GarageBucketStatus defines the observed state of GarageBucket
+              properties:
+                bucketId:
+                  description: BucketID is the internal Garage bucket ID
+                  type: string
+                conditions:
+                  description: Conditions represent the current state
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                createdAt:
+                  description: CreatedAt is when the bucket was created in Garage
+                  format: date-time
+                  type: string
+                globalAlias:
+                  description: GlobalAlias is the assigned global alias
+                  type: string
+                incompleteUploadBytes:
+                  description: IncompleteUploadBytes is the total bytes in incomplete multipart uploads
+                  format: int64
+                  type: integer
+                incompleteUploadParts:
+                  description: IncompleteUploadParts is the count of parts in incomplete multipart uploads
+                  format: int64
+                  type: integer
+                incompleteUploads:
+                  description: IncompleteUploads is the count of incomplete multipart uploads
+                  format: int64
+                  type: integer
+                keys:
+                  description: Keys contains keys with access to this bucket
+                  items:
+                    description: BucketKeyStatus shows key access status
+                    properties:
+                      keyId:
+                        description: KeyID is the access key ID
+                        type: string
+                      name:
+                        description: Name is the key name
+                        type: string
+                      permissions:
+                        description: Permissions granted to this key
+                        properties:
+                          owner:
+                            description: Owner permission
+                            type: boolean
+                          read:
+                            description: Read permission
+                            type: boolean
+                          write:
+                            description: Write permission
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                localAliases:
+                  description: LocalAliases tracks per-key local aliases for this bucket
+                  items:
+                    description: LocalAliasStatus shows the status of a local alias for this bucket
+                    properties:
+                      alias:
+                        description: Alias is the local alias name
+                        type: string
+                      keyId:
+                        description: KeyID is the access key ID that owns this alias
+                        type: string
+                      keyName:
+                        description: KeyName is the friendly name of the key
+                        type: string
+                    type: object
+                  type: array
+                objectCount:
+                  description: ObjectCount is the current object count
+                  format: int64
+                  type: integer
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation
+                  format: int64
+                  type: integer
+                phase:
+                  description: Phase represents the current phase
+                  type: string
+                quotaUsage:
+                  description: QuotaUsage shows current quota consumption
+                  properties:
+                    objectCount:
+                      description: ObjectCount is the current object count
+                      format: int64
+                      type: integer
+                    objectLimit:
+                      description: ObjectLimit is the configured object limit (0 = unlimited)
+                      format: int64
+                      type: integer
+                    objectPercent:
+                      description: ObjectPercent is the percentage of object quota used
+                      format: int32
+                      type: integer
+                    sizeBytes:
+                      description: SizeBytes is the current size in bytes
+                      format: int64
+                      type: integer
+                    sizeLimit:
+                      description: SizeLimit is the configured size limit in bytes (0 = unlimited)
+                      format: int64
+                      type: integer
+                    sizePercent:
+                      description: SizePercent is the percentage of size quota used
+                      format: int32
+                      type: integer
+                  type: object
+                size:
+                  description: Size is the current bucket size
+                  type: string
+                websiteConfig:
+                  description: WebsiteConfig shows the current website configuration details
+                  properties:
+                    errorDocument:
+                      description: ErrorDocument is the configured error document
+                      type: string
+                    indexDocument:
+                      description: IndexDocument is the configured index document
+                      type: string
+                  type: object
+                websiteEnabled:
+                  description: WebsiteEnabled indicates if website hosting is currently enabled
+                  type: boolean
+                websiteUrl:
+                  description: WebsiteURL is the computed website URL (if website hosting is enabled)
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.clusterRef.name
+          name: Cluster
+          type: string
+        - jsonPath: .status.globalAlias
+          name: Alias
+          type: string
+        - jsonPath: .status.size
+          name: Size
+          type: string
+        - jsonPath: .status.quotaUsage.objectCount
+          name: Objects
+          type: integer
+        - jsonPath: .status.websiteEnabled
+          name: Website
+          type: boolean
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: GarageBucket is the Schema for the garagebuckets API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: GarageBucketSpec defines the desired state of GarageBucket
+              properties:
+                bucketId:
+                  description: |-
+                    BucketID pins this resource to a pre-existing Garage bucket ID.
+                    When set, the operator will never create a new bucket — it only manages
+                    settings and key permissions for the identified bucket. Takes priority
+                    over GlobalAlias-based lookup. Useful for importing existing buckets and
+                    for recovery after cluster incidents.
+                  type: string
+                clusterRef:
+                  description: ClusterRef references the GarageCluster this bucket belongs to
+                  properties:
+                    kubeConfigSecretRef:
+                      description: |-
+                        KubeConfigSecretRef references a secret containing a kubeconfig for a remote Kubernetes cluster.
+                        Only needed for multi-cluster federation where the GarageCluster lives in a different
+                        Kubernetes cluster entirely (not just a different namespace).
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    name:
+                      description: Name of the GarageCluster resource.
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the GarageCluster. Defaults to the referencing resource's namespace.
+                        Cross-namespace references require a GarageReferenceGrant in the target namespace.
+                        Not supported on GarageNode.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                globalAlias:
+                  description: |-
+                    GlobalAlias is the global alias for this bucket (optional)
+                    If not set, the bucket name from metadata.name is used
+                  type: string
+                keyPermissions:
+                  description: |-
+                    KeyPermissions grants access to specific GarageKeys.
+
+                    Note: Permissions can be granted from either direction:
+                    - Here (GarageBucket.keyPermissions): Grant keys access to this bucket
+                    - On GarageKey (GarageKey.bucketPermissions): Grant the key access to buckets
+
+                    Both approaches are equivalent and result in the same Garage API calls.
+                    Use whichever is more convenient for your workflow:
+                    - Bucket-centric: Define all key access on the bucket
+                    - Key-centric: Define all bucket access on the key
+
+                    If the same permission is defined in both places, they are merged (not conflicting).
+                  items:
+                    description: KeyPermission grants access to a key
+                    properties:
+                      keyRef:
+                        description: KeyRef references the GarageKey by name (and optionally namespace).
+                        properties:
+                          name:
+                            description: Name of the GarageKey.
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the GarageKey. Defaults to the GarageBucket's namespace.
+                              Cross-namespace references require a GarageReferenceGrant in the target namespace.
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      owner:
+                        description: Owner allows bucket owner operations
+                        type: boolean
+                      read:
+                        description: Read allows reading objects
+                        type: boolean
+                      write:
+                        description: Write allows writing objects
+                        type: boolean
+                    required:
+                      - keyRef
+                    type: object
+                  type: array
+                lifecycle:
+                  description: |-
+                    Lifecycle configures bucket lifecycle policies (object expiration,
+                    abort of incomplete multipart uploads).
+
+                    Garage exposes lifecycle only via the S3 API, not the admin API. The
+                    operator applies rules using an internal access key it manages per
+                    GarageCluster. Garage supports a strict subset of the AWS S3 lifecycle
+                    spec: only Expiration (days or date, no ExpiredObjectDeleteMarker) and
+                    AbortIncompleteMultipartUpload. Filters support prefix and object size
+                    bounds; tag filters and the deprecated rule-level Prefix are not
+                    accepted.
+
+                    Garage's lifecycle worker runs daily at midnight (UTC by default), so
+                    rule evaluation is asynchronous from reconciliation.
+                  properties:
+                    rules:
+                      description: |-
+                        Rules to apply. The operator replaces the bucket's lifecycle
+                        configuration with this exact set on each reconcile.
+                      items:
+                        description: |-
+                          LifecycleRule is a single lifecycle rule. At least one action
+                          (ExpirationDays, ExpirationDate, AbortIncompleteMultipartUploadDays)
+                          must be set. ExpirationDays and ExpirationDate are mutually exclusive.
+                        properties:
+                          abortIncompleteMultipartUploadDays:
+                            description: |-
+                              AbortIncompleteMultipartUploadDays aborts multipart uploads that have
+                              been pending for at least this many days.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          expirationDate:
+                            description: ExpirationDate expires current objects on or after this UTC date.
+                            format: date-time
+                            type: string
+                          expirationDays:
+                            description: ExpirationDays expires current objects this many days after creation.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          filter:
+                            description: |-
+                              Filter narrows the rule to a subset of objects. If unset, the rule
+                              applies to every object in the bucket.
+                            properties:
+                              objectSizeGreaterThan:
+                                description: |-
+                                  ObjectSizeGreaterThan matches objects strictly larger than this many
+                                  bytes.
+                                format: int64
+                                minimum: 0
+                                type: integer
+                              objectSizeLessThan:
+                                description: |-
+                                  ObjectSizeLessThan matches objects strictly smaller than this many
+                                  bytes.
+                                format: int64
+                                minimum: 1
+                                type: integer
+                              prefix:
+                                description: Prefix matches object keys starting with this string.
+                                type: string
+                            type: object
+                          id:
+                            description: ID is the rule identifier. Must be unique within the bucket.
+                            minLength: 1
+                            type: string
+                          status:
+                            default: Enabled
+                            description: |-
+                              Status enables or disables this rule. Disabled rules are sent to
+                              Garage but skipped by the lifecycle worker.
+                            enum:
+                              - Enabled
+                              - Disabled
+                            type: string
+                        required:
+                          - id
+                        type: object
+                      type: array
+                  type: object
+                localAliases:
+                  description: LocalAliases are per-key local aliases for this bucket
+                  items:
+                    description: |-
+                      LocalAlias is a bucket alias that is only visible to a specific key.
+                      Unlike global aliases (which any key can use), a local alias is scoped to one key —
+                      useful when different teams share the same Garage cluster but use different bucket names.
+                      The alias is accessible via S3 as a bucket name when authenticated with that key.
+                    properties:
+                      alias:
+                        description: |-
+                          Alias is the bucket name this key will use to access the bucket.
+                          Must be unique within the key's alias namespace.
+                        type: string
+                      keyRef:
+                        description: KeyRef is the name of the GarageKey in the same namespace that owns this alias.
+                        type: string
+                    required:
+                      - alias
+                      - keyRef
+                    type: object
+                  type: array
+                quotas:
+                  description: Quotas configures bucket quotas
+                  properties:
+                    maxObjects:
+                      description: MaxObjects is the maximum number of objects
+                      format: int64
+                      type: integer
+                    maxSize:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: MaxSize is the maximum bucket size in bytes
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                website:
+                  description: |-
+                    Website configures static website hosting for this bucket.
+                    Note: Only indexDocument and errorDocument are supported via the Admin API.
+                    For advanced features (routing rules, redirectAll), use S3 PutBucketWebsite API directly.
+                  properties:
+                    enabled:
+                      description: Enabled enables static website hosting.
+                      type: boolean
+                    errorDocument:
+                      description: ErrorDocument is the error document to serve for 404s
+                      type: string
+                    indexDocument:
+                      default: index.html
+                      description: 'IndexDocument is the default index document (default: index.html)'
+                      type: string
+                  type: object
+              required:
+                - clusterRef
+              type: object
+            status:
+              description: GarageBucketStatus defines the observed state of GarageBucket
+              properties:
+                bucketId:
+                  description: BucketID is the internal Garage bucket ID
+                  type: string
+                conditions:
+                  description: Conditions represent the current state
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                createdAt:
+                  description: CreatedAt is when the bucket was created in Garage
+                  format: date-time
+                  type: string
+                globalAlias:
+                  description: GlobalAlias is the assigned global alias
+                  type: string
+                incompleteUploadBytes:
+                  description: IncompleteUploadBytes is the total bytes in incomplete multipart uploads
+                  format: int64
+                  type: integer
+                incompleteUploadParts:
+                  description: IncompleteUploadParts is the count of parts in incomplete multipart uploads
+                  format: int64
+                  type: integer
+                incompleteUploads:
+                  description: IncompleteUploads is the count of incomplete multipart uploads
+                  format: int64
+                  type: integer
+                keys:
+                  description: Keys contains keys with access to this bucket
+                  items:
+                    description: BucketKeyStatus shows key access status
+                    properties:
+                      keyId:
+                        description: KeyID is the access key ID
+                        type: string
+                      name:
+                        description: Name is the key name
+                        type: string
+                      permissions:
+                        description: Permissions granted to this key
+                        properties:
+                          owner:
+                            description: Owner permission
+                            type: boolean
+                          read:
+                            description: Read permission
+                            type: boolean
+                          write:
+                            description: Write permission
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                lifecycleRules:
+                  description: |-
+                    LifecycleRules summarises lifecycle rules currently applied to the
+                    bucket in Garage. Spec is the source of truth for rule contents; this
+                    list reports id and enabled state only.
+                  items:
+                    description: |-
+                      LifecycleRuleStatus reports the id and enabled state of a lifecycle rule
+                      currently applied to the bucket.
+                    properties:
+                      id:
+                        description: ID of the rule.
+                        type: string
+                      status:
+                        description: Status is Enabled or Disabled.
+                        enum:
+                          - Enabled
+                          - Disabled
+                        type: string
+                    required:
+                      - id
+                      - status
+                    type: object
+                  type: array
+                localAliases:
+                  description: LocalAliases tracks per-key local aliases for this bucket
+                  items:
+                    description: LocalAliasStatus shows the status of a local alias for this bucket
+                    properties:
+                      alias:
+                        description: Alias is the local alias name
+                        type: string
+                      keyId:
+                        description: KeyID is the access key ID that owns this alias
+                        type: string
+                      keyName:
+                        description: KeyName is the friendly name of the key
+                        type: string
+                    type: object
+                  type: array
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation
+                  format: int64
+                  type: integer
+                phase:
+                  description: Phase represents the current phase
+                  enum:
+                    - Pending
+                    - Creating
+                    - Ready
+                    - Deleting
+                    - Failed
+                    - Unknown
+                  type: string
+                quotaUsage:
+                  description: QuotaUsage shows current quota consumption
+                  properties:
+                    objectCount:
+                      description: ObjectCount is the current object count
+                      format: int64
+                      type: integer
+                    objectLimit:
+                      description: ObjectLimit is the configured object limit (0 = unlimited)
+                      format: int64
+                      type: integer
+                    objectPercent:
+                      description: ObjectPercent is the percentage of object quota used
+                      format: int32
+                      type: integer
+                    sizeBytes:
+                      description: SizeBytes is the current size in bytes
+                      format: int64
+                      type: integer
+                    sizeLimit:
+                      description: SizeLimit is the configured size limit in bytes (0 = unlimited)
+                      format: int64
+                      type: integer
+                    sizePercent:
+                      description: SizePercent is the percentage of size quota used
+                      format: int32
+                      type: integer
+                  type: object
+                size:
+                  description: Size is the current bucket size
+                  type: string
+                websiteConfig:
+                  description: WebsiteConfig shows the current website configuration details
+                  properties:
+                    errorDocument:
+                      description: ErrorDocument is the configured error document
+                      type: string
+                    indexDocument:
+                      description: IndexDocument is the configured index document
+                      type: string
+                  type: object
+                websiteEnabled:
+                  description: WebsiteEnabled indicates if website hosting is currently enabled
+                  type: boolean
+                websiteUrl:
+                  description: WebsiteURL is the computed website URL (if website hosting is enabled)
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-garageclusters-garage-rajsingh-info.yaml
+++ b/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-garageclusters-garage-rajsingh-info.yaml
@@ -1,0 +1,11533 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/instance: garage-operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: garage-operator
+    app.kubernetes.io/version: 0.6.2
+    control-plane: controller-manager
+    helm.sh/chart: garage-operator-0.6.2
+  name: garageclusters.garage.rajsingh.info
+spec:
+  group: garage.rajsingh.info
+  names:
+    kind: GarageCluster
+    listKind: GarageClusterList
+    plural: garageclusters
+    shortNames:
+      - gc
+    singular: garagecluster
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: false
+      storage: false
+    - additionalPrinterColumns:
+        - jsonPath: .spec.replicas
+          name: Replicas
+          type: integer
+        - jsonPath: .status.readyReplicas
+          name: Ready
+          type: integer
+        - jsonPath: .spec.zone
+          name: Zone
+          type: string
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      deprecated: true
+      deprecationWarning: garage.rajsingh.info/v1beta1 GarageCluster is deprecated; migrate to garage.rajsingh.info/v1beta2
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            GarageCluster is the Schema for the garageclusters API.
+
+            Deprecated: v1beta1 is retained for read-only access via the conversion
+            webhook. New CRs should use garage.rajsingh.info/v1beta2 which supports
+            the storage + gateway tier-based schema.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: GarageClusterSpec defines the desired state of GarageCluster
+              properties:
+                admin:
+                  description: Admin configures the admin API endpoint and metrics
+                  properties:
+                    adminTokenSecretRef:
+                      description: |-
+                        AdminTokenSecretRef references the secret the operator uses to authenticate
+                        with Garage's Admin API. The operator reads this token to manage buckets, keys,
+                        and layout on behalf of GarageBucket/GarageKey/GarageNode resources.
+                        Required for gateway clusters that use connectTo — the operator needs admin API
+                        access to issue ConnectNode commands. If omitted for storage clusters, layout
+                        management and bucket/key reconciliation are unavailable.
+                        Use GarageAdminToken to create tokens for external tooling; this field is
+                        specifically for the operator's own access.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    bindAddress:
+                      description: |-
+                        BindAddress is a custom bind address for the Admin API.
+                        Can be a TCP address or Unix socket path (e.g., "unix:///run/garage/admin.sock").
+                        If set, this overrides BindPort.
+                      type: string
+                    bindPort:
+                      default: 3903
+                      description: BindPort is the port to bind for admin API
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    metricsRequireToken:
+                      description: |-
+                        MetricsRequireToken requires Bearer token authentication for the /metrics endpoint.
+                        When true, Prometheus scrape configs must include the token from metricsTokenSecretRef.
+                      type: boolean
+                    metricsTokenSecretRef:
+                      description: |-
+                        MetricsTokenSecretRef references a secret containing a token that protects
+                        the /metrics endpoint. Only used when metricsRequireToken is true.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    traceSink:
+                      description: |-
+                        TraceSink is the OpenTelemetry collector address for tracing
+                        Example: "http://localhost:4317"
+                      type: string
+                  type: object
+                affinity:
+                  description: Affinity for pod scheduling
+                  properties:
+                    nodeAffinity:
+                      description: Describes node affinity scheduling rules for the pod.
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: |-
+                            The scheduler will prefer to schedule pods to nodes that satisfy
+                            the affinity expressions specified by this field, but it may choose
+                            a node that violates one or more of the expressions. The node that is
+                            most preferred is the one with the greatest sum of weights, i.e.
+                            for each node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling affinity expressions, etc.),
+                            compute a sum by iterating through the elements of this field and adding
+                            "weight" to the sum if the node matches the corresponding matchExpressions; the
+                            node(s) with the highest sum are the most preferred.
+                          items:
+                            description: |-
+                              An empty preferred scheduling term matches all objects with implicit weight 0
+                              (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                            properties:
+                              preference:
+                                description: A node selector term, associated with the corresponding weight.
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements by node's labels.
+                                    items:
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchFields:
+                                    description: A list of node selector requirements by node's fields.
+                                    items:
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              weight:
+                                description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - preference
+                              - weight
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: |-
+                            If the affinity requirements specified by this field are not met at
+                            scheduling time, the pod will not be scheduled onto the node.
+                            If the affinity requirements specified by this field cease to be met
+                            at some point during pod execution (e.g. due to an update), the system
+                            may or may not try to eventually evict the pod from its node.
+                          properties:
+                            nodeSelectorTerms:
+                              description: Required. A list of node selector terms. The terms are ORed.
+                              items:
+                                description: |-
+                                  A null or empty node selector term matches no objects. The requirements of
+                                  them are ANDed.
+                                  The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements by node's labels.
+                                    items:
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchFields:
+                                    description: A list of node selector requirements by node's fields.
+                                    items:
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - nodeSelectorTerms
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    podAffinity:
+                      description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: |-
+                            The scheduler will prefer to schedule pods to nodes that satisfy
+                            the affinity expressions specified by this field, but it may choose
+                            a node that violates one or more of the expressions. The node that is
+                            most preferred is the one with the greatest sum of weights, i.e.
+                            for each node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling affinity expressions, etc.),
+                            compute a sum by iterating through the elements of this field and adding
+                            "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                            node(s) with the highest sum are the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  topologyKey:
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                description: |-
+                                  weight associated with matching the corresponding podAffinityTerm,
+                                  in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: |-
+                            If the affinity requirements specified by this field are not met at
+                            scheduling time, the pod will not be scheduled onto the node.
+                            If the affinity requirements specified by this field cease to be met
+                            at some point during pod execution (e.g. due to a pod label update), the
+                            system may or may not try to eventually evict the pod from its node.
+                            When there are multiple elements, the lists of nodes corresponding to each
+                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                          items:
+                            description: |-
+                              Defines a set of pods (namely those matching the labelSelector
+                              relative to the given namespace(s)) that this pod should be
+                              co-located (affinity) or not co-located (anti-affinity) with,
+                              where co-located is defined as running on a node whose value of
+                              the label with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: |-
+                                  A label query over a set of resources, in this case pods.
+                                  If it's null, this PodAffinityTerm matches with no Pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                description: |-
+                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mismatchLabelKeys:
+                                description: |-
+                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              namespaceSelector:
+                                description: |-
+                                  A label query over the set of namespaces that the term applies to.
+                                  The term is applied to the union of the namespaces selected by this field
+                                  and the ones listed in the namespaces field.
+                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                  An empty selector ({}) matches all namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaces:
+                                description: |-
+                                  namespaces specifies a static list of namespace names that the term applies to.
+                                  The term is applied to the union of the namespaces listed in this field
+                                  and the ones selected by namespaceSelector.
+                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              topologyKey:
+                                description: |-
+                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                  selected pods is running.
+                                  Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    podAntiAffinity:
+                      description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: |-
+                            The scheduler will prefer to schedule pods to nodes that satisfy
+                            the anti-affinity expressions specified by this field, but it may choose
+                            a node that violates one or more of the expressions. The node that is
+                            most preferred is the one with the greatest sum of weights, i.e.
+                            for each node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling anti-affinity expressions, etc.),
+                            compute a sum by iterating through the elements of this field and subtracting
+                            "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                            node(s) with the highest sum are the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  topologyKey:
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                description: |-
+                                  weight associated with matching the corresponding podAffinityTerm,
+                                  in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: |-
+                            If the anti-affinity requirements specified by this field are not met at
+                            scheduling time, the pod will not be scheduled onto the node.
+                            If the anti-affinity requirements specified by this field cease to be met
+                            at some point during pod execution (e.g. due to a pod label update), the
+                            system may or may not try to eventually evict the pod from its node.
+                            When there are multiple elements, the lists of nodes corresponding to each
+                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                          items:
+                            description: |-
+                              Defines a set of pods (namely those matching the labelSelector
+                              relative to the given namespace(s)) that this pod should be
+                              co-located (affinity) or not co-located (anti-affinity) with,
+                              where co-located is defined as running on a node whose value of
+                              the label with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: |-
+                                  A label query over a set of resources, in this case pods.
+                                  If it's null, this PodAffinityTerm matches with no Pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                description: |-
+                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mismatchLabelKeys:
+                                description: |-
+                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              namespaceSelector:
+                                description: |-
+                                  A label query over the set of namespaces that the term applies to.
+                                  The term is applied to the union of the namespaces selected by this field
+                                  and the ones listed in the namespaces field.
+                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                  An empty selector ({}) matches all namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaces:
+                                description: |-
+                                  namespaces specifies a static list of namespace names that the term applies to.
+                                  The term is applied to the union of the namespaces listed in this field
+                                  and the ones selected by namespaceSelector.
+                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              topologyKey:
+                                description: |-
+                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                  selected pods is running.
+                                  Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                  type: object
+                blocks:
+                  description: Blocks configures block storage settings
+                  properties:
+                    compressionLevel:
+                      description: |-
+                        CompressionLevel is the zstd compression level
+                        1-19: standard, 20-22: ultra, -1 to -99: fast, "none": disabled
+                      pattern: ^(none|-?[1-9][0-9]*)$
+                      type: string
+                    disableScrub:
+                      description: DisableScrub disables automatic monthly data directory scrub
+                      type: boolean
+                    maxConcurrentReads:
+                      description: MaxConcurrentReads is the maximum simultaneous block file reads
+                      minimum: 1
+                      type: integer
+                    maxConcurrentWritesPerRequest:
+                      description: |-
+                        MaxConcurrentWritesPerRequest is the maximum parallel block writes per PUT request.
+                        Higher values improve throughput but increase memory usage.
+                        Default: 3. Recommended: 10-30 for NVMe, 3-10 for HDD.
+                        Added in Garage v2.2.0.
+                      minimum: 1
+                      type: integer
+                    ramBufferMax:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: RAMBufferMax is the maximum RAM for buffering blocks
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    size:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: 'Size is the size of data blocks (default: 1M)'
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    useLocalTZ:
+                      description: UseLocalTZ runs lifecycle worker at midnight in local timezone
+                      type: boolean
+                  type: object
+                capacityReservePercent:
+                  description: |-
+                    CapacityReservePercent reserves a percentage of PVC capacity for overhead.
+                    Only used when LayoutPolicy is "Auto".
+                    For example, setting this to 10 will report 90% of PVC size as node capacity.
+                    This is useful to reserve headroom for filesystem overhead, snapshots, or growth.
+                    Default: 0 (use full PVC size as capacity)
+                  maximum: 50
+                  minimum: 0
+                  type: integer
+                connectTo:
+                  description: |-
+                    ConnectTo specifies the storage cluster this gateway cluster connects to.
+                    Required when gateway=true. The gateway cluster will:
+                    - Use the same RPC secret as the storage cluster
+                    - Connect to the storage cluster's nodes
+                    - Register its pods as gateway nodes in the storage cluster's layout
+                  properties:
+                    adminApiEndpoint:
+                      description: |-
+                        AdminAPIEndpoint is the storage cluster's Admin API URL.
+                        Used by the operator to discover nodes and register this gateway's pods.
+                        Required when clusterRef is not set or is in a different namespace.
+                        Example: "http://garage-storage.other-namespace:3903"
+                      type: string
+                    adminTokenSecretRef:
+                      description: |-
+                        AdminTokenSecretRef references the storage cluster's admin token.
+                        Required when adminApiEndpoint is set and the storage cluster requires auth.
+                        If clusterRef is in the same namespace, the operator reads the token automatically.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    bootstrapPeers:
+                      description: |-
+                        BootstrapPeers are initial peers for cluster formation.
+                        Required when clusterRef is not set (the operator can't auto-discover peers).
+                        Format: "<64-hex-node-id>@<ip_or_hostname>:<port>"
+                      items:
+                        type: string
+                      type: array
+                    clusterRef:
+                      description: |-
+                        ClusterRef references a GarageCluster in the same namespace.
+                        When set, the operator automatically reads the RPC secret and admin token from
+                        the referenced cluster — no need to set rpcSecretRef or adminTokenSecretRef.
+                      properties:
+                        kubeConfigSecretRef:
+                          description: |-
+                            KubeConfigSecretRef references a secret containing a kubeconfig for a remote Kubernetes cluster.
+                            Only needed for multi-cluster federation where the GarageCluster lives in a different
+                            Kubernetes cluster entirely (not just a different namespace).
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        name:
+                          description: Name of the GarageCluster resource.
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the GarageCluster. Defaults to the referencing resource's namespace.
+                            Cross-namespace references require a GarageReferenceGrant in the target namespace.
+                            Not supported on GarageNode.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    rpcSecretRef:
+                      description: |-
+                        RPCSecretRef references a secret containing the shared RPC secret.
+                        Required when clusterRef is not set or references a different namespace.
+                        The secret must have a key with a 32-byte hex-encoded value.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                containerSecurityContext:
+                  description: ContainerSecurityContext for Garage containers
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: |-
+                        AllowPrivilegeEscalation controls whether a process can gain more
+                        privileges than its parent process. This bool directly controls if
+                        the no_new_privs flag will be set on the container process.
+                        AllowPrivilegeEscalation is true always when the container is:
+                        1) run as Privileged
+                        2) has CAP_SYS_ADMIN
+                        Note that this field cannot be set when spec.os.name is windows.
+                      type: boolean
+                    appArmorProfile:
+                      description: |-
+                        appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                        overrides the pod's appArmorProfile.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: |-
+                            localhostProfile indicates a profile loaded on the node that should be used.
+                            The profile must be preconfigured on the node to work.
+                            Must match the loaded name of the profile.
+                            Must be set if and only if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of AppArmor profile will be applied.
+                            Valid options are:
+                              Localhost - a profile pre-loaded on the node.
+                              RuntimeDefault - the container runtime's default profile.
+                              Unconfined - no AppArmor enforcement.
+                          type: string
+                      required:
+                        - type
+                      type: object
+                    capabilities:
+                      description: |-
+                        The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the container runtime.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            description: Capability represent POSIX capabilities type
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            description: Capability represent POSIX capabilities type
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    privileged:
+                      description: |-
+                        Run container in privileged mode.
+                        Processes in privileged containers are essentially equivalent to root on the host.
+                        Defaults to false.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      type: boolean
+                    procMount:
+                      description: |-
+                        procMount denotes the type of proc mount to use for the containers.
+                        The default value is Default which uses the container runtime defaults for
+                        readonly paths and masked paths.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: |-
+                        Whether this container has a read-only root filesystem.
+                        Default is false.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      type: boolean
+                    runAsGroup:
+                      description: |-
+                        The GID to run the entrypoint of the container process.
+                        Uses runtime default if unset.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: |-
+                        Indicates that the container must run as a non-root user.
+                        If true, the Kubelet will validate the image at runtime to ensure that it
+                        does not run as UID 0 (root) and fail to start the container if it does.
+                        If unset or false, no such validation will be performed.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: |-
+                        The UID to run the entrypoint of the container process.
+                        Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: |-
+                        The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random SELinux context for each
+                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: |-
+                        The seccomp options to use by this container. If seccomp options are
+                        provided at both the pod & container level, the container options
+                        override the pod options.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: |-
+                            localhostProfile indicates a profile defined in a file on the node should be used.
+                            The profile must be preconfigured on the node to work.
+                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                            Must be set if type is "Localhost". Must NOT be set for any other type.
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied.
+                            Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used.
+                            RuntimeDefault - the container runtime default profile should be used.
+                            Unconfined - no profile should be applied.
+                          type: string
+                      required:
+                        - type
+                      type: object
+                    windowsOptions:
+                      description: |-
+                        The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will be used.
+                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is linux.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: |-
+                            GMSACredentialSpec is where the GMSA admission webhook
+                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                            GMSA credential spec named by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: |-
+                            HostProcess determines if a container should be run as a 'Host Process' container.
+                            All of a Pod's containers must have the same effective HostProcess value
+                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                            In addition, if HostProcess is true then HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: |-
+                            The UserName in Windows to run the entrypoint of the container process.
+                            Defaults to the user specified in image metadata if unspecified.
+                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                database:
+                  description: Database configures the metadata database engine
+                  properties:
+                    engine:
+                      default: lmdb
+                      description: Engine specifies the database engine to use
+                      enum:
+                        - lmdb
+                        - sqlite
+                        - fjall
+                      type: string
+                    fjallBlockCacheSize:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: FjallBlockCacheSize is the block cache size for Fjall
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    lmdbMapSize:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: LMDBMapSize is the virtual memory region size for LMDB
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                defaultNodeTags:
+                  description: |-
+                    DefaultNodeTags are tags applied to all auto-managed nodes.
+                    Only used when LayoutPolicy is "Auto".
+                    For per-node tags, use LayoutPolicy "Manual" with GarageNode resources.
+                  items:
+                    type: string
+                  type: array
+                discovery:
+                  description: Discovery configures peer discovery mechanisms
+                  properties:
+                    consul:
+                      description: Consul configures Consul-based peer discovery
+                      properties:
+                        api:
+                          default: catalog
+                          description: API specifies the service registration API ("catalog" or "agent")
+                          enum:
+                            - catalog
+                            - agent
+                          type: string
+                        caCert:
+                          description: CACert is the CA certificate for TLS connection
+                          type: string
+                        caCertSecretRef:
+                          description: CACertSecretRef references a secret containing the CA certificate
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        clientCertSecretRef:
+                          description: ClientCertSecretRef references a secret containing client TLS cert
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        clientKeySecretRef:
+                          description: ClientKeySecretRef references a secret containing client TLS key
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        datacenters:
+                          description: Datacenters for WAN federation
+                          items:
+                            type: string
+                          type: array
+                        enabled:
+                          description: Enabled enables Consul-based discovery
+                          type: boolean
+                        httpAddr:
+                          description: HTTPAddr is the full HTTP(S) address of Consul server
+                          type: string
+                        meta:
+                          additionalProperties:
+                            type: string
+                          description: Meta is service metadata key-value pairs
+                          type: object
+                        serviceName:
+                          description: ServiceName for Garage RPC port registration
+                          type: string
+                        tags:
+                          description: Tags are additional service tags
+                          items:
+                            type: string
+                          type: array
+                        tlsSkipVerify:
+                          description: TLSSkipVerify skips TLS hostname verification
+                          type: boolean
+                        tokenSecretRef:
+                          description: TokenSecretRef references a secret containing the bearer token
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    kubernetes:
+                      description: Kubernetes configures Kubernetes-based peer discovery
+                      properties:
+                        enabled:
+                          description: Enabled enables Kubernetes-based discovery
+                          type: boolean
+                        namespace:
+                          description: Namespace for Garage custom resources
+                          type: string
+                        serviceName:
+                          description: ServiceName label to filter custom resources
+                          type: string
+                        skipCRD:
+                          description: SkipCRD skips automatic CRD creation/patching
+                          type: boolean
+                      type: object
+                  type: object
+                gateway:
+                  description: |-
+                    Gateway marks this cluster as a gateway-only cluster.
+                    Gateway clusters don't store data - they only handle API requests.
+                    When true:
+                    - Creates a StatefulSet with metadata PVC only (for node identity persistence)
+                    - Data storage uses EmptyDir (gateways don't store blocks)
+                    - Pods are registered as gateway nodes in the layout (capacity=null)
+                    - Must specify connectTo to reference a storage cluster
+                  type: boolean
+                image:
+                  default: dxflrs/garage:v2.3.0
+                  description: |-
+                    Image specifies the Garage container image to use.
+                    Takes precedence over imageRepository if both are set.
+                  type: string
+                imagePullPolicy:
+                  default: IfNotPresent
+                  description: ImagePullPolicy specifies the image pull policy
+                  type: string
+                imagePullSecrets:
+                  description: ImagePullSecrets specifies secrets for pulling images from private registries
+                  items:
+                    description: |-
+                      LocalObjectReference contains enough information to let you locate the
+                      referenced object inside the same namespace.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                imageRepository:
+                  description: |-
+                    ImageRepository overrides just the repository portion of the default Garage image,
+                    preserving the default tag for automatic version upgrades.
+                    For example, setting this to "my-mirror/garage" with the default tag v2.3.0
+                    produces "my-mirror/garage:v2.3.0".
+                    Ignored if image is set.
+                  type: string
+                k2vApi:
+                  description: |-
+                    K2VAPI configures the K2V (key-value) API endpoint.
+                    Omit to disable K2V.
+                  properties:
+                    bindAddress:
+                      description: |-
+                        BindAddress is a custom bind address for the K2V API.
+                        Can be a TCP address or Unix socket path (e.g., "unix:///run/garage/k2v.sock").
+                        If set, this overrides BindPort.
+                      type: string
+                    bindPort:
+                      default: 3904
+                      description: BindPort is the port to bind for K2V API
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                  type: object
+                layoutManagement:
+                  description: |-
+                    LayoutManagement controls automatic layout application behavior.
+                    By default, staged layout changes are NOT applied automatically — the operator
+                    stages them and waits for manual approval (or the force-layout-apply annotation).
+                    Set autoApply: true to apply changes automatically once minNodesHealthy are connected.
+                  properties:
+                    autoApply:
+                      description: AutoApply automatically applies staged layout changes
+                      type: boolean
+                    minNodesHealthy:
+                      description: MinNodesHealthy is the minimum healthy nodes required before applying layout changes
+                      type: integer
+                  type: object
+                layoutPolicy:
+                  default: Auto
+                  description: |-
+                    LayoutPolicy controls whether node layouts are automatically managed or manually configured.
+                    - "Auto": The controller automatically assigns all local pods to the layout using the
+                      cluster's zone and derives capacity from data PVC size. No GarageNode resources needed.
+                    - "Manual": You must create GarageNode resources for each node you want in the layout.
+                      Use this for fine-grained control over zones, capacities, or external nodes.
+                  enum:
+                    - Auto
+                    - Manual
+                  type: string
+                logging:
+                  description: Logging configures logging behavior for Garage nodes
+                  properties:
+                    journald:
+                      description: Journald enables logging to systemd journald (requires Garage built with journald feature)
+                      type: boolean
+                    level:
+                      description: |-
+                        Level sets the log level using RUST_LOG format.
+
+                        Examples:
+                        - "info": Default info level for all components
+                        - "debug": Debug level for all components
+                        - "garage=debug": Debug only for garage module
+                        - "garage=debug,netapp=info": Fine-grained per-component levels
+                        - "garage=trace,netapp=debug,rusoto=warn": Multiple components
+
+                        See https://docs.rs/env_logger for full syntax.
+                      type: string
+                    syslog:
+                      description: Syslog enables logging to syslog (requires Garage built with syslog feature)
+                      type: boolean
+                  type: object
+                maintenance:
+                  description: Maintenance configures maintenance mode for this cluster.
+                  properties:
+                    suspended:
+                      description: |-
+                        Suspended pauses all reconciliation for this cluster.
+                        The operator will not make any changes while suspended.
+                      type: boolean
+                  type: object
+                monitoring:
+                  description: Monitoring configures Prometheus integration for this cluster.
+                  properties:
+                    additionalLabels:
+                      additionalProperties:
+                        type: string
+                      description: AdditionalLabels are added to the ServiceMonitor metadata.
+                      type: object
+                    enabled:
+                      description: |-
+                        Enabled creates a ServiceMonitor targeting the admin API /metrics endpoint.
+                        Requires prometheus-operator to be installed in the cluster.
+                      type: boolean
+                    interval:
+                      description: |-
+                        Interval is the Prometheus scrape interval (e.g. "30s", "1m").
+                        Defaults to the Prometheus global scrape interval when unset.
+                      type: string
+                  type: object
+                network:
+                  description: Network configures RPC and API networking
+                  properties:
+                    bootstrapPeers:
+                      description: |-
+                        BootstrapPeers lists initial peers for cluster formation.
+
+                        Format: "<node_public_key>@<ip_or_hostname>:<port>"
+
+                        Example:
+                        - "563e1ac825ee3323aa441e72c26d1030d6d4414aeb3dd25287c531e7fc2bc95d@10.0.0.1:3901"
+                        - "ec79480e0ce52ae26fd00c9da684e4fa56f77571b9b8560382f859930e63571d@garage-2.example.com:3901"
+                      items:
+                        type: string
+                      type: array
+                    rpcBindAddress:
+                      description: |-
+                        RPCBindAddress is a custom bind address for the RPC server.
+                        Can be a TCP address (e.g., "0.0.0.0:3901", "[::]:3901").
+                        If set, this overrides RPCBindPort.
+                      type: string
+                    rpcBindOutgoing:
+                      description: RPCBindOutgoing pre-binds outgoing sockets to same IP
+                      type: boolean
+                    rpcBindPort:
+                      default: 3901
+                      description: RPCBindPort is the port for inter-cluster RPC
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    rpcPingTimeout:
+                      description: RPCPingTimeout sets the RPC ping timeout (e.g. "10s", "500ms").
+                      type: string
+                    rpcPublicAddr:
+                      description: RPCPublicAddr is the external address for other nodes to contact this node
+                      type: string
+                    rpcPublicAddrSubnet:
+                      description: RPCPublicAddrSubnet filters autodiscovered IPs to specific subnet
+                      type: string
+                    rpcSecretRef:
+                      description: |-
+                        RPCSecret is a reference to a secret containing the RPC secret
+                        The secret must have a key 'rpc-secret' with a 32-byte hex-encoded value
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    rpcTimeout:
+                      description: RPCTimeout sets the RPC call timeout (e.g. "30s").
+                      type: string
+                    service:
+                      description: Service configures the Kubernetes Service for the cluster
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations to add to the service.
+                          type: object
+                        externalTrafficPolicy:
+                          description: ExternalTrafficPolicy for LoadBalancer/NodePort
+                          type: string
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels to add to the service. Operator-managed labels take precedence on conflict.
+                          type: object
+                        loadBalancerIP:
+                          description: LoadBalancerIP for LoadBalancer type
+                          type: string
+                        loadBalancerSourceRanges:
+                          description: LoadBalancerSourceRanges for LoadBalancer type
+                          items:
+                            type: string
+                          type: array
+                        type:
+                          default: ClusterIP
+                          description: Type of service
+                          enum:
+                            - ClusterIP
+                            - NodePort
+                            - LoadBalancer
+                          type: string
+                      type: object
+                  type: object
+                nodeSelector:
+                  additionalProperties:
+                    type: string
+                  description: NodeSelector for pod scheduling
+                  type: object
+                podAnnotations:
+                  additionalProperties:
+                    type: string
+                  description: PodAnnotations to add to Garage pods
+                  type: object
+                podDisruptionBudget:
+                  description: |-
+                    PodDisruptionBudget configures a PodDisruptionBudget for the cluster's StatefulSet.
+                    When set, the operator creates a PDB to limit voluntary pod disruptions during
+                    node maintenance, rolling updates, or cluster autoscaler actions.
+                    If omitted, no PDB is created.
+                  properties:
+                    enabled:
+                      default: true
+                      description: Enabled enables PodDisruptionBudget creation
+                      type: boolean
+                    maxUnavailable:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: |-
+                        MaxUnavailable specifies the maximum number of pods that can be unavailable.
+                        Can be an absolute number (e.g., 1) or a percentage (e.g., "25%").
+                        Mutually exclusive with MinAvailable.
+                      x-kubernetes-int-or-string: true
+                    minAvailable:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: |-
+                        MinAvailable specifies the minimum number of pods that must be available.
+                        Can be an absolute number (e.g., 2) or a percentage (e.g., "50%").
+                        Mutually exclusive with MaxUnavailable.
+                      x-kubernetes-int-or-string: true
+                  type: object
+                podLabels:
+                  additionalProperties:
+                    type: string
+                  description: PodLabels to add to Garage pods
+                  type: object
+                priorityClassName:
+                  description: PriorityClassName for Garage pods
+                  type: string
+                publicEndpoint:
+                  description: |-
+                    PublicEndpoint configures how remote clusters reach this cluster's nodes
+                    Required for multi-cluster federation
+                  properties:
+                    externalIP:
+                      description: ExternalIP configuration
+                      properties:
+                        addressTemplate:
+                          description: |-
+                            AddressTemplate uses go template to generate addresses from pod info
+                            Example: "garage-{{.Index}}.example.com"
+                          type: string
+                        addresses:
+                          additionalProperties:
+                            type: string
+                          description: Addresses maps pod names to external IPs
+                          type: object
+                      type: object
+                    loadBalancer:
+                      description: LoadBalancer configuration
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations to add to the service.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels to add to the service. Operator-managed labels take precedence on conflict.
+                          type: object
+                        perNode:
+                          description: |-
+                            PerNode creates a separate LoadBalancer service per GarageCluster pod instead
+                            of one shared LoadBalancer service. In auto-layout GarageCluster mode, those
+                            services are used for operator-driven reverse ConnectClusterNodes calls; the
+                            pods still share one Garage ConfigMap, so distinct per-pod rpc_public_addr
+                            values are not written into Garage config. Use Manual layout with GarageNode
+                            resources when each node also needs its own advertised rpc_public_addr.
+                          type: boolean
+                      type: object
+                    nodePort:
+                      description: NodePort configuration
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations to add to the service.
+                          type: object
+                        basePort:
+                          description: |-
+                            BasePort is the starting NodePort; Garage pod N is exposed on BasePort+N.
+                            If omitted, the controller allocates starting from the RPC port base (30901).
+                          format: int32
+                          maximum: 32767
+                          minimum: 30000
+                          type: integer
+                        externalAddresses:
+                          description: |-
+                            ExternalAddresses are the externally-reachable IPs or hostnames of the Kubernetes nodes.
+                            The operator maps Garage pod N to ExternalAddresses[N % len(ExternalAddresses)],
+                            so the order should be stable. Must have at least one entry.
+                          items:
+                            type: string
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels to add to the service. Operator-managed labels take precedence on conflict.
+                          type: object
+                      required:
+                        - externalAddresses
+                      type: object
+                    type:
+                      description: Type specifies how nodes are exposed to remote clusters for RPC
+                      enum:
+                        - LoadBalancer
+                        - NodePort
+                        - ExternalIP
+                        - Headless
+                      type: string
+                  required:
+                    - type
+                  type: object
+                remoteClusters:
+                  description: |-
+                    RemoteClusters lists Garage clusters in other Kubernetes clusters to federate with.
+                    The operator connects to each remote cluster's Admin API to discover its nodes,
+                    merge them into the shared layout, and keep the layout in sync as nodes come and go.
+                    All clusters in a federation must share the same RPC secret.
+                  items:
+                    description: RemoteClusterConfig defines a Garage cluster in another Kubernetes cluster
+                    properties:
+                      connection:
+                        description: Connection defines how to connect to this remote cluster
+                        properties:
+                          adminApiEndpoint:
+                            description: |-
+                              AdminAPIEndpoint is the admin API endpoint of the remote cluster
+                              This should be a reachable HTTP/HTTPS URL (e.g., via Tailscale, LoadBalancer, or port-forward)
+                              Example: "http://garage-remote.tailscale:3903"
+                            minLength: 1
+                            type: string
+                          adminTokenSecretRef:
+                            description: |-
+                              AdminTokenSecretRef references the admin token for the remote cluster's API
+                              If not specified, uses the local cluster's admin token (for shared-token setups)
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          gatewayRpcEndpointTemplate:
+                            description: |-
+                              GatewayRPCEndpointTemplate is a hostname:port template used by federation
+                              to connect to remote gateway pods individually. The literal `{ordinal}`
+                              is replaced with each remote gateway pod's ordinal (0, 1, ...).
+                              Example: "ottawa-garage-gw-{ordinal}.keiretsu.ts.net:3901"
+                            type: string
+                        required:
+                          - adminApiEndpoint
+                        type: object
+                      defaultCapacity:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: |-
+                          DefaultCapacity is the default storage capacity to assign to remote nodes
+                          that don't yet have a role in the layout. If not specified, defaults to 100Gi.
+                          Set to "0" to add nodes as gateway-only (no storage).
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      name:
+                        description: Name is a friendly name for this remote cluster
+                        minLength: 1
+                        type: string
+                      zone:
+                        description: Zone is the zone name for nodes in this remote cluster
+                        minLength: 1
+                        type: string
+                    required:
+                      - connection
+                      - name
+                      - zone
+                    type: object
+                  type: array
+                replicas:
+                  default: 3
+                  description: |-
+                    Replicas is the number of Garage nodes to deploy in this cluster.
+                    Set to 0 to keep the cluster declared but stop all pods.
+                  format: int32
+                  minimum: 0
+                  type: integer
+                replication:
+                  description: |-
+                    Replication configures data replication settings.
+                    If omitted, defaults to factor: 3 and consistencyMode: consistent.
+                  properties:
+                    consistencyMode:
+                      default: consistent
+                      description: |-
+                        ConsistencyMode controls quorum behavior for read/write operations.
+
+                        Values:
+                        - "consistent" (default): Require quorum for both reads and writes.
+                          Safest option, ensures strong consistency.
+                        - "degraded": Allow reads from single node when quorum unavailable.
+                          May return stale data during network partitions.
+                        - "dangerous": Allow reads AND writes without quorum.
+                          WARNING: May lose data during failures!
+                      enum:
+                        - consistent
+                        - degraded
+                        - dangerous
+                      type: string
+                    factor:
+                      default: 3
+                      description: |-
+                        Factor is the replication factor (1, 2, 3, 5, 7, etc.)
+                        Must be the same on all nodes in the cluster
+                      maximum: 7
+                      minimum: 1
+                      type: integer
+                    zoneRedundancyMinZones:
+                      description: |-
+                        ZoneRedundancyMinZones is the minimum number of zones required.
+                        Only valid when ZoneRedundancyMode is "AtLeast". Must not exceed the replication factor.
+                      maximum: 7
+                      minimum: 1
+                      type: integer
+                    zoneRedundancyMode:
+                      description: |-
+                        ZoneRedundancyMode controls how data is distributed across zones.
+                        "Maximum": spread replicas across as many zones as possible (default).
+                        "AtLeast": require replicas in at least ZoneRedundancyMinZones zones.
+                      enum:
+                        - Maximum
+                        - AtLeast
+                      type: string
+                  required:
+                    - factor
+                  type: object
+                resources:
+                  description: Resources specifies compute resources for Garage pods
+                  properties:
+                    claims:
+                      description: |-
+                        Claims lists the names of resources, defined in spec.resourceClaims,
+                        that are used by this container.
+
+                        This field depends on the
+                        DynamicResourceAllocation feature gate.
+
+                        This field is immutable. It can only be set for containers.
+                      items:
+                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                        properties:
+                          name:
+                            description: |-
+                              Name must match the name of one entry in pod.spec.resourceClaims of
+                              the Pod where this field is used. It makes that resource available
+                              inside a container.
+                            type: string
+                          request:
+                            description: |-
+                              Request is the name chosen for a request in the referenced claim.
+                              If empty, everything from the claim is made available, otherwise
+                              only the result of this request.
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: |-
+                        Limits describes the maximum amount of compute resources allowed.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: |-
+                        Requests describes the minimum amount of compute resources required.
+                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      type: object
+                  type: object
+                s3Api:
+                  description: S3API configures the S3-compatible API endpoint
+                  properties:
+                    bindAddress:
+                      description: |-
+                        BindAddress is a custom bind address for the S3 API.
+                        Can be a TCP address (e.g., "0.0.0.0:3900", "[::]:3900") or
+                        a Unix socket path (e.g., "unix:///run/garage/s3.sock").
+                        If set, this overrides BindPort.
+                      type: string
+                    bindPort:
+                      default: 3900
+                      description: BindPort is the port to bind for S3 API
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    region:
+                      default: garage
+                      description: Region is the AWS S3 region name to use
+                      type: string
+                    rootDomain:
+                      description: |-
+                        RootDomain is the root domain suffix for vhost-style S3 access.
+                        When set, buckets can be accessed via <bucket-name>.<root-domain>.
+
+                        Examples:
+                        - ".s3.garage.tld" -> Access bucket "mybucket" at "mybucket.s3.garage.tld"
+                        - ".s3.example.com" -> Access bucket "data" at "data.s3.example.com"
+
+                        Note: Include the leading dot.
+                      type: string
+                  required:
+                    - region
+                  type: object
+                security:
+                  description: Security configures security-related settings
+                  properties:
+                    allowInsecureSecretPermissions:
+                      description: |-
+                        AllowInsecureSecretPermissions bypasses Garage's check that secret files
+                        (RPC secret, admin token) are not world-readable on disk.
+                        Only enable if your container security model handles file permissions externally.
+                        Enabling this weakens the defense-in-depth for credential exposure.
+                      type: boolean
+                    allowPunycode:
+                      description: AllowPunycode allows punycode in bucket names
+                      type: boolean
+                    tls:
+                      description: TLS configures TLS settings
+                      properties:
+                        caSecretRef:
+                          description: CASecretRef references a secret containing the CA certificate for verifying peer nodes
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        certSecretRef:
+                          description: CertSecretRef references a secret containing the TLS certificate for RPC
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        enabled:
+                          description: |-
+                            Enabled enables TLS for inter-node RPC communication.
+                            NOTE: This does NOT enable TLS for S3/Admin APIs - use a service mesh or load balancer for that.
+                          type: boolean
+                        keySecretRef:
+                          description: KeySecretRef references a secret containing the TLS private key for RPC
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  type: object
+                securityContext:
+                  description: SecurityContext for Garage pods
+                  properties:
+                    appArmorProfile:
+                      description: |-
+                        appArmorProfile is the AppArmor options to use by the containers in this pod.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: |-
+                            localhostProfile indicates a profile loaded on the node that should be used.
+                            The profile must be preconfigured on the node to work.
+                            Must match the loaded name of the profile.
+                            Must be set if and only if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of AppArmor profile will be applied.
+                            Valid options are:
+                              Localhost - a profile pre-loaded on the node.
+                              RuntimeDefault - the container runtime's default profile.
+                              Unconfined - no AppArmor enforcement.
+                          type: string
+                      required:
+                        - type
+                      type: object
+                    fsGroup:
+                      description: |-
+                        A special supplemental group that applies to all containers in a pod.
+                        Some volume types allow the Kubelet to change the ownership of that volume
+                        to be owned by the pod:
+
+                        1. The owning GID will be the FSGroup
+                        2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                        3. The permission bits are OR'd with rw-rw----
+
+                        If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    fsGroupChangePolicy:
+                      description: |-
+                        fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                        before being exposed inside Pod. This field will only apply to
+                        volume types which support fsGroup based ownership(and permissions).
+                        It will have no effect on ephemeral volume types such as: secret, configmaps
+                        and emptydir.
+                        Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      type: string
+                    runAsGroup:
+                      description: |-
+                        The GID to run the entrypoint of the container process.
+                        Uses runtime default if unset.
+                        May also be set in SecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence
+                        for that container.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: |-
+                        Indicates that the container must run as a non-root user.
+                        If true, the Kubelet will validate the image at runtime to ensure that it
+                        does not run as UID 0 (root) and fail to start the container if it does.
+                        If unset or false, no such validation will be performed.
+                        May also be set in SecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: |-
+                        The UID to run the entrypoint of the container process.
+                        Defaults to user specified in image metadata if unspecified.
+                        May also be set in SecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence
+                        for that container.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    seLinuxChangePolicy:
+                      description: |-
+                        seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                        It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                        Valid values are "MountOption" and "Recursive".
+
+                        "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                        This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                        "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                        This requires all Pods that share the same volume to use the same SELinux label.
+                        It is not possible to share the same volume among privileged and unprivileged Pods.
+                        Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                        whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                        CSIDriver instance. Other volumes are always re-labelled recursively.
+                        "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                        If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                        If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                        and "Recursive" for all other volumes.
+
+                        This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                        All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      type: string
+                    seLinuxOptions:
+                      description: |-
+                        The SELinux context to be applied to all containers.
+                        If unspecified, the container runtime will allocate a random SELinux context for each
+                        container.  May also be set in SecurityContext.  If set in
+                        both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence for that container.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: |-
+                        The seccomp options to use by the containers in this pod.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: |-
+                            localhostProfile indicates a profile defined in a file on the node should be used.
+                            The profile must be preconfigured on the node to work.
+                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                            Must be set if type is "Localhost". Must NOT be set for any other type.
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied.
+                            Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used.
+                            RuntimeDefault - the container runtime default profile should be used.
+                            Unconfined - no profile should be applied.
+                          type: string
+                      required:
+                        - type
+                      type: object
+                    supplementalGroups:
+                      description: |-
+                        A list of groups applied to the first process run in each container, in
+                        addition to the container's primary GID and fsGroup (if specified).  If
+                        the SupplementalGroupsPolicy feature is enabled, the
+                        supplementalGroupsPolicy field determines whether these are in addition
+                        to or instead of any group memberships defined in the container image.
+                        If unspecified, no additional groups are added, though group memberships
+                        defined in the container image may still be used, depending on the
+                        supplementalGroupsPolicy field.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    supplementalGroupsPolicy:
+                      description: |-
+                        Defines how supplemental groups of the first container processes are calculated.
+                        Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                        (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                        and the container runtime must implement support for this feature.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      type: string
+                    sysctls:
+                      description: |-
+                        Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                        sysctls (by the container runtime) might fail to launch.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      items:
+                        description: Sysctl defines a kernel parameter to be set
+                        properties:
+                          name:
+                            description: Name of a property to set
+                            type: string
+                          value:
+                            description: Value of a property to set
+                            type: string
+                        required:
+                          - name
+                          - value
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    windowsOptions:
+                      description: |-
+                        The Windows specific settings applied to all containers.
+                        If unspecified, the options within a container's SecurityContext will be used.
+                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is linux.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: |-
+                            GMSACredentialSpec is where the GMSA admission webhook
+                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                            GMSA credential spec named by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: |-
+                            HostProcess determines if a container should be run as a 'Host Process' container.
+                            All of a Pod's containers must have the same effective HostProcess value
+                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                            In addition, if HostProcess is true then HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: |-
+                            The UserName in Windows to run the entrypoint of the container process.
+                            Defaults to the user specified in image metadata if unspecified.
+                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                serviceAccountName:
+                  description: ServiceAccountName for Garage pods
+                  type: string
+                storage:
+                  description: |-
+                    Storage configures storage settings for metadata and data.
+                    Optional - sensible defaults are provided:
+                    - Storage clusters: 10Gi metadata, 100Gi data
+                    - Gateway clusters: 1Gi metadata only (data uses EmptyDir)
+                  properties:
+                    data:
+                      description: Data configures data block storage
+                      properties:
+                        accessModes:
+                          description: AccessModes for the PVC. Only valid when Type=PersistentVolumeClaim.
+                          items:
+                            type: string
+                          type: array
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations to set on the PVC. Only valid when Type=PersistentVolumeClaim.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels to set on the PVC. Only valid when Type=PersistentVolumeClaim.
+                          type: object
+                        paths:
+                          description: |-
+                            Paths configures multiple data directories for multi-disk setups.
+                            Only valid for data volumes — webhook rejects this on metadata volumes.
+                            Only valid when Type=PersistentVolumeClaim.
+                          items:
+                            description: DataPath specifies a data directory with capacity
+                            properties:
+                              capacity:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Capacity of the drive (required unless readOnly)
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              path:
+                                description: Path to the data directory
+                                type: string
+                              readOnly:
+                                description: ReadOnly marks directory as legacy read-only for migrations
+                                type: boolean
+                              volume:
+                                description: Volume configuration if using PVC
+                                properties:
+                                  accessModes:
+                                    description: AccessModes for the PVC.
+                                    items:
+                                      type: string
+                                    type: array
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to set on the PVC.
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: Labels to set on the PVC.
+                                    type: object
+                                  selector:
+                                    description: Selector to select PVs.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  size:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Size of the volume (storage request).
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  storageClassName:
+                                    description: StorageClassName for the PVC.
+                                    type: string
+                                  type:
+                                    default: PersistentVolumeClaim
+                                    description: 'Type specifies the volume type: PersistentVolumeClaim (default) or EmptyDir.'
+                                    enum:
+                                      - PersistentVolumeClaim
+                                      - EmptyDir
+                                    type: string
+                                  volumeClaimTemplateSpec:
+                                    description: VolumeClaimTemplateSpec allows full customization of the PVC.
+                                    properties:
+                                      accessModes:
+                                        description: |-
+                                          accessModes contains the desired access modes the volume should have.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      dataSource:
+                                        description: |-
+                                          dataSource field can be used to specify either:
+                                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          * An existing PVC (PersistentVolumeClaim)
+                                          If the provisioner or an external controller can support the specified data source,
+                                          it will create a new volume based on the contents of the specified data source.
+                                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource being referenced
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      dataSourceRef:
+                                        description: |-
+                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                          volume is desired. This may be any object from a non-empty API group (non
+                                          core object) or a PersistentVolumeClaim object.
+                                          When this field is specified, volume binding will only succeed if the type of
+                                          the specified object matches some installed volume populator or dynamic
+                                          provisioner.
+                                          This field will replace the functionality of the dataSource field and as such
+                                          if both fields are non-empty, they must have the same value. For backwards
+                                          compatibility, when namespace isn't specified in dataSourceRef,
+                                          both fields (dataSource and dataSourceRef) will be set to the same
+                                          value automatically if one of them is empty and the other is non-empty.
+                                          When namespace is specified in dataSourceRef,
+                                          dataSource isn't set to the same value and must be empty.
+                                          There are three important differences between dataSource and dataSourceRef:
+                                          * While dataSource only allows two specific types of objects, dataSourceRef
+                                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                            preserves all values, and generates an error if a disallowed value is
+                                            specified.
+                                          * While dataSource only allows local objects, dataSourceRef allows objects
+                                            in any namespaces.
+                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource being referenced
+                                            type: string
+                                          namespace:
+                                            description: |-
+                                              Namespace is the namespace of resource being referenced
+                                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                      resources:
+                                        description: |-
+                                          resources represents the minimum resources the volume should have.
+                                          Users are allowed to specify resource requirements
+                                          that are lower than previous value but must still be higher than capacity recorded in the
+                                          status field of the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Limits describes the maximum amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Requests describes the minimum amount of compute resources required.
+                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                        type: object
+                                      selector:
+                                        description: selector is a label query over volumes to consider for binding.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      storageClassName:
+                                        description: |-
+                                          storageClassName is the name of the StorageClass required by the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                        type: string
+                                      volumeAttributesClassName:
+                                        description: |-
+                                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                          If specified, the CSI driver will create or update the volume with the attributes defined
+                                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                          this field can be reset to its previous value (including nil) to cancel the modification.
+                                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                          exists.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                        type: string
+                                      volumeMode:
+                                        description: |-
+                                          volumeMode defines what type of volume is required by the claim.
+                                          Value of Filesystem is implied when not included in claim spec.
+                                        type: string
+                                      volumeName:
+                                        description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                        type: string
+                                    type: object
+                                type: object
+                            required:
+                              - path
+                            type: object
+                          type: array
+                        selector:
+                          description: Selector to select PVs. Only valid when Type=PersistentVolumeClaim.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        size:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: |-
+                            Size of the volume.
+                            - For PVC: storage request (defaults to 10Gi for metadata if not specified)
+                            - For EmptyDir: optional sizeLimit (if omitted, uses available node resources)
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        storageClassName:
+                          description: StorageClassName for the PVC. Only valid when Type=PersistentVolumeClaim.
+                          type: string
+                        type:
+                          default: PersistentVolumeClaim
+                          description: |-
+                            Type specifies the volume type: PersistentVolumeClaim (default) or EmptyDir.
+                            When EmptyDir, data is lost on pod restart - only use for testing.
+                          enum:
+                            - PersistentVolumeClaim
+                            - EmptyDir
+                          type: string
+                        volumeClaimTemplateSpec:
+                          description: |-
+                            VolumeClaimTemplateSpec allows full customization of the PVC.
+                            Only valid when Type=PersistentVolumeClaim.
+                          properties:
+                            accessModes:
+                              description: |-
+                                accessModes contains the desired access modes the volume should have.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            dataSource:
+                              description: |-
+                                dataSource field can be used to specify either:
+                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                * An existing PVC (PersistentVolumeClaim)
+                                If the provisioner or an external controller can support the specified data source,
+                                it will create a new volume based on the contents of the specified data source.
+                                When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being referenced
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            dataSourceRef:
+                              description: |-
+                                dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                volume is desired. This may be any object from a non-empty API group (non
+                                core object) or a PersistentVolumeClaim object.
+                                When this field is specified, volume binding will only succeed if the type of
+                                the specified object matches some installed volume populator or dynamic
+                                provisioner.
+                                This field will replace the functionality of the dataSource field and as such
+                                if both fields are non-empty, they must have the same value. For backwards
+                                compatibility, when namespace isn't specified in dataSourceRef,
+                                both fields (dataSource and dataSourceRef) will be set to the same
+                                value automatically if one of them is empty and the other is non-empty.
+                                When namespace is specified in dataSourceRef,
+                                dataSource isn't set to the same value and must be empty.
+                                There are three important differences between dataSource and dataSourceRef:
+                                * While dataSource only allows two specific types of objects, dataSourceRef
+                                  allows any non-core object, as well as PersistentVolumeClaim objects.
+                                * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                  preserves all values, and generates an error if a disallowed value is
+                                  specified.
+                                * While dataSource only allows local objects, dataSourceRef allows objects
+                                  in any namespaces.
+                                (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being referenced
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace is the namespace of resource being referenced
+                                    Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                    (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                            resources:
+                              description: |-
+                                resources represents the minimum resources the volume should have.
+                                Users are allowed to specify resource requirements
+                                that are lower than previous value but must still be higher than capacity recorded in the
+                                status field of the claim.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            selector:
+                              description: selector is a label query over volumes to consider for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            storageClassName:
+                              description: |-
+                                storageClassName is the name of the StorageClass required by the claim.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                              type: string
+                            volumeAttributesClassName:
+                              description: |-
+                                volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                If specified, the CSI driver will create or update the volume with the attributes defined
+                                in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                it can be changed after the claim is created. An empty string or nil value indicates that no
+                                VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                this field can be reset to its previous value (including nil) to cancel the modification.
+                                If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                exists.
+                                More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                              type: string
+                            volumeMode:
+                              description: |-
+                                volumeMode defines what type of volume is required by the claim.
+                                Value of Filesystem is implied when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                      type: object
+                    dataFsync:
+                      description: DataFsync enables fsync for data block writes
+                      type: boolean
+                    metadata:
+                      description: Metadata configures metadata storage
+                      properties:
+                        accessModes:
+                          description: AccessModes for the PVC. Only valid when Type=PersistentVolumeClaim.
+                          items:
+                            type: string
+                          type: array
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations to set on the PVC. Only valid when Type=PersistentVolumeClaim.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels to set on the PVC. Only valid when Type=PersistentVolumeClaim.
+                          type: object
+                        paths:
+                          description: |-
+                            Paths configures multiple data directories for multi-disk setups.
+                            Only valid for data volumes — webhook rejects this on metadata volumes.
+                            Only valid when Type=PersistentVolumeClaim.
+                          items:
+                            description: DataPath specifies a data directory with capacity
+                            properties:
+                              capacity:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Capacity of the drive (required unless readOnly)
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              path:
+                                description: Path to the data directory
+                                type: string
+                              readOnly:
+                                description: ReadOnly marks directory as legacy read-only for migrations
+                                type: boolean
+                              volume:
+                                description: Volume configuration if using PVC
+                                properties:
+                                  accessModes:
+                                    description: AccessModes for the PVC.
+                                    items:
+                                      type: string
+                                    type: array
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to set on the PVC.
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: Labels to set on the PVC.
+                                    type: object
+                                  selector:
+                                    description: Selector to select PVs.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  size:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Size of the volume (storage request).
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  storageClassName:
+                                    description: StorageClassName for the PVC.
+                                    type: string
+                                  type:
+                                    default: PersistentVolumeClaim
+                                    description: 'Type specifies the volume type: PersistentVolumeClaim (default) or EmptyDir.'
+                                    enum:
+                                      - PersistentVolumeClaim
+                                      - EmptyDir
+                                    type: string
+                                  volumeClaimTemplateSpec:
+                                    description: VolumeClaimTemplateSpec allows full customization of the PVC.
+                                    properties:
+                                      accessModes:
+                                        description: |-
+                                          accessModes contains the desired access modes the volume should have.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      dataSource:
+                                        description: |-
+                                          dataSource field can be used to specify either:
+                                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          * An existing PVC (PersistentVolumeClaim)
+                                          If the provisioner or an external controller can support the specified data source,
+                                          it will create a new volume based on the contents of the specified data source.
+                                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource being referenced
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      dataSourceRef:
+                                        description: |-
+                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                          volume is desired. This may be any object from a non-empty API group (non
+                                          core object) or a PersistentVolumeClaim object.
+                                          When this field is specified, volume binding will only succeed if the type of
+                                          the specified object matches some installed volume populator or dynamic
+                                          provisioner.
+                                          This field will replace the functionality of the dataSource field and as such
+                                          if both fields are non-empty, they must have the same value. For backwards
+                                          compatibility, when namespace isn't specified in dataSourceRef,
+                                          both fields (dataSource and dataSourceRef) will be set to the same
+                                          value automatically if one of them is empty and the other is non-empty.
+                                          When namespace is specified in dataSourceRef,
+                                          dataSource isn't set to the same value and must be empty.
+                                          There are three important differences between dataSource and dataSourceRef:
+                                          * While dataSource only allows two specific types of objects, dataSourceRef
+                                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                            preserves all values, and generates an error if a disallowed value is
+                                            specified.
+                                          * While dataSource only allows local objects, dataSourceRef allows objects
+                                            in any namespaces.
+                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource being referenced
+                                            type: string
+                                          namespace:
+                                            description: |-
+                                              Namespace is the namespace of resource being referenced
+                                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                      resources:
+                                        description: |-
+                                          resources represents the minimum resources the volume should have.
+                                          Users are allowed to specify resource requirements
+                                          that are lower than previous value but must still be higher than capacity recorded in the
+                                          status field of the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Limits describes the maximum amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Requests describes the minimum amount of compute resources required.
+                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                        type: object
+                                      selector:
+                                        description: selector is a label query over volumes to consider for binding.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      storageClassName:
+                                        description: |-
+                                          storageClassName is the name of the StorageClass required by the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                        type: string
+                                      volumeAttributesClassName:
+                                        description: |-
+                                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                          If specified, the CSI driver will create or update the volume with the attributes defined
+                                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                          this field can be reset to its previous value (including nil) to cancel the modification.
+                                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                          exists.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                        type: string
+                                      volumeMode:
+                                        description: |-
+                                          volumeMode defines what type of volume is required by the claim.
+                                          Value of Filesystem is implied when not included in claim spec.
+                                        type: string
+                                      volumeName:
+                                        description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                        type: string
+                                    type: object
+                                type: object
+                            required:
+                              - path
+                            type: object
+                          type: array
+                        selector:
+                          description: Selector to select PVs. Only valid when Type=PersistentVolumeClaim.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        size:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: |-
+                            Size of the volume.
+                            - For PVC: storage request (defaults to 10Gi for metadata if not specified)
+                            - For EmptyDir: optional sizeLimit (if omitted, uses available node resources)
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        storageClassName:
+                          description: StorageClassName for the PVC. Only valid when Type=PersistentVolumeClaim.
+                          type: string
+                        type:
+                          default: PersistentVolumeClaim
+                          description: |-
+                            Type specifies the volume type: PersistentVolumeClaim (default) or EmptyDir.
+                            When EmptyDir, data is lost on pod restart - only use for testing.
+                          enum:
+                            - PersistentVolumeClaim
+                            - EmptyDir
+                          type: string
+                        volumeClaimTemplateSpec:
+                          description: |-
+                            VolumeClaimTemplateSpec allows full customization of the PVC.
+                            Only valid when Type=PersistentVolumeClaim.
+                          properties:
+                            accessModes:
+                              description: |-
+                                accessModes contains the desired access modes the volume should have.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            dataSource:
+                              description: |-
+                                dataSource field can be used to specify either:
+                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                * An existing PVC (PersistentVolumeClaim)
+                                If the provisioner or an external controller can support the specified data source,
+                                it will create a new volume based on the contents of the specified data source.
+                                When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being referenced
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            dataSourceRef:
+                              description: |-
+                                dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                volume is desired. This may be any object from a non-empty API group (non
+                                core object) or a PersistentVolumeClaim object.
+                                When this field is specified, volume binding will only succeed if the type of
+                                the specified object matches some installed volume populator or dynamic
+                                provisioner.
+                                This field will replace the functionality of the dataSource field and as such
+                                if both fields are non-empty, they must have the same value. For backwards
+                                compatibility, when namespace isn't specified in dataSourceRef,
+                                both fields (dataSource and dataSourceRef) will be set to the same
+                                value automatically if one of them is empty and the other is non-empty.
+                                When namespace is specified in dataSourceRef,
+                                dataSource isn't set to the same value and must be empty.
+                                There are three important differences between dataSource and dataSourceRef:
+                                * While dataSource only allows two specific types of objects, dataSourceRef
+                                  allows any non-core object, as well as PersistentVolumeClaim objects.
+                                * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                  preserves all values, and generates an error if a disallowed value is
+                                  specified.
+                                * While dataSource only allows local objects, dataSourceRef allows objects
+                                  in any namespaces.
+                                (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being referenced
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace is the namespace of resource being referenced
+                                    Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                    (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                            resources:
+                              description: |-
+                                resources represents the minimum resources the volume should have.
+                                Users are allowed to specify resource requirements
+                                that are lower than previous value but must still be higher than capacity recorded in the
+                                status field of the claim.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            selector:
+                              description: selector is a label query over volumes to consider for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            storageClassName:
+                              description: |-
+                                storageClassName is the name of the StorageClass required by the claim.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                              type: string
+                            volumeAttributesClassName:
+                              description: |-
+                                volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                If specified, the CSI driver will create or update the volume with the attributes defined
+                                in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                it can be changed after the claim is created. An empty string or nil value indicates that no
+                                VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                this field can be reset to its previous value (including nil) to cancel the modification.
+                                If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                exists.
+                                More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                              type: string
+                            volumeMode:
+                              description: |-
+                                volumeMode defines what type of volume is required by the claim.
+                                Value of Filesystem is implied when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                      type: object
+                    metadataAutoSnapshotInterval:
+                      description: |-
+                        MetadataAutoSnapshotInterval enables automatic metadata snapshots.
+                        Uses Garage duration format: "6h", "1d", "1w", etc.
+                      pattern: ^(\d+(\.\d+)?\s*(ns|us|ms|s|m|h|d|w|M|y)\s*)+$
+                      type: string
+                    metadataFsync:
+                      description: MetadataFsync enables fsync for metadata transactions
+                      type: boolean
+                    metadataSnapshotsDir:
+                      description: MetadataSnapshotsDir specifies directory for metadata snapshots
+                      type: string
+                    pvcRetentionPolicy:
+                      description: |-
+                        PVCRetentionPolicy controls whether PVCs are deleted when the StatefulSet is deleted or scaled down.
+                        Requires Kubernetes 1.23+. If not specified, defaults to Retain for both policies.
+                      properties:
+                        whenDeleted:
+                          default: Retain
+                          description: |-
+                            WhenDeleted specifies what happens to PVCs when the StatefulSet is deleted.
+                            - "Retain" (default): PVCs are kept for manual cleanup or data recovery
+                            - "Delete": PVCs are automatically deleted with the StatefulSet
+                          enum:
+                            - Retain
+                            - Delete
+                          type: string
+                        whenScaled:
+                          default: Retain
+                          description: |-
+                            WhenScaled specifies what happens to PVCs when the StatefulSet is scaled down.
+                            - "Retain" (default): PVCs are kept when scaling down (allows scale back up)
+                            - "Delete": PVCs for removed replicas are deleted
+                          enum:
+                            - Retain
+                            - Delete
+                          type: string
+                      type: object
+                  type: object
+                tolerations:
+                  description: Tolerations for pod scheduling
+                  items:
+                    description: |-
+                      The pod this Toleration is attached to tolerates any taint that matches
+                      the triple <key,value,effect> using the matching operator <operator>.
+                    properties:
+                      effect:
+                        description: |-
+                          Effect indicates the taint effect to match. Empty means match all taint effects.
+                          When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: |-
+                          Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                          If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                        type: string
+                      operator:
+                        description: |-
+                          Operator represents a key's relationship to the value.
+                          Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                          Exists is equivalent to wildcard for value, so that a pod can
+                          tolerate all taints of a particular category.
+                          Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                        type: string
+                      tolerationSeconds:
+                        description: |-
+                          TolerationSeconds represents the period of time the toleration (which must be
+                          of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                          it is not set, which means tolerate the taint forever (do not evict). Zero and
+                          negative values will be treated as 0 (evict immediately) by the system.
+                        format: int64
+                        type: integer
+                      value:
+                        description: |-
+                          Value is the taint value the toleration matches to.
+                          If the operator is Exists, the value should be empty, otherwise just a regular string.
+                        type: string
+                    type: object
+                  type: array
+                topologySpreadConstraints:
+                  description: TopologySpreadConstraints for pod scheduling
+                  items:
+                    description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                    properties:
+                      labelSelector:
+                        description: |-
+                          LabelSelector is used to find matching pods.
+                          Pods that match this label selector are counted to determine the number of pods
+                          in their corresponding topology domain.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      matchLabelKeys:
+                        description: |-
+                          MatchLabelKeys is a set of pod label keys to select the pods over which
+                          spreading will be calculated. The keys are used to lookup values from the
+                          incoming pod labels, those key-value labels are ANDed with labelSelector
+                          to select the group of existing pods over which spreading will be calculated
+                          for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                          MatchLabelKeys cannot be set when LabelSelector isn't set.
+                          Keys that don't exist in the incoming pod labels will
+                          be ignored. A null or empty list means only match against labelSelector.
+
+                          This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      maxSkew:
+                        description: |-
+                          MaxSkew describes the degree to which pods may be unevenly distributed.
+                          When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                          between the number of matching pods in the target topology and the global minimum.
+                          The global minimum is the minimum number of matching pods in an eligible domain
+                          or zero if the number of eligible domains is less than MinDomains.
+                          For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                          labelSelector spread as 2/2/1:
+                          In this case, the global minimum is 1.
+                          | zone1 | zone2 | zone3 |
+                          |  P P  |  P P  |   P   |
+                          - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                          scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                          violate MaxSkew(1).
+                          - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                          When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                          to topologies that satisfy it.
+                          It's a required field. Default value is 1 and 0 is not allowed.
+                        format: int32
+                        type: integer
+                      minDomains:
+                        description: |-
+                          MinDomains indicates a minimum number of eligible domains.
+                          When the number of eligible domains with matching topology keys is less than minDomains,
+                          Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                          And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                          this value has no effect on scheduling.
+                          As a result, when the number of eligible domains is less than minDomains,
+                          scheduler won't schedule more than maxSkew Pods to those domains.
+                          If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                          Valid values are integers greater than 0.
+                          When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                          For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                          labelSelector spread as 2/2/2:
+                          | zone1 | zone2 | zone3 |
+                          |  P P  |  P P  |  P P  |
+                          The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                          In this situation, new pod with the same labelSelector cannot be scheduled,
+                          because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                          it will violate MaxSkew.
+                        format: int32
+                        type: integer
+                      nodeAffinityPolicy:
+                        description: |-
+                          NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                          when calculating pod topology spread skew. Options are:
+                          - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                          - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                          If this value is nil, the behavior is equivalent to the Honor policy.
+                        type: string
+                      nodeTaintsPolicy:
+                        description: |-
+                          NodeTaintsPolicy indicates how we will treat node taints when calculating
+                          pod topology spread skew. Options are:
+                          - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                          has a toleration, are included.
+                          - Ignore: node taints are ignored. All nodes are included.
+
+                          If this value is nil, the behavior is equivalent to the Ignore policy.
+                        type: string
+                      topologyKey:
+                        description: |-
+                          TopologyKey is the key of node labels. Nodes that have a label with this key
+                          and identical values are considered to be in the same topology.
+                          We consider each <key, value> as a "bucket", and try to put balanced number
+                          of pods into each bucket.
+                          We define a domain as a particular instance of a topology.
+                          Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                          nodeAffinityPolicy and nodeTaintsPolicy.
+                          e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                          And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                          It's a required field.
+                        type: string
+                      whenUnsatisfiable:
+                        description: |-
+                          WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                          the spread constraint.
+                          - DoNotSchedule (default) tells the scheduler not to schedule it.
+                          - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                            but giving higher precedence to topologies that would help reduce the
+                            skew.
+                          A constraint is considered "Unsatisfiable" for an incoming pod
+                          if and only if every possible node assignment for that pod would violate
+                          "MaxSkew" on some topology.
+                          For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                          labelSelector spread as 3/1/1:
+                          | zone1 | zone2 | zone3 |
+                          | P P P |   P   |   P   |
+                          If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                          to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                          MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                          won't make it *more* imbalanced.
+                          It's a required field.
+                        type: string
+                    required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
+                    type: object
+                  type: array
+                webApi:
+                  description: |-
+                    WebAPI configures the static website hosting endpoint.
+                    Enabled by default with rootDomain ".<name>.<namespace>.svc".
+                    Set webApi.enabled: false to turn off.
+                  properties:
+                    addHostToMetrics:
+                      description: AddHostToMetrics adds the domain name to metrics labels for per-domain tracking.
+                      type: boolean
+                    bindAddress:
+                      description: |-
+                        BindAddress is a custom bind address for the Web API.
+                        Can be a TCP address or Unix socket path (e.g., "unix:///run/garage/web.sock").
+                        If set, this overrides BindPort.
+                      type: string
+                    bindPort:
+                      default: 3902
+                      description: BindPort is the port to bind for web serving
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    enabled:
+                      description: |-
+                        Enabled controls whether the web endpoint is active.
+                        Defaults to true. Set to false to disable.
+                      type: boolean
+                    rootDomain:
+                      description: |-
+                        RootDomain is the root domain suffix for bucket website access.
+                        Bucket websites are accessible via <bucket-name>.<root-domain>.
+                        Defaults to ".<cluster-name>.<namespace>.svc" if not specified.
+
+                        Examples:
+                        - ".web.garage.tld" -> Access bucket "site" website at "site.web.garage.tld"
+                        - ".sites.example.com" -> Access bucket "blog" at "blog.sites.example.com"
+
+                        Note: Include the leading dot.
+                      type: string
+                  type: object
+                workers:
+                  description: |-
+                    Workers configures Garage background worker behavior.
+                    Settings are applied to all nodes on every reconcile via the Admin API.
+                    Unset fields leave the corresponding worker variable at its Garage default.
+                  properties:
+                    resyncTranquility:
+                      description: |-
+                        ResyncTranquility controls how aggressively the block resync worker runs.
+                        Higher values add more pauses between block resyncs.
+                        Maps to the "resync-tranquility" worker variable.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    resyncWorkerCount:
+                      description: |-
+                        ResyncWorkerCount sets the number of parallel block resync worker goroutines.
+                        Higher values increase resync throughput at the cost of disk I/O.
+                        Maps to the "resync-worker-count" worker variable.
+                      format: int32
+                      maximum: 8
+                      minimum: 1
+                      type: integer
+                    scrubTranquility:
+                      description: |-
+                        ScrubTranquility controls how aggressively the block integrity scrub runs.
+                        Higher values add more pauses between block checks, reducing disk I/O at the cost
+                        of longer scrub duration. Maps to the "scrub-tranquility" worker variable.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                  type: object
+                zone:
+                  description: |-
+                    Zone is the Garage layout zone assigned to all nodes in this cluster.
+                    Garage distributes object replicas across zones for fault tolerance — data
+                    survives the loss of an entire zone as long as enough zones remain for quorum.
+
+                    Each cluster in a federation must have a unique zone name.
+                    Single-cluster deployments may omit this (Garage uses a default zone).
+
+                    Examples: "us-east-1", "rack-a", "dc1", "zone-a"
+                  type: string
+              required:
+                - replicas
+              type: object
+              x-kubernetes-validations:
+                - message: connectTo is required when gateway is true
+                  rule: '!has(self.gateway) || !self.gateway || has(self.connectTo)'
+                - message: connectTo can only be specified when gateway is true
+                  rule: (has(self.gateway) && self.gateway) || !has(self.connectTo)
+            status:
+              description: GarageClusterStatus defines the observed state of GarageCluster
+              properties:
+                activeRepairs:
+                  description: ActiveRepairs contains currently running repair operations
+                  items:
+                    description: RepairStatus contains status of a repair operation
+                    properties:
+                      nodeId:
+                        description: NodeID is the node running this repair
+                        type: string
+                      progress:
+                        description: Progress is a human-readable progress description
+                        type: string
+                      startedAt:
+                        description: StartedAt is when the repair started
+                        format: date-time
+                        type: string
+                      type:
+                        description: Type is the repair operation type (Tables, Blocks, Scrub, Rebalance, etc.)
+                        type: string
+                    type: object
+                  type: array
+                blockErrorDetails:
+                  description: BlockErrorDetails provides detailed information about block errors
+                  properties:
+                    count:
+                      description: Count is the total number of blocks with errors
+                      format: int32
+                      type: integer
+                    lastErrorAt:
+                      description: LastErrorAt is when the most recent block error occurred
+                      format: date-time
+                      type: string
+                    topErrors:
+                      description: |-
+                        TopErrors contains details about the most problematic blocks
+                        Limited to top 10 blocks by error count
+                      items:
+                        description: BlockErrorDetail contains information about a specific block error
+                        properties:
+                          blockHash:
+                            description: BlockHash is the hash of the affected block
+                            type: string
+                          errorCount:
+                            description: ErrorCount is the number of times this block failed to sync
+                            format: int32
+                            type: integer
+                          lastAttempt:
+                            description: LastAttempt is when the last sync attempt occurred
+                            format: date-time
+                            type: string
+                          lastError:
+                            description: LastError is the most recent error message for this block
+                            type: string
+                          nextRetry:
+                            description: NextRetry is when the next sync retry is scheduled
+                            format: date-time
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                blockErrors:
+                  description: BlockErrors is the count of blocks with sync errors across all nodes
+                  format: int32
+                  type: integer
+                buildInfo:
+                  description: BuildInfo contains Garage build information
+                  properties:
+                    features:
+                      description: Features lists enabled Cargo features
+                      items:
+                        type: string
+                      type: array
+                    rustVersion:
+                      description: RustVersion is the Rust compiler version used to build Garage
+                      type: string
+                    version:
+                      description: Version is the Garage version string (e.g., "v1.0.1")
+                      type: string
+                  type: object
+                clusterId:
+                  description: ClusterID is the unique identifier of the Garage cluster
+                  type: string
+                conditions:
+                  description: Conditions represent the current state of the cluster
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                drainingNodes:
+                  description: |-
+                    DrainingNodes is the count of nodes that are draining data from an older layout version.
+                    These nodes had a storage role in a previous layout and are migrating data to other nodes.
+                    A non-zero value indicates a layout transition is in progress.
+                  type: integer
+                endpoints:
+                  description: Endpoints contains service endpoints
+                  properties:
+                    admin:
+                      description: Admin is the admin API endpoint
+                      type: string
+                    k2v:
+                      description: K2V is the K2V API endpoint
+                      type: string
+                    metrics:
+                      description: Metrics is the Prometheus metrics endpoint (typically Admin + /metrics)
+                      type: string
+                    rpc:
+                      description: RPC is the internal RPC endpoint
+                      type: string
+                    s3:
+                      description: S3 is the S3 API endpoint
+                      type: string
+                    web:
+                      description: Web is the web hosting endpoint
+                      type: string
+                  type: object
+                health:
+                  description: Health contains cluster health information
+                  properties:
+                    available:
+                      description: Available indicates if quorum is available
+                      type: boolean
+                    connectedNodes:
+                      description: ConnectedNodes is the number of currently connected nodes
+                      type: integer
+                    healthy:
+                      description: Healthy indicates if all nodes are connected
+                      type: boolean
+                    knownNodes:
+                      description: KnownNodes is the number of nodes seen in cluster
+                      type: integer
+                    partitions:
+                      description: Partitions is the total partitions in layout
+                      type: integer
+                    partitionsAllOk:
+                      description: PartitionsAllOK is partitions with all nodes connected
+                      type: integer
+                    partitionsQuorum:
+                      description: PartitionsQuorum is partitions with quorum connectivity
+                      type: integer
+                    status:
+                      description: Status is the overall cluster status
+                      type: string
+                    storageNodes:
+                      description: StorageNodes is the number of storage nodes in layout
+                      type: integer
+                    storageNodesOk:
+                      description: StorageNodesOK is the number of connected storage nodes
+                      type: integer
+                  type: object
+                lastOperation:
+                  description: |-
+                    LastOperation records the result of the most recently triggered operational annotation
+                    (trigger-snapshot, trigger-repair, scrub-command)
+                  properties:
+                    error:
+                      description: Error contains the error message when Succeeded is false
+                      type: string
+                    succeeded:
+                      description: Succeeded indicates the operation completed without error
+                      type: boolean
+                    triggeredAt:
+                      description: TriggeredAt is when the operation was triggered
+                      format: date-time
+                      type: string
+                    type:
+                      description: Type is the operation type (e.g. "Snapshot", "Repair:Blocks", "Scrub:start")
+                      type: string
+                  type: object
+                layoutHistory:
+                  description: LayoutHistory contains layout version history
+                  properties:
+                    currentVersion:
+                      description: CurrentVersion is the current layout version
+                      format: int64
+                      type: integer
+                    minAck:
+                      description: MinAck is the minimum acknowledged layout version by all nodes
+                      format: int64
+                      type: integer
+                    versions:
+                      description: Versions contains the history of layout versions
+                      items:
+                        description: LayoutVersionInfo contains information about a layout version
+                        properties:
+                          gatewayNodes:
+                            description: GatewayNodes is the number of gateway nodes in this version
+                            type: integer
+                          status:
+                            description: Status is the version status (Current, Draining, Historical)
+                            type: string
+                          storageNodes:
+                            description: StorageNodes is the number of storage nodes in this version
+                            type: integer
+                          version:
+                            description: Version is the layout version number
+                            format: int64
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+                layoutPreview:
+                  description: LayoutPreview shows what would change if staged layout is applied
+                  properties:
+                    dataTransferEstimate:
+                      description: DataTransferEstimate is a human-readable estimate of data movement (e.g., "~50 GB")
+                      type: string
+                    nodesAdded:
+                      description: NodesAdded shows node IDs that would be added to the layout
+                      items:
+                        type: string
+                      type: array
+                    nodesModified:
+                      description: NodesModified shows node IDs with changed configuration (zone, capacity, tags)
+                      items:
+                        type: string
+                      type: array
+                    nodesRemoved:
+                      description: NodesRemoved shows node IDs that would be removed from the layout
+                      items:
+                        type: string
+                      type: array
+                    partitionTransfers:
+                      description: PartitionTransfers is the estimated number of partition transfers
+                      format: int32
+                      type: integer
+                    zonesAffected:
+                      description: ZonesAffected shows which zones would be affected by the changes
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                layoutVersion:
+                  description: LayoutVersion is the current layout version
+                  format: int64
+                  type: integer
+                lifecycleStatus:
+                  description: LifecycleStatus contains the status of bucket lifecycle operations
+                  properties:
+                    lastCompleted:
+                      description: |-
+                        LastCompleted is when the last lifecycle worker run completed
+                        (from lifecycle-last-completed worker variable)
+                      format: date-time
+                      type: string
+                  type: object
+                nodes:
+                  description: Nodes contains status information for each node
+                  items:
+                    description: NodeStatus contains status information for a Garage node
+                    properties:
+                      capacity:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: Capacity is the storage capacity of the node
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      connected:
+                        description: Connected indicates if the node is connected to the cluster
+                        type: boolean
+                      dataDiskAvailable:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: DataDiskAvailable is the available space on data disk
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      dataDiskTotal:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: DataDiskTotal is the total space on data disk
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      gateway:
+                        description: Gateway indicates if the node is gateway-only
+                        type: boolean
+                      metadataDiskAvailable:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: MetadataDiskAvailable is the available space on metadata disk
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      metadataDiskTotal:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: MetadataDiskTotal is the total space on metadata disk
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      nodeId:
+                        description: NodeID is the public key of the node
+                        type: string
+                      podName:
+                        description: PodName is the name of the pod running this node
+                        type: string
+                      version:
+                        description: Version is the Garage version running on this node
+                        type: string
+                      zone:
+                        description: Zone is the zone assignment of the node
+                        type: string
+                    type: object
+                  type: array
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation
+                  format: int64
+                  type: integer
+                phase:
+                  description: Phase represents the current phase of the cluster
+                  enum:
+                    - Pending
+                    - Creating
+                    - Running
+                    - Ready
+                    - Degraded
+                    - Updating
+                    - Deleting
+                    - Failed
+                    - Unknown
+                  type: string
+                readyReplicas:
+                  description: ReadyReplicas is the number of ready Garage pods
+                  format: int32
+                  type: integer
+                remoteClusters:
+                  description: RemoteClusters contains status of remote clusters in the federation
+                  items:
+                    description: RemoteClusterStatus is the status of a remote cluster
+                    properties:
+                      connected:
+                        description: Connected indicates if we can reach this cluster
+                        type: boolean
+                      healthyNodes:
+                        description: HealthyNodes is the number of healthy nodes
+                        type: integer
+                      lastSeen:
+                        description: LastSeen is when we last successfully connected
+                        format: date-time
+                        type: string
+                      name:
+                        description: Name is the cluster name
+                        type: string
+                      nodes:
+                        description: Nodes is the number of nodes in this cluster
+                        type: integer
+                      zone:
+                        description: Zone is the cluster's zone
+                        type: string
+                    type: object
+                  type: array
+                replicas:
+                  description: Replicas is the total number of Garage pods targeted by this cluster
+                  format: int32
+                  type: integer
+                resyncQueueLength:
+                  description: ResyncQueueLength is the total block resync queue depth across all nodes
+                  format: int64
+                  type: integer
+                scrubStatus:
+                  description: ScrubStatus contains the status of data scrub operations
+                  properties:
+                    corruptedBlocks:
+                      description: |-
+                        CorruptedBlocks is the number of corrupted blocks found in the last scrub
+                        (from scrub-corruptions_detected worker variable)
+                      format: int32
+                      type: integer
+                    lastCompleted:
+                      description: LastCompleted is when the last scrub completed (from scrub-last-completed worker variable)
+                      format: date-time
+                      type: string
+                    nextRun:
+                      description: NextRun is when the next scrub is scheduled to run (from scrub-next-run worker variable)
+                      format: date-time
+                      type: string
+                    nodeStatuses:
+                      description: NodeStatuses contains per-node scrub status
+                      items:
+                        description: NodeScrubStatus contains scrub status for a single node
+                        properties:
+                          errorsFound:
+                            description: ErrorsFound is the number of errors found on this node
+                            format: int32
+                            type: integer
+                          itemsChecked:
+                            description: ItemsChecked is the number of items checked
+                            format: int64
+                            type: integer
+                          nodeId:
+                            description: NodeID is the node identifier
+                            type: string
+                          progress:
+                            description: Progress percentage (0-100)
+                            type: integer
+                          running:
+                            description: Running indicates if scrub is running on this node
+                            type: boolean
+                        type: object
+                      type: array
+                    paused:
+                      description: Paused indicates if the scrub is paused
+                      type: boolean
+                    progress:
+                      description: Progress is a human-readable progress description (e.g., "45% complete")
+                      type: string
+                    running:
+                      description: Running indicates if a scrub is currently running on any node
+                      type: boolean
+                    tranquilityLevel:
+                      description: TranquilityLevel is the current tranquility setting (higher = less aggressive)
+                      type: integer
+                  type: object
+                selector:
+                  description: |-
+                    Selector is the serialized label selector for pods managed by this cluster.
+                    Required for the scale subresource to work with HPA/VPA.
+                  type: string
+                stagedLayoutVersion:
+                  description: StagedLayoutVersion is the staged layout version pending application
+                  format: int64
+                  type: integer
+                stagedRoles:
+                  description: StagedRoles is the number of roles in the staged layout
+                  format: int32
+                  type: integer
+                storageStats:
+                  description: StorageStats contains cluster-wide storage statistics
+                  properties:
+                    availableCapacity:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: AvailableCapacity is the available storage across all nodes
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    healthyPartitions:
+                      description: HealthyPartitions is the number of partitions with full redundancy
+                      format: int32
+                      type: integer
+                    totalCapacity:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: TotalCapacity is the total storage capacity across all nodes
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    totalPartitions:
+                      description: TotalPartitions is the total number of partitions in the layout
+                      format: int32
+                      type: integer
+                    usedCapacity:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: UsedCapacity is the used storage across all nodes
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                totalNodes:
+                  description: TotalNodes is the total nodes across all clusters (local + remote)
+                  type: integer
+                workerCount:
+                  description: WorkerCount is the total number of background workers
+                  format: int32
+                  type: integer
+                workers:
+                  description: Workers contains detailed information about background workers
+                  properties:
+                    busy:
+                      description: Busy is the number of busy/active workers
+                      format: int32
+                      type: integer
+                    errored:
+                      description: Errored is the number of workers with errors
+                      format: int32
+                      type: integer
+                    errors:
+                      description: Errors contains details about worker errors
+                      items:
+                        description: WorkerError contains information about a worker error
+                        properties:
+                          consecutiveErrors:
+                            description: ConsecutiveErrors is the count of consecutive errors
+                            format: int32
+                            type: integer
+                          lastError:
+                            description: LastError is the last error message
+                            type: string
+                          lastErrorSecsAgo:
+                            description: LastErrorSecsAgo is seconds since the last error
+                            format: int64
+                            type: integer
+                          name:
+                            description: Name is the worker name
+                            type: string
+                          workerId:
+                            description: WorkerID is the worker identifier
+                            format: int64
+                            type: integer
+                        type: object
+                      type: array
+                    idle:
+                      description: Idle is the number of idle workers
+                      format: int32
+                      type: integer
+                    total:
+                      description: Total is the total number of background workers
+                      format: int32
+                      type: integer
+                    variables:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Variables contains runtime worker configuration variables
+                        These can be adjusted through the Admin API to tune background worker behavior
+                      type: object
+                  type: object
+                workersFailed:
+                  description: WorkersFailed is the number of failed workers
+                  format: int32
+                  type: integer
+              required:
+                - replicas
+                - selector
+              type: object
+          required:
+            - spec
+          type: object
+      served: false
+      storage: false
+      subresources:
+        scale:
+          labelSelectorPath: .status.selector
+          specReplicasPath: .spec.replicas
+          statusReplicasPath: .status.replicas
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .status.storageReplicas
+          name: Storage
+          type: integer
+        - jsonPath: .status.gatewayReplicas
+          name: Gateway
+          type: integer
+        - jsonPath: .status.readyReplicas
+          name: Ready
+          type: integer
+        - jsonPath: .spec.zone
+          name: Zone
+          type: string
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: GarageCluster is the Schema for the garageclusters API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                GarageClusterSpec defines the desired state of a GarageCluster.
+
+                A cluster has two optional tiers:
+
+                  - `storage` — long-lived StatefulSet with PVCs for metadata and data blocks.
+                  - `gateway` — StatefulSet with a small metadata PVC and EmptyDir for the
+                    data dir. Routes S3/Admin traffic and stores no object blocks. The
+                    metadata PVC preserves the Ed25519 node identity across pod restarts,
+                    so rolling updates don't churn the cluster layout.
+
+                Exactly one of these must hold true:
+
+                 1. `storage` set (storage-only or unified with `gateway`).
+                 2. `gateway` set together with `storage` (unified cluster — most common).
+                 3. `gateway` set together with `connectTo` (edge gateway pattern — gateway pods
+                    live in a different K8s cluster from the storage backend).
+              properties:
+                admin:
+                  description: Admin configures the admin API endpoint and metrics
+                  properties:
+                    adminTokenSecretRef:
+                      description: |-
+                        AdminTokenSecretRef references the secret used by the operator to authenticate
+                        with Garage's Admin API.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    bindAddress:
+                      description: BindAddress is a custom bind address for the Admin API.
+                      type: string
+                    bindPort:
+                      default: 3903
+                      description: BindPort is the port to bind for admin API.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    metricsRequireToken:
+                      description: MetricsRequireToken requires Bearer token authentication for the /metrics endpoint.
+                      type: boolean
+                    metricsTokenSecretRef:
+                      description: MetricsTokenSecretRef references a secret containing a token that protects /metrics.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    traceSink:
+                      description: TraceSink is the OpenTelemetry collector address for tracing.
+                      type: string
+                  type: object
+                blocks:
+                  description: Blocks configures block storage settings
+                  properties:
+                    compressionLevel:
+                      description: CompressionLevel is the zstd compression level.
+                      pattern: ^(none|-?[1-9][0-9]*)$
+                      type: string
+                    disableScrub:
+                      description: DisableScrub disables automatic monthly data directory scrub.
+                      type: boolean
+                    maxConcurrentReads:
+                      description: MaxConcurrentReads is the maximum simultaneous block file reads.
+                      minimum: 1
+                      type: integer
+                    maxConcurrentWritesPerRequest:
+                      description: MaxConcurrentWritesPerRequest is the maximum parallel block writes per PUT request.
+                      minimum: 1
+                      type: integer
+                    ramBufferMax:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: RAMBufferMax is the maximum RAM for buffering blocks.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    size:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: 'Size is the size of data blocks (default: 1M).'
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    useLocalTZ:
+                      description: UseLocalTZ runs lifecycle worker at midnight in local timezone.
+                      type: boolean
+                  type: object
+                connectTo:
+                  description: |-
+                    ConnectTo specifies a remote storage cluster this cluster connects to.
+                    Required when `gateway` is set without `storage` (edge gateway pattern).
+                  properties:
+                    adminApiEndpoint:
+                      description: AdminAPIEndpoint is the storage cluster's Admin API URL.
+                      type: string
+                    adminTokenSecretRef:
+                      description: AdminTokenSecretRef references the storage cluster's admin token.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    bootstrapPeers:
+                      description: BootstrapPeers are initial peers for cluster formation.
+                      items:
+                        type: string
+                      type: array
+                    clusterRef:
+                      description: ClusterRef references a GarageCluster in the same namespace.
+                      properties:
+                        kubeConfigSecretRef:
+                          description: |-
+                            KubeConfigSecretRef references a secret containing a kubeconfig for a remote Kubernetes cluster.
+                            Only needed for multi-cluster federation where the GarageCluster lives in a different
+                            Kubernetes cluster entirely (not just a different namespace).
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        name:
+                          description: Name of the GarageCluster resource.
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the GarageCluster. Defaults to the referencing resource's namespace.
+                            Cross-namespace references require a GarageReferenceGrant in the target namespace.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    rpcSecretRef:
+                      description: RPCSecretRef references a secret containing the shared RPC secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                database:
+                  description: Database configures the metadata database engine
+                  properties:
+                    engine:
+                      default: lmdb
+                      description: Engine specifies the database engine to use.
+                      enum:
+                        - lmdb
+                        - sqlite
+                        - fjall
+                      type: string
+                    fjallBlockCacheSize:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: FjallBlockCacheSize is the block cache size for Fjall.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    lmdbMapSize:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: LMDBMapSize is the virtual memory region size for LMDB.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                defaultNodeTags:
+                  description: |-
+                    DefaultNodeTags are tags applied to all auto-managed nodes.
+                    Only used when LayoutPolicy is "Auto".
+                  items:
+                    type: string
+                  type: array
+                discovery:
+                  description: Discovery configures peer discovery mechanisms
+                  properties:
+                    consul:
+                      description: Consul configures Consul-based peer discovery.
+                      properties:
+                        api:
+                          default: catalog
+                          description: API specifies the service registration API.
+                          enum:
+                            - catalog
+                            - agent
+                          type: string
+                        caCert:
+                          description: CACert is the CA certificate for TLS connection.
+                          type: string
+                        caCertSecretRef:
+                          description: CACertSecretRef references a secret containing the CA certificate.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        clientCertSecretRef:
+                          description: ClientCertSecretRef references a secret containing client TLS cert.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        clientKeySecretRef:
+                          description: ClientKeySecretRef references a secret containing client TLS key.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        datacenters:
+                          description: Datacenters for WAN federation.
+                          items:
+                            type: string
+                          type: array
+                        enabled:
+                          description: Enabled enables Consul-based discovery.
+                          type: boolean
+                        httpAddr:
+                          description: HTTPAddr is the full HTTP(S) address of Consul server.
+                          type: string
+                        meta:
+                          additionalProperties:
+                            type: string
+                          description: Meta is service metadata key-value pairs.
+                          type: object
+                        serviceName:
+                          description: ServiceName for Garage RPC port registration.
+                          type: string
+                        tags:
+                          description: Tags are additional service tags.
+                          items:
+                            type: string
+                          type: array
+                        tlsSkipVerify:
+                          description: TLSSkipVerify skips TLS hostname verification.
+                          type: boolean
+                        tokenSecretRef:
+                          description: TokenSecretRef references a secret containing the bearer token.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    kubernetes:
+                      description: Kubernetes configures Kubernetes-based peer discovery.
+                      properties:
+                        enabled:
+                          description: Enabled enables Kubernetes-based discovery.
+                          type: boolean
+                        namespace:
+                          description: Namespace for Garage custom resources.
+                          type: string
+                        serviceName:
+                          description: ServiceName label to filter custom resources.
+                          type: string
+                        skipCRD:
+                          description: SkipCRD skips automatic CRD creation/patching.
+                          type: boolean
+                      type: object
+                  type: object
+                gateway:
+                  description: |-
+                    Gateway configures the gateway tier (StatefulSet + small metadata PVC).
+                    Gateway pods route S3/Admin traffic and store no object blocks; the
+                    metadata PVC persists their node identity across restarts.
+                    May be combined with `storage` (unified cluster) or `connectTo` (edge cluster).
+                  properties:
+                    affinity:
+                      description: Affinity for pod scheduling.
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and adding
+                                "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: |-
+                                  An empty preferred scheduling term matches all objects with implicit weight 0
+                                  (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated with the corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements by node's labels.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        description: A list of node selector requirements by node's fields.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  weight:
+                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                If the affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to an update), the system
+                                may or may not try to eventually evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms. The terms are ORed.
+                                  items:
+                                    description: |-
+                                      A null or empty node selector term matches no objects. The requirements of
+                                      them are ANDed.
+                                      The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements by node's labels.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        description: A list of node selector requirements by node's fields.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and adding
+                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          A label query over a set of resources, in this case pods.
+                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: |-
+                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: |-
+                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      namespaceSelector:
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      topologyKey:
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    description: |-
+                                      weight associated with matching the corresponding podAffinityTerm,
+                                      in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                If the affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod label update), the
+                                system may or may not try to eventually evict the pod from its node.
+                                When there are multiple elements, the lists of nodes corresponding to each
+                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: |-
+                                  Defines a set of pods (namely those matching the labelSelector
+                                  relative to the given namespace(s)) that this pod should be
+                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                  where co-located is defined as running on a node whose value of
+                                  the label with key <topologyKey> matches that of any node on which
+                                  a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  topologyKey:
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the anti-affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and subtracting
+                                "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          A label query over a set of resources, in this case pods.
+                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: |-
+                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: |-
+                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      namespaceSelector:
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      topologyKey:
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    description: |-
+                                      weight associated with matching the corresponding podAffinityTerm,
+                                      in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                If the anti-affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the anti-affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod label update), the
+                                system may or may not try to eventually evict the pod from its node.
+                                When there are multiple elements, the lists of nodes corresponding to each
+                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: |-
+                                  Defines a set of pods (namely those matching the labelSelector
+                                  relative to the given namespace(s)) that this pod should be
+                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                  where co-located is defined as running on a node whose value of
+                                  the label with key <topologyKey> matches that of any node on which
+                                  a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  topologyKey:
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                      type: object
+                    containerSecurityContext:
+                      description: ContainerSecurityContext for the Garage container.
+                      properties:
+                        allowPrivilegeEscalation:
+                          description: |-
+                            AllowPrivilegeEscalation controls whether a process can gain more
+                            privileges than its parent process. This bool directly controls if
+                            the no_new_privs flag will be set on the container process.
+                            AllowPrivilegeEscalation is true always when the container is:
+                            1) run as Privileged
+                            2) has CAP_SYS_ADMIN
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: boolean
+                        appArmorProfile:
+                          description: |-
+                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                            overrides the pod's appArmorProfile.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile loaded on the node that should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must match the loaded name of the profile.
+                                Must be set if and only if type is "Localhost".
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of AppArmor profile will be applied.
+                                Valid options are:
+                                  Localhost - a profile pre-loaded on the node.
+                                  RuntimeDefault - the container runtime's default profile.
+                                  Unconfined - no AppArmor enforcement.
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        capabilities:
+                          description: |-
+                            The capabilities to add/drop when running containers.
+                            Defaults to the default set of capabilities granted by the container runtime.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            add:
+                              description: Added capabilities
+                              items:
+                                description: Capability represent POSIX capabilities type
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            drop:
+                              description: Removed capabilities
+                              items:
+                                description: Capability represent POSIX capabilities type
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        privileged:
+                          description: |-
+                            Run container in privileged mode.
+                            Processes in privileged containers are essentially equivalent to root on the host.
+                            Defaults to false.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: boolean
+                        procMount:
+                          description: |-
+                            procMount denotes the type of proc mount to use for the containers.
+                            The default value is Default which uses the container runtime defaults for
+                            readonly paths and masked paths.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        readOnlyRootFilesystem:
+                          description: |-
+                            Whether this container has a read-only root filesystem.
+                            Default is false.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: boolean
+                        runAsGroup:
+                          description: |-
+                            The GID to run the entrypoint of the container process.
+                            Uses runtime default if unset.
+                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: |-
+                            Indicates that the container must run as a non-root user.
+                            If true, the Kubelet will validate the image at runtime to ensure that it
+                            does not run as UID 0 (root) and fail to start the container if it does.
+                            If unset or false, no such validation will be performed.
+                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: |-
+                            The UID to run the entrypoint of the container process.
+                            Defaults to user specified in image metadata if unspecified.
+                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: |-
+                            The SELinux context to be applied to the container.
+                            If unspecified, the container runtime will allocate a random SELinux context for each
+                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: |-
+                            The seccomp options to use by this container. If seccomp options are
+                            provided at both the pod & container level, the container options
+                            override the pod options.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of seccomp profile will be applied.
+                                Valid options are:
+
+                                Localhost - a profile defined in a file on the node should be used.
+                                RuntimeDefault - the container runtime default profile should be used.
+                                Unconfined - no profile should be applied.
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        windowsOptions:
+                          description: |-
+                            The Windows specific settings applied to all containers.
+                            If unspecified, the options from the PodSecurityContext will be used.
+                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is linux.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: |-
+                                GMSACredentialSpec is where the GMSA admission webhook
+                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                GMSA credential spec named by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: |-
+                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                All of a Pod's containers must have the same effective HostProcess value
+                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: |-
+                                The UserName in Windows to run the entrypoint of the container process.
+                                Defaults to the user specified in image metadata if unspecified.
+                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    env:
+                      description: |-
+                        Env is a list of additional environment variables to set on the Garage
+                        container. These are appended AFTER the operator's built-in vars
+                        (GARAGE_NODE_HOST, RUST_LOG, etc.), so a user-supplied entry with the same
+                        name as a built-in will override it. Typical use: setting
+                        GARAGE_ALLOW_WORLD_READABLE_SECRETS, or any other GARAGE_* env Garage
+                        honors at startup.
+                      items:
+                        description: EnvVar represents an environment variable present in a Container.
+                        properties:
+                          name:
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
+                            type: string
+                          value:
+                            description: |-
+                              Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in the container and
+                              any service environment variables. If a variable cannot be resolved,
+                              the reference in the input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                              Escaped references will never be expanded, regardless of whether the variable
+                              exists or not.
+                              Defaults to "".
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value. Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                description: |-
+                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the specified API version.
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                    type: string
+                                  optional:
+                                    default: false
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
+                                      If optional is set to true and the specified key does not exist,
+                                      the environment variable will not be set in the Pod's containers.
+
+                                      If optional is set to false and the specified key does not exist,
+                                      an error will be returned during Pod creation.
+                                    type: boolean
+                                  path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
+                                    type: string
+                                  volumeName:
+                                    description: The name of the volume mount containing the env file.
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes, optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Specifies the output format of the exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    envFrom:
+                      description: |-
+                        EnvFrom is a list of sources to populate environment variables in the
+                        Garage container, allowing injection from Secrets or ConfigMaps. These
+                        sources are evaluated before the per-variable Env list, matching standard
+                        Kubernetes container semantics.
+                      items:
+                        description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
+                        properties:
+                          configMapRef:
+                            description: The ConfigMap to select from
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap must be defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          prefix:
+                            description: |-
+                              Optional text to prepend to the name of each environment variable.
+                              May consist of any printable ASCII characters except '='.
+                            type: string
+                          secretRef:
+                            description: The Secret to select from
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret must be defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      type: array
+                    metadata:
+                      description: |-
+                        Metadata configures the metadata PVC for gateway pods. Only metadata_dir
+                        is persisted — data_dir stays EmptyDir because gateways do not store
+                        object blocks. Default size is 1Gi.
+                      properties:
+                        accessModes:
+                          description: AccessModes for the PVC.
+                          items:
+                            type: string
+                          type: array
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations to set on the PVC.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels to set on the PVC.
+                          type: object
+                        paths:
+                          description: |-
+                            Paths configures multiple data directories for multi-disk setups.
+                            Only valid for data volumes — webhook rejects this on metadata volumes.
+                          items:
+                            description: DataPath specifies a data directory with capacity.
+                            properties:
+                              capacity:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Capacity of the drive (required unless readOnly).
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              path:
+                                description: Path to the data directory.
+                                type: string
+                              readOnly:
+                                description: ReadOnly marks directory as legacy read-only for migrations.
+                                type: boolean
+                              volume:
+                                description: Volume configuration if using PVC.
+                                properties:
+                                  accessModes:
+                                    description: AccessModes for the PVC.
+                                    items:
+                                      type: string
+                                    type: array
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to set on the PVC.
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: Labels to set on the PVC.
+                                    type: object
+                                  selector:
+                                    description: Selector to select PVs.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  size:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Size of the volume (storage request).
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  storageClassName:
+                                    description: StorageClassName for the PVC.
+                                    type: string
+                                  type:
+                                    default: PersistentVolumeClaim
+                                    description: Type specifies the volume type.
+                                    enum:
+                                      - PersistentVolumeClaim
+                                      - EmptyDir
+                                    type: string
+                                  volumeClaimTemplateSpec:
+                                    description: VolumeClaimTemplateSpec allows full customization of the PVC.
+                                    properties:
+                                      accessModes:
+                                        description: |-
+                                          accessModes contains the desired access modes the volume should have.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      dataSource:
+                                        description: |-
+                                          dataSource field can be used to specify either:
+                                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          * An existing PVC (PersistentVolumeClaim)
+                                          If the provisioner or an external controller can support the specified data source,
+                                          it will create a new volume based on the contents of the specified data source.
+                                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource being referenced
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      dataSourceRef:
+                                        description: |-
+                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                          volume is desired. This may be any object from a non-empty API group (non
+                                          core object) or a PersistentVolumeClaim object.
+                                          When this field is specified, volume binding will only succeed if the type of
+                                          the specified object matches some installed volume populator or dynamic
+                                          provisioner.
+                                          This field will replace the functionality of the dataSource field and as such
+                                          if both fields are non-empty, they must have the same value. For backwards
+                                          compatibility, when namespace isn't specified in dataSourceRef,
+                                          both fields (dataSource and dataSourceRef) will be set to the same
+                                          value automatically if one of them is empty and the other is non-empty.
+                                          When namespace is specified in dataSourceRef,
+                                          dataSource isn't set to the same value and must be empty.
+                                          There are three important differences between dataSource and dataSourceRef:
+                                          * While dataSource only allows two specific types of objects, dataSourceRef
+                                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                            preserves all values, and generates an error if a disallowed value is
+                                            specified.
+                                          * While dataSource only allows local objects, dataSourceRef allows objects
+                                            in any namespaces.
+                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource being referenced
+                                            type: string
+                                          namespace:
+                                            description: |-
+                                              Namespace is the namespace of resource being referenced
+                                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                      resources:
+                                        description: |-
+                                          resources represents the minimum resources the volume should have.
+                                          Users are allowed to specify resource requirements
+                                          that are lower than previous value but must still be higher than capacity recorded in the
+                                          status field of the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Limits describes the maximum amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Requests describes the minimum amount of compute resources required.
+                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                        type: object
+                                      selector:
+                                        description: selector is a label query over volumes to consider for binding.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      storageClassName:
+                                        description: |-
+                                          storageClassName is the name of the StorageClass required by the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                        type: string
+                                      volumeAttributesClassName:
+                                        description: |-
+                                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                          If specified, the CSI driver will create or update the volume with the attributes defined
+                                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                          this field can be reset to its previous value (including nil) to cancel the modification.
+                                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                          exists.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                        type: string
+                                      volumeMode:
+                                        description: |-
+                                          volumeMode defines what type of volume is required by the claim.
+                                          Value of Filesystem is implied when not included in claim spec.
+                                        type: string
+                                      volumeName:
+                                        description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                        type: string
+                                    type: object
+                                type: object
+                            required:
+                              - path
+                            type: object
+                          type: array
+                        selector:
+                          description: Selector to select PVs.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        size:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: Size of the volume.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        storageClassName:
+                          description: StorageClassName for the PVC.
+                          type: string
+                        type:
+                          default: PersistentVolumeClaim
+                          description: 'Type specifies the volume type: PersistentVolumeClaim (default) or EmptyDir.'
+                          enum:
+                            - PersistentVolumeClaim
+                            - EmptyDir
+                          type: string
+                        volumeClaimTemplateSpec:
+                          description: VolumeClaimTemplateSpec allows full customization of the PVC.
+                          properties:
+                            accessModes:
+                              description: |-
+                                accessModes contains the desired access modes the volume should have.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            dataSource:
+                              description: |-
+                                dataSource field can be used to specify either:
+                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                * An existing PVC (PersistentVolumeClaim)
+                                If the provisioner or an external controller can support the specified data source,
+                                it will create a new volume based on the contents of the specified data source.
+                                When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being referenced
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            dataSourceRef:
+                              description: |-
+                                dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                volume is desired. This may be any object from a non-empty API group (non
+                                core object) or a PersistentVolumeClaim object.
+                                When this field is specified, volume binding will only succeed if the type of
+                                the specified object matches some installed volume populator or dynamic
+                                provisioner.
+                                This field will replace the functionality of the dataSource field and as such
+                                if both fields are non-empty, they must have the same value. For backwards
+                                compatibility, when namespace isn't specified in dataSourceRef,
+                                both fields (dataSource and dataSourceRef) will be set to the same
+                                value automatically if one of them is empty and the other is non-empty.
+                                When namespace is specified in dataSourceRef,
+                                dataSource isn't set to the same value and must be empty.
+                                There are three important differences between dataSource and dataSourceRef:
+                                * While dataSource only allows two specific types of objects, dataSourceRef
+                                  allows any non-core object, as well as PersistentVolumeClaim objects.
+                                * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                  preserves all values, and generates an error if a disallowed value is
+                                  specified.
+                                * While dataSource only allows local objects, dataSourceRef allows objects
+                                  in any namespaces.
+                                (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being referenced
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace is the namespace of resource being referenced
+                                    Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                    (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                            resources:
+                              description: |-
+                                resources represents the minimum resources the volume should have.
+                                Users are allowed to specify resource requirements
+                                that are lower than previous value but must still be higher than capacity recorded in the
+                                status field of the claim.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            selector:
+                              description: selector is a label query over volumes to consider for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            storageClassName:
+                              description: |-
+                                storageClassName is the name of the StorageClass required by the claim.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                              type: string
+                            volumeAttributesClassName:
+                              description: |-
+                                volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                If specified, the CSI driver will create or update the volume with the attributes defined
+                                in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                it can be changed after the claim is created. An empty string or nil value indicates that no
+                                VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                this field can be reset to its previous value (including nil) to cancel the modification.
+                                If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                exists.
+                                More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                              type: string
+                            volumeMode:
+                              description: |-
+                                volumeMode defines what type of volume is required by the claim.
+                                Value of Filesystem is implied when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                      type: object
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: NodeSelector for pod scheduling.
+                      type: object
+                    podAnnotations:
+                      additionalProperties:
+                        type: string
+                      description: PodAnnotations to add to pods.
+                      type: object
+                    podLabels:
+                      additionalProperties:
+                        type: string
+                      description: PodLabels to add to pods.
+                      type: object
+                    priorityClassName:
+                      description: PriorityClassName for pods.
+                      type: string
+                    replicas:
+                      default: 2
+                      description: |-
+                        Replicas is the number of gateway pods to deploy. Set to 0 to keep the
+                        gateway tier declared but stop all pods; the operator scales the
+                        statefulset down and removes vacated entries from the layout.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    resources:
+                      description: Resources specifies compute resources for the pod.
+                      properties:
+                        claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
+
+                            This field depends on the
+                            DynamicResourceAllocation feature gate.
+
+                            This field is immutable. It can only be set for containers.
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used. It makes that resource available
+                                  inside a container.
+                                type: string
+                              request:
+                                description: |-
+                                  Request is the name chosen for a request in the referenced claim.
+                                  If empty, everything from the claim is made available, otherwise
+                                  only the result of this request.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                    rpcPublicAddr:
+                      description: |-
+                        RPCPublicAddr, when set, is written into the gateway pods' garage.toml as
+                        rpc_public_addr so that peers in other regions can dial gateways by hostname.
+                        Purely cosmetic for federated layouts — leave unset when gateways only
+                        communicate with the local storage tier.
+                      type: string
+                    securityContext:
+                      description: SecurityContext for the pod.
+                      properties:
+                        appArmorProfile:
+                          description: |-
+                            appArmorProfile is the AppArmor options to use by the containers in this pod.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile loaded on the node that should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must match the loaded name of the profile.
+                                Must be set if and only if type is "Localhost".
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of AppArmor profile will be applied.
+                                Valid options are:
+                                  Localhost - a profile pre-loaded on the node.
+                                  RuntimeDefault - the container runtime's default profile.
+                                  Unconfined - no AppArmor enforcement.
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        fsGroup:
+                          description: |-
+                            A special supplemental group that applies to all containers in a pod.
+                            Some volume types allow the Kubelet to change the ownership of that volume
+                            to be owned by the pod:
+
+                            1. The owning GID will be the FSGroup
+                            2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                            3. The permission bits are OR'd with rw-rw----
+
+                            If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          description: |-
+                            fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                            before being exposed inside Pod. This field will only apply to
+                            volume types which support fsGroup based ownership(and permissions).
+                            It will have no effect on ephemeral volume types such as: secret, configmaps
+                            and emptydir.
+                            Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        runAsGroup:
+                          description: |-
+                            The GID to run the entrypoint of the container process.
+                            Uses runtime default if unset.
+                            May also be set in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                            for that container.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: |-
+                            Indicates that the container must run as a non-root user.
+                            If true, the Kubelet will validate the image at runtime to ensure that it
+                            does not run as UID 0 (root) and fail to start the container if it does.
+                            If unset or false, no such validation will be performed.
+                            May also be set in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: |-
+                            The UID to run the entrypoint of the container process.
+                            Defaults to user specified in image metadata if unspecified.
+                            May also be set in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                            for that container.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        seLinuxChangePolicy:
+                          description: |-
+                            seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                            It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                            Valid values are "MountOption" and "Recursive".
+
+                            "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                            This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                            "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                            This requires all Pods that share the same volume to use the same SELinux label.
+                            It is not possible to share the same volume among privileged and unprivileged Pods.
+                            Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                            whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                            CSIDriver instance. Other volumes are always re-labelled recursively.
+                            "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                            If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                            If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                            and "Recursive" for all other volumes.
+
+                            This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                            All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        seLinuxOptions:
+                          description: |-
+                            The SELinux context to be applied to all containers.
+                            If unspecified, the container runtime will allocate a random SELinux context for each
+                            container.  May also be set in SecurityContext.  If set in
+                            both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: |-
+                            The seccomp options to use by the containers in this pod.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of seccomp profile will be applied.
+                                Valid options are:
+
+                                Localhost - a profile defined in a file on the node should be used.
+                                RuntimeDefault - the container runtime default profile should be used.
+                                Unconfined - no profile should be applied.
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        supplementalGroups:
+                          description: |-
+                            A list of groups applied to the first process run in each container, in
+                            addition to the container's primary GID and fsGroup (if specified).  If
+                            the SupplementalGroupsPolicy feature is enabled, the
+                            supplementalGroupsPolicy field determines whether these are in addition
+                            to or instead of any group memberships defined in the container image.
+                            If unspecified, no additional groups are added, though group memberships
+                            defined in the container image may still be used, depending on the
+                            supplementalGroupsPolicy field.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        supplementalGroupsPolicy:
+                          description: |-
+                            Defines how supplemental groups of the first container processes are calculated.
+                            Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                            (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                            and the container runtime must implement support for this feature.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        sysctls:
+                          description: |-
+                            Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                            sysctls (by the container runtime) might fail to launch.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          items:
+                            description: Sysctl defines a kernel parameter to be set
+                            properties:
+                              name:
+                                description: Name of a property to set
+                                type: string
+                              value:
+                                description: Value of a property to set
+                                type: string
+                            required:
+                              - name
+                              - value
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        windowsOptions:
+                          description: |-
+                            The Windows specific settings applied to all containers.
+                            If unspecified, the options within a container's SecurityContext will be used.
+                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is linux.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: |-
+                                GMSACredentialSpec is where the GMSA admission webhook
+                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                GMSA credential spec named by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: |-
+                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                All of a Pod's containers must have the same effective HostProcess value
+                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: |-
+                                The UserName in Windows to run the entrypoint of the container process.
+                                Defaults to the user specified in image metadata if unspecified.
+                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    tolerations:
+                      description: Tolerations for pod scheduling.
+                      items:
+                        description: |-
+                          The pod this Toleration is attached to tolerates any taint that matches
+                          the triple <key,value,effect> using the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: |-
+                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value.
+                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                              Exists is equivalent to wildcard for value, so that a pod can
+                              tolerate all taints of a particular category.
+                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                            type: string
+                          tolerationSeconds:
+                            description: |-
+                              TolerationSeconds represents the period of time the toleration (which must be
+                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                              negative values will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: |-
+                              Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                    topologySpreadConstraints:
+                      description: TopologySpreadConstraints for pod scheduling.
+                      items:
+                        description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                        properties:
+                          labelSelector:
+                            description: |-
+                              LabelSelector is used to find matching pods.
+                              Pods that match this label selector are counted to determine the number of pods
+                              in their corresponding topology domain.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          matchLabelKeys:
+                            description: |-
+                              MatchLabelKeys is a set of pod label keys to select the pods over which
+                              spreading will be calculated. The keys are used to lookup values from the
+                              incoming pod labels, those key-value labels are ANDed with labelSelector
+                              to select the group of existing pods over which spreading will be calculated
+                              for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                              MatchLabelKeys cannot be set when LabelSelector isn't set.
+                              Keys that don't exist in the incoming pod labels will
+                              be ignored. A null or empty list means only match against labelSelector.
+
+                              This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          maxSkew:
+                            description: |-
+                              MaxSkew describes the degree to which pods may be unevenly distributed.
+                              When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                              between the number of matching pods in the target topology and the global minimum.
+                              The global minimum is the minimum number of matching pods in an eligible domain
+                              or zero if the number of eligible domains is less than MinDomains.
+                              For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                              labelSelector spread as 2/2/1:
+                              In this case, the global minimum is 1.
+                              | zone1 | zone2 | zone3 |
+                              |  P P  |  P P  |   P   |
+                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                              scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                              violate MaxSkew(1).
+                              - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                              When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                              to topologies that satisfy it.
+                              It's a required field. Default value is 1 and 0 is not allowed.
+                            format: int32
+                            type: integer
+                          minDomains:
+                            description: |-
+                              MinDomains indicates a minimum number of eligible domains.
+                              When the number of eligible domains with matching topology keys is less than minDomains,
+                              Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                              And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                              this value has no effect on scheduling.
+                              As a result, when the number of eligible domains is less than minDomains,
+                              scheduler won't schedule more than maxSkew Pods to those domains.
+                              If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                              Valid values are integers greater than 0.
+                              When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                              For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                              labelSelector spread as 2/2/2:
+                              | zone1 | zone2 | zone3 |
+                              |  P P  |  P P  |  P P  |
+                              The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                              In this situation, new pod with the same labelSelector cannot be scheduled,
+                              because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                              it will violate MaxSkew.
+                            format: int32
+                            type: integer
+                          nodeAffinityPolicy:
+                            description: |-
+                              NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                              when calculating pod topology spread skew. Options are:
+                              - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                              - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                              If this value is nil, the behavior is equivalent to the Honor policy.
+                            type: string
+                          nodeTaintsPolicy:
+                            description: |-
+                              NodeTaintsPolicy indicates how we will treat node taints when calculating
+                              pod topology spread skew. Options are:
+                              - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                              has a toleration, are included.
+                              - Ignore: node taints are ignored. All nodes are included.
+
+                              If this value is nil, the behavior is equivalent to the Ignore policy.
+                            type: string
+                          topologyKey:
+                            description: |-
+                              TopologyKey is the key of node labels. Nodes that have a label with this key
+                              and identical values are considered to be in the same topology.
+                              We consider each <key, value> as a "bucket", and try to put balanced number
+                              of pods into each bucket.
+                              We define a domain as a particular instance of a topology.
+                              Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                              nodeAffinityPolicy and nodeTaintsPolicy.
+                              e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                              And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                              It's a required field.
+                            type: string
+                          whenUnsatisfiable:
+                            description: |-
+                              WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                              the spread constraint.
+                              - DoNotSchedule (default) tells the scheduler not to schedule it.
+                              - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                but giving higher precedence to topologies that would help reduce the
+                                skew.
+                              A constraint is considered "Unsatisfiable" for an incoming pod
+                              if and only if every possible node assignment for that pod would violate
+                              "MaxSkew" on some topology.
+                              For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                              labelSelector spread as 3/1/1:
+                              | zone1 | zone2 | zone3 |
+                              | P P P |   P   |   P   |
+                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                              to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                              MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                              won't make it *more* imbalanced.
+                              It's a required field.
+                            type: string
+                        required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
+                        type: object
+                      type: array
+                  required:
+                    - replicas
+                  type: object
+                image:
+                  default: dxflrs/garage:v2.3.0
+                  description: |-
+                    Image specifies the Garage container image to use.
+                    Takes precedence over imageRepository if both are set.
+                  type: string
+                imagePullPolicy:
+                  default: IfNotPresent
+                  description: ImagePullPolicy specifies the image pull policy
+                  type: string
+                imagePullSecrets:
+                  description: ImagePullSecrets specifies secrets for pulling images from private registries
+                  items:
+                    description: |-
+                      LocalObjectReference contains enough information to let you locate the
+                      referenced object inside the same namespace.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                imageRepository:
+                  description: |-
+                    ImageRepository overrides just the repository portion of the default Garage image,
+                    preserving the default tag for automatic version upgrades.
+                    Ignored if image is set.
+                  type: string
+                k2vApi:
+                  description: |-
+                    K2VAPI configures the K2V (key-value) API endpoint.
+                    Omit to disable K2V.
+                  properties:
+                    bindAddress:
+                      description: BindAddress is a custom bind address for the K2V API.
+                      type: string
+                    bindPort:
+                      default: 3904
+                      description: BindPort is the port to bind for K2V API.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                  type: object
+                layoutManagement:
+                  description: LayoutManagement controls automatic layout application behavior.
+                  properties:
+                    autoApply:
+                      description: AutoApply automatically applies staged layout changes.
+                      type: boolean
+                    minNodesHealthy:
+                      description: MinNodesHealthy is the minimum healthy nodes required before applying layout changes.
+                      type: integer
+                  type: object
+                layoutPolicy:
+                  default: Auto
+                  description: LayoutPolicy controls whether node layouts are automatically managed or manually configured.
+                  enum:
+                    - Auto
+                    - Manual
+                  type: string
+                logging:
+                  description: Logging configures logging behavior for Garage nodes
+                  properties:
+                    journald:
+                      description: Journald enables logging to systemd journald.
+                      type: boolean
+                    level:
+                      description: Level sets the log level using RUST_LOG format.
+                      type: string
+                    syslog:
+                      description: Syslog enables logging to syslog.
+                      type: boolean
+                  type: object
+                maintenance:
+                  description: Maintenance configures maintenance mode for this cluster.
+                  properties:
+                    suspended:
+                      description: Suspended pauses all reconciliation for this cluster.
+                      type: boolean
+                  type: object
+                monitoring:
+                  description: Monitoring configures Prometheus integration for this cluster.
+                  properties:
+                    additionalLabels:
+                      additionalProperties:
+                        type: string
+                      description: AdditionalLabels are added to the ServiceMonitor metadata.
+                      type: object
+                    enabled:
+                      description: Enabled creates a ServiceMonitor targeting the admin API /metrics endpoint.
+                      type: boolean
+                    interval:
+                      description: Interval is the Prometheus scrape interval (e.g. "30s", "1m").
+                      type: string
+                  type: object
+                network:
+                  description: Network configures RPC and API networking
+                  properties:
+                    bootstrapPeers:
+                      description: BootstrapPeers lists initial peers for cluster formation.
+                      items:
+                        type: string
+                      type: array
+                    rpcBindAddress:
+                      description: RPCBindAddress is a custom bind address for the RPC server.
+                      type: string
+                    rpcBindOutgoing:
+                      description: RPCBindOutgoing pre-binds outgoing sockets to same IP.
+                      type: boolean
+                    rpcBindPort:
+                      default: 3901
+                      description: RPCBindPort is the port for inter-cluster RPC.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    rpcPingTimeout:
+                      description: RPCPingTimeout sets the RPC ping timeout.
+                      type: string
+                    rpcPublicAddr:
+                      description: |-
+                        RPCPublicAddr is the external address for storage-tier nodes to advertise.
+                        Gateway tier has its own rpcPublicAddr field on `spec.gateway`.
+                      type: string
+                    rpcPublicAddrSubnet:
+                      description: RPCPublicAddrSubnet filters autodiscovered IPs to specific subnet.
+                      type: string
+                    rpcSecretRef:
+                      description: RPCSecretRef references a secret containing the shared RPC secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    rpcTimeout:
+                      description: RPCTimeout sets the RPC call timeout.
+                      type: string
+                    service:
+                      description: Service configures the Kubernetes Service for the cluster.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations to add to the service.
+                          type: object
+                        externalTrafficPolicy:
+                          description: ExternalTrafficPolicy for LoadBalancer/NodePort.
+                          type: string
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels to add to the service. Operator-managed labels take precedence on conflict.
+                          type: object
+                        loadBalancerIP:
+                          description: LoadBalancerIP for LoadBalancer type.
+                          type: string
+                        loadBalancerSourceRanges:
+                          description: LoadBalancerSourceRanges for LoadBalancer type.
+                          items:
+                            type: string
+                          type: array
+                        type:
+                          default: ClusterIP
+                          description: Type of service.
+                          enum:
+                            - ClusterIP
+                            - NodePort
+                            - LoadBalancer
+                          type: string
+                      type: object
+                  type: object
+                publicEndpoint:
+                  description: |-
+                    PublicEndpoint configures how remote clusters reach this cluster's nodes.
+                    Used for multi-cluster federation of the storage tier.
+                  properties:
+                    externalIP:
+                      description: ExternalIP configuration.
+                      properties:
+                        addressTemplate:
+                          description: AddressTemplate uses go template to generate addresses from pod info.
+                          type: string
+                        addresses:
+                          additionalProperties:
+                            type: string
+                          description: Addresses maps pod names to external IPs.
+                          type: object
+                      type: object
+                    loadBalancer:
+                      description: LoadBalancer configuration.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations to add to the service.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels to add to the service. Operator-managed labels take precedence on conflict.
+                          type: object
+                        perNode:
+                          description: PerNode creates a separate LoadBalancer service per GarageCluster pod.
+                          type: boolean
+                      type: object
+                    nodePort:
+                      description: NodePort configuration.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations to add to the service.
+                          type: object
+                        basePort:
+                          description: BasePort is the starting NodePort; Garage pod N is exposed on BasePort+N.
+                          format: int32
+                          maximum: 32767
+                          minimum: 30000
+                          type: integer
+                        externalAddresses:
+                          description: ExternalAddresses are the externally-reachable IPs or hostnames of the Kubernetes nodes.
+                          items:
+                            type: string
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels to add to the service. Operator-managed labels take precedence on conflict.
+                          type: object
+                      required:
+                        - externalAddresses
+                      type: object
+                    type:
+                      description: Type specifies how nodes are exposed to remote clusters for RPC.
+                      enum:
+                        - LoadBalancer
+                        - NodePort
+                        - ExternalIP
+                        - Headless
+                      type: string
+                  required:
+                    - type
+                  type: object
+                remoteClusters:
+                  description: |-
+                    RemoteClusters lists Garage clusters in other Kubernetes clusters to federate with.
+                    Applies to the storage tier. Gateways inherit reachability via the local storage peer.
+                  items:
+                    description: RemoteClusterConfig defines a Garage cluster in another Kubernetes cluster.
+                    properties:
+                      connection:
+                        description: Connection defines how to connect to this remote cluster.
+                        properties:
+                          adminApiEndpoint:
+                            description: AdminAPIEndpoint is the admin API endpoint of the remote cluster.
+                            minLength: 1
+                            type: string
+                          adminTokenSecretRef:
+                            description: AdminTokenSecretRef references the admin token for the remote cluster's API.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          gatewayRpcEndpointTemplate:
+                            description: |-
+                              GatewayRPCEndpointTemplate is a hostname:port template used by federation
+                              to connect to remote gateway pods individually. The literal `{ordinal}`
+                              is replaced with each remote gateway pod's ordinal (0, 1, ...) parsed
+                              from the layout role's pod-name tag (e.g. `garage-gateway-0`).
+
+                              Required when the remote cluster runs gateway pods that participate in
+                              the cluster layout (default since v0.5.8). FullReplication tables
+                              (key_table, bucket_table, ...) need quorum across all_nodes, which
+                              includes remote gateways. Without this field the operator only peers
+                              storage↔storage cross-region; remote gateways appear in layout but
+                              remain unreachable, blocking GetKeyInfo / DeleteKey / FullReplication
+                              writes that need full quorum.
+
+                              Example: "ottawa-garage-gw-{ordinal}.keiretsu.ts.net:3901"
+                            type: string
+                        required:
+                          - adminApiEndpoint
+                        type: object
+                      defaultCapacity:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: DefaultCapacity is the default storage capacity to assign to remote nodes.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      name:
+                        description: Name is a friendly name for this remote cluster.
+                        minLength: 1
+                        type: string
+                      zone:
+                        description: Zone is the zone name for nodes in this remote cluster.
+                        minLength: 1
+                        type: string
+                    required:
+                      - connection
+                      - name
+                      - zone
+                    type: object
+                  type: array
+                replication:
+                  description: |-
+                    Replication configures data replication settings.
+                    If omitted, defaults to factor: 3 and consistencyMode: consistent.
+                  properties:
+                    consistencyMode:
+                      default: consistent
+                      description: ConsistencyMode controls quorum behavior for read/write operations.
+                      enum:
+                        - consistent
+                        - degraded
+                        - dangerous
+                      type: string
+                    factor:
+                      default: 3
+                      description: Factor is the replication factor (1, 2, 3, 5, 7, etc.)
+                      maximum: 7
+                      minimum: 1
+                      type: integer
+                    zoneRedundancyMinZones:
+                      description: ZoneRedundancyMinZones is the minimum number of zones required.
+                      maximum: 7
+                      minimum: 1
+                      type: integer
+                    zoneRedundancyMode:
+                      description: ZoneRedundancyMode controls how data is distributed across zones.
+                      enum:
+                        - Maximum
+                        - AtLeast
+                      type: string
+                  required:
+                    - factor
+                  type: object
+                s3Api:
+                  description: S3API configures the S3-compatible API endpoint
+                  properties:
+                    bindAddress:
+                      description: BindAddress is a custom bind address for the S3 API.
+                      type: string
+                    bindPort:
+                      default: 3900
+                      description: BindPort is the port to bind for S3 API.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    region:
+                      default: garage
+                      description: Region is the AWS S3 region name to use.
+                      type: string
+                    rootDomain:
+                      description: RootDomain is the root domain suffix for vhost-style S3 access.
+                      type: string
+                  required:
+                    - region
+                  type: object
+                security:
+                  description: Security configures security-related settings
+                  properties:
+                    allowInsecureSecretPermissions:
+                      description: |-
+                        AllowInsecureSecretPermissions bypasses Garage's check that secret files
+                        are not world-readable on disk.
+                      type: boolean
+                    allowPunycode:
+                      description: AllowPunycode allows punycode in bucket names.
+                      type: boolean
+                    tls:
+                      description: TLS configures TLS settings.
+                      properties:
+                        caSecretRef:
+                          description: CASecretRef references a secret containing the CA certificate.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        certSecretRef:
+                          description: CertSecretRef references a secret containing the TLS certificate for RPC.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        enabled:
+                          description: Enabled enables TLS for inter-node RPC communication.
+                          type: boolean
+                        keySecretRef:
+                          description: KeySecretRef references a secret containing the TLS private key for RPC.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  type: object
+                serviceAccountName:
+                  description: ServiceAccountName for Garage pods (shared by both tiers).
+                  type: string
+                storage:
+                  description: |-
+                    Storage configures the long-lived storage tier (StatefulSet + PVCs).
+                    Omit for gateway-only edge clusters.
+                  properties:
+                    affinity:
+                      description: Affinity for pod scheduling.
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and adding
+                                "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: |-
+                                  An empty preferred scheduling term matches all objects with implicit weight 0
+                                  (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated with the corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements by node's labels.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        description: A list of node selector requirements by node's fields.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  weight:
+                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                If the affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to an update), the system
+                                may or may not try to eventually evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms. The terms are ORed.
+                                  items:
+                                    description: |-
+                                      A null or empty node selector term matches no objects. The requirements of
+                                      them are ANDed.
+                                      The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements by node's labels.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        description: A list of node selector requirements by node's fields.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and adding
+                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          A label query over a set of resources, in this case pods.
+                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: |-
+                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: |-
+                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      namespaceSelector:
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      topologyKey:
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    description: |-
+                                      weight associated with matching the corresponding podAffinityTerm,
+                                      in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                If the affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod label update), the
+                                system may or may not try to eventually evict the pod from its node.
+                                When there are multiple elements, the lists of nodes corresponding to each
+                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: |-
+                                  Defines a set of pods (namely those matching the labelSelector
+                                  relative to the given namespace(s)) that this pod should be
+                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                  where co-located is defined as running on a node whose value of
+                                  the label with key <topologyKey> matches that of any node on which
+                                  a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  topologyKey:
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the anti-affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and subtracting
+                                "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          A label query over a set of resources, in this case pods.
+                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: |-
+                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: |-
+                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      namespaceSelector:
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      topologyKey:
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    description: |-
+                                      weight associated with matching the corresponding podAffinityTerm,
+                                      in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                If the anti-affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the anti-affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod label update), the
+                                system may or may not try to eventually evict the pod from its node.
+                                When there are multiple elements, the lists of nodes corresponding to each
+                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: |-
+                                  Defines a set of pods (namely those matching the labelSelector
+                                  relative to the given namespace(s)) that this pod should be
+                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                  where co-located is defined as running on a node whose value of
+                                  the label with key <topologyKey> matches that of any node on which
+                                  a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  topologyKey:
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                      type: object
+                    capacityReservePercent:
+                      description: |-
+                        CapacityReservePercent reserves a percentage of PVC capacity for overhead.
+                        Only meaningful when LayoutPolicy is "Auto".
+                      maximum: 50
+                      minimum: 0
+                      type: integer
+                    containerSecurityContext:
+                      description: ContainerSecurityContext for the Garage container.
+                      properties:
+                        allowPrivilegeEscalation:
+                          description: |-
+                            AllowPrivilegeEscalation controls whether a process can gain more
+                            privileges than its parent process. This bool directly controls if
+                            the no_new_privs flag will be set on the container process.
+                            AllowPrivilegeEscalation is true always when the container is:
+                            1) run as Privileged
+                            2) has CAP_SYS_ADMIN
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: boolean
+                        appArmorProfile:
+                          description: |-
+                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                            overrides the pod's appArmorProfile.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile loaded on the node that should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must match the loaded name of the profile.
+                                Must be set if and only if type is "Localhost".
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of AppArmor profile will be applied.
+                                Valid options are:
+                                  Localhost - a profile pre-loaded on the node.
+                                  RuntimeDefault - the container runtime's default profile.
+                                  Unconfined - no AppArmor enforcement.
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        capabilities:
+                          description: |-
+                            The capabilities to add/drop when running containers.
+                            Defaults to the default set of capabilities granted by the container runtime.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            add:
+                              description: Added capabilities
+                              items:
+                                description: Capability represent POSIX capabilities type
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            drop:
+                              description: Removed capabilities
+                              items:
+                                description: Capability represent POSIX capabilities type
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        privileged:
+                          description: |-
+                            Run container in privileged mode.
+                            Processes in privileged containers are essentially equivalent to root on the host.
+                            Defaults to false.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: boolean
+                        procMount:
+                          description: |-
+                            procMount denotes the type of proc mount to use for the containers.
+                            The default value is Default which uses the container runtime defaults for
+                            readonly paths and masked paths.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        readOnlyRootFilesystem:
+                          description: |-
+                            Whether this container has a read-only root filesystem.
+                            Default is false.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: boolean
+                        runAsGroup:
+                          description: |-
+                            The GID to run the entrypoint of the container process.
+                            Uses runtime default if unset.
+                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: |-
+                            Indicates that the container must run as a non-root user.
+                            If true, the Kubelet will validate the image at runtime to ensure that it
+                            does not run as UID 0 (root) and fail to start the container if it does.
+                            If unset or false, no such validation will be performed.
+                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: |-
+                            The UID to run the entrypoint of the container process.
+                            Defaults to user specified in image metadata if unspecified.
+                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: |-
+                            The SELinux context to be applied to the container.
+                            If unspecified, the container runtime will allocate a random SELinux context for each
+                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: |-
+                            The seccomp options to use by this container. If seccomp options are
+                            provided at both the pod & container level, the container options
+                            override the pod options.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of seccomp profile will be applied.
+                                Valid options are:
+
+                                Localhost - a profile defined in a file on the node should be used.
+                                RuntimeDefault - the container runtime default profile should be used.
+                                Unconfined - no profile should be applied.
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        windowsOptions:
+                          description: |-
+                            The Windows specific settings applied to all containers.
+                            If unspecified, the options from the PodSecurityContext will be used.
+                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is linux.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: |-
+                                GMSACredentialSpec is where the GMSA admission webhook
+                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                GMSA credential spec named by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: |-
+                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                All of a Pod's containers must have the same effective HostProcess value
+                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: |-
+                                The UserName in Windows to run the entrypoint of the container process.
+                                Defaults to the user specified in image metadata if unspecified.
+                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    data:
+                      description: Data configures the data PVC (object blocks).
+                      properties:
+                        accessModes:
+                          description: AccessModes for the PVC.
+                          items:
+                            type: string
+                          type: array
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations to set on the PVC.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels to set on the PVC.
+                          type: object
+                        paths:
+                          description: |-
+                            Paths configures multiple data directories for multi-disk setups.
+                            Only valid for data volumes — webhook rejects this on metadata volumes.
+                          items:
+                            description: DataPath specifies a data directory with capacity.
+                            properties:
+                              capacity:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Capacity of the drive (required unless readOnly).
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              path:
+                                description: Path to the data directory.
+                                type: string
+                              readOnly:
+                                description: ReadOnly marks directory as legacy read-only for migrations.
+                                type: boolean
+                              volume:
+                                description: Volume configuration if using PVC.
+                                properties:
+                                  accessModes:
+                                    description: AccessModes for the PVC.
+                                    items:
+                                      type: string
+                                    type: array
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to set on the PVC.
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: Labels to set on the PVC.
+                                    type: object
+                                  selector:
+                                    description: Selector to select PVs.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  size:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Size of the volume (storage request).
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  storageClassName:
+                                    description: StorageClassName for the PVC.
+                                    type: string
+                                  type:
+                                    default: PersistentVolumeClaim
+                                    description: Type specifies the volume type.
+                                    enum:
+                                      - PersistentVolumeClaim
+                                      - EmptyDir
+                                    type: string
+                                  volumeClaimTemplateSpec:
+                                    description: VolumeClaimTemplateSpec allows full customization of the PVC.
+                                    properties:
+                                      accessModes:
+                                        description: |-
+                                          accessModes contains the desired access modes the volume should have.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      dataSource:
+                                        description: |-
+                                          dataSource field can be used to specify either:
+                                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          * An existing PVC (PersistentVolumeClaim)
+                                          If the provisioner or an external controller can support the specified data source,
+                                          it will create a new volume based on the contents of the specified data source.
+                                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource being referenced
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      dataSourceRef:
+                                        description: |-
+                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                          volume is desired. This may be any object from a non-empty API group (non
+                                          core object) or a PersistentVolumeClaim object.
+                                          When this field is specified, volume binding will only succeed if the type of
+                                          the specified object matches some installed volume populator or dynamic
+                                          provisioner.
+                                          This field will replace the functionality of the dataSource field and as such
+                                          if both fields are non-empty, they must have the same value. For backwards
+                                          compatibility, when namespace isn't specified in dataSourceRef,
+                                          both fields (dataSource and dataSourceRef) will be set to the same
+                                          value automatically if one of them is empty and the other is non-empty.
+                                          When namespace is specified in dataSourceRef,
+                                          dataSource isn't set to the same value and must be empty.
+                                          There are three important differences between dataSource and dataSourceRef:
+                                          * While dataSource only allows two specific types of objects, dataSourceRef
+                                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                            preserves all values, and generates an error if a disallowed value is
+                                            specified.
+                                          * While dataSource only allows local objects, dataSourceRef allows objects
+                                            in any namespaces.
+                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource being referenced
+                                            type: string
+                                          namespace:
+                                            description: |-
+                                              Namespace is the namespace of resource being referenced
+                                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                      resources:
+                                        description: |-
+                                          resources represents the minimum resources the volume should have.
+                                          Users are allowed to specify resource requirements
+                                          that are lower than previous value but must still be higher than capacity recorded in the
+                                          status field of the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Limits describes the maximum amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Requests describes the minimum amount of compute resources required.
+                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                        type: object
+                                      selector:
+                                        description: selector is a label query over volumes to consider for binding.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      storageClassName:
+                                        description: |-
+                                          storageClassName is the name of the StorageClass required by the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                        type: string
+                                      volumeAttributesClassName:
+                                        description: |-
+                                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                          If specified, the CSI driver will create or update the volume with the attributes defined
+                                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                          this field can be reset to its previous value (including nil) to cancel the modification.
+                                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                          exists.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                        type: string
+                                      volumeMode:
+                                        description: |-
+                                          volumeMode defines what type of volume is required by the claim.
+                                          Value of Filesystem is implied when not included in claim spec.
+                                        type: string
+                                      volumeName:
+                                        description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                        type: string
+                                    type: object
+                                type: object
+                            required:
+                              - path
+                            type: object
+                          type: array
+                        selector:
+                          description: Selector to select PVs.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        size:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: Size of the volume.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        storageClassName:
+                          description: StorageClassName for the PVC.
+                          type: string
+                        type:
+                          default: PersistentVolumeClaim
+                          description: 'Type specifies the volume type: PersistentVolumeClaim (default) or EmptyDir.'
+                          enum:
+                            - PersistentVolumeClaim
+                            - EmptyDir
+                          type: string
+                        volumeClaimTemplateSpec:
+                          description: VolumeClaimTemplateSpec allows full customization of the PVC.
+                          properties:
+                            accessModes:
+                              description: |-
+                                accessModes contains the desired access modes the volume should have.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            dataSource:
+                              description: |-
+                                dataSource field can be used to specify either:
+                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                * An existing PVC (PersistentVolumeClaim)
+                                If the provisioner or an external controller can support the specified data source,
+                                it will create a new volume based on the contents of the specified data source.
+                                When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being referenced
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            dataSourceRef:
+                              description: |-
+                                dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                volume is desired. This may be any object from a non-empty API group (non
+                                core object) or a PersistentVolumeClaim object.
+                                When this field is specified, volume binding will only succeed if the type of
+                                the specified object matches some installed volume populator or dynamic
+                                provisioner.
+                                This field will replace the functionality of the dataSource field and as such
+                                if both fields are non-empty, they must have the same value. For backwards
+                                compatibility, when namespace isn't specified in dataSourceRef,
+                                both fields (dataSource and dataSourceRef) will be set to the same
+                                value automatically if one of them is empty and the other is non-empty.
+                                When namespace is specified in dataSourceRef,
+                                dataSource isn't set to the same value and must be empty.
+                                There are three important differences between dataSource and dataSourceRef:
+                                * While dataSource only allows two specific types of objects, dataSourceRef
+                                  allows any non-core object, as well as PersistentVolumeClaim objects.
+                                * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                  preserves all values, and generates an error if a disallowed value is
+                                  specified.
+                                * While dataSource only allows local objects, dataSourceRef allows objects
+                                  in any namespaces.
+                                (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being referenced
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace is the namespace of resource being referenced
+                                    Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                    (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                            resources:
+                              description: |-
+                                resources represents the minimum resources the volume should have.
+                                Users are allowed to specify resource requirements
+                                that are lower than previous value but must still be higher than capacity recorded in the
+                                status field of the claim.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            selector:
+                              description: selector is a label query over volumes to consider for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            storageClassName:
+                              description: |-
+                                storageClassName is the name of the StorageClass required by the claim.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                              type: string
+                            volumeAttributesClassName:
+                              description: |-
+                                volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                If specified, the CSI driver will create or update the volume with the attributes defined
+                                in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                it can be changed after the claim is created. An empty string or nil value indicates that no
+                                VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                this field can be reset to its previous value (including nil) to cancel the modification.
+                                If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                exists.
+                                More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                              type: string
+                            volumeMode:
+                              description: |-
+                                volumeMode defines what type of volume is required by the claim.
+                                Value of Filesystem is implied when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                      type: object
+                    dataFsync:
+                      description: DataFsync enables fsync for data block writes.
+                      type: boolean
+                    env:
+                      description: |-
+                        Env is a list of additional environment variables to set on the Garage
+                        container. These are appended AFTER the operator's built-in vars
+                        (GARAGE_NODE_HOST, RUST_LOG, etc.), so a user-supplied entry with the same
+                        name as a built-in will override it. Typical use: setting
+                        GARAGE_ALLOW_WORLD_READABLE_SECRETS, or any other GARAGE_* env Garage
+                        honors at startup.
+                      items:
+                        description: EnvVar represents an environment variable present in a Container.
+                        properties:
+                          name:
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
+                            type: string
+                          value:
+                            description: |-
+                              Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in the container and
+                              any service environment variables. If a variable cannot be resolved,
+                              the reference in the input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                              Escaped references will never be expanded, regardless of whether the variable
+                              exists or not.
+                              Defaults to "".
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value. Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                description: |-
+                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the specified API version.
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                    type: string
+                                  optional:
+                                    default: false
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
+                                      If optional is set to true and the specified key does not exist,
+                                      the environment variable will not be set in the Pod's containers.
+
+                                      If optional is set to false and the specified key does not exist,
+                                      an error will be returned during Pod creation.
+                                    type: boolean
+                                  path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
+                                    type: string
+                                  volumeName:
+                                    description: The name of the volume mount containing the env file.
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes, optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Specifies the output format of the exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    envFrom:
+                      description: |-
+                        EnvFrom is a list of sources to populate environment variables in the
+                        Garage container, allowing injection from Secrets or ConfigMaps. These
+                        sources are evaluated before the per-variable Env list, matching standard
+                        Kubernetes container semantics.
+                      items:
+                        description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
+                        properties:
+                          configMapRef:
+                            description: The ConfigMap to select from
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap must be defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          prefix:
+                            description: |-
+                              Optional text to prepend to the name of each environment variable.
+                              May consist of any printable ASCII characters except '='.
+                            type: string
+                          secretRef:
+                            description: The Secret to select from
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret must be defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      type: array
+                    metadata:
+                      description: Metadata configures the metadata PVC (Garage node identity + index DB).
+                      properties:
+                        accessModes:
+                          description: AccessModes for the PVC.
+                          items:
+                            type: string
+                          type: array
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations to set on the PVC.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels to set on the PVC.
+                          type: object
+                        paths:
+                          description: |-
+                            Paths configures multiple data directories for multi-disk setups.
+                            Only valid for data volumes — webhook rejects this on metadata volumes.
+                          items:
+                            description: DataPath specifies a data directory with capacity.
+                            properties:
+                              capacity:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Capacity of the drive (required unless readOnly).
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              path:
+                                description: Path to the data directory.
+                                type: string
+                              readOnly:
+                                description: ReadOnly marks directory as legacy read-only for migrations.
+                                type: boolean
+                              volume:
+                                description: Volume configuration if using PVC.
+                                properties:
+                                  accessModes:
+                                    description: AccessModes for the PVC.
+                                    items:
+                                      type: string
+                                    type: array
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to set on the PVC.
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: Labels to set on the PVC.
+                                    type: object
+                                  selector:
+                                    description: Selector to select PVs.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  size:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Size of the volume (storage request).
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  storageClassName:
+                                    description: StorageClassName for the PVC.
+                                    type: string
+                                  type:
+                                    default: PersistentVolumeClaim
+                                    description: Type specifies the volume type.
+                                    enum:
+                                      - PersistentVolumeClaim
+                                      - EmptyDir
+                                    type: string
+                                  volumeClaimTemplateSpec:
+                                    description: VolumeClaimTemplateSpec allows full customization of the PVC.
+                                    properties:
+                                      accessModes:
+                                        description: |-
+                                          accessModes contains the desired access modes the volume should have.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      dataSource:
+                                        description: |-
+                                          dataSource field can be used to specify either:
+                                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          * An existing PVC (PersistentVolumeClaim)
+                                          If the provisioner or an external controller can support the specified data source,
+                                          it will create a new volume based on the contents of the specified data source.
+                                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource being referenced
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      dataSourceRef:
+                                        description: |-
+                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                          volume is desired. This may be any object from a non-empty API group (non
+                                          core object) or a PersistentVolumeClaim object.
+                                          When this field is specified, volume binding will only succeed if the type of
+                                          the specified object matches some installed volume populator or dynamic
+                                          provisioner.
+                                          This field will replace the functionality of the dataSource field and as such
+                                          if both fields are non-empty, they must have the same value. For backwards
+                                          compatibility, when namespace isn't specified in dataSourceRef,
+                                          both fields (dataSource and dataSourceRef) will be set to the same
+                                          value automatically if one of them is empty and the other is non-empty.
+                                          When namespace is specified in dataSourceRef,
+                                          dataSource isn't set to the same value and must be empty.
+                                          There are three important differences between dataSource and dataSourceRef:
+                                          * While dataSource only allows two specific types of objects, dataSourceRef
+                                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                            preserves all values, and generates an error if a disallowed value is
+                                            specified.
+                                          * While dataSource only allows local objects, dataSourceRef allows objects
+                                            in any namespaces.
+                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource being referenced
+                                            type: string
+                                          namespace:
+                                            description: |-
+                                              Namespace is the namespace of resource being referenced
+                                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                      resources:
+                                        description: |-
+                                          resources represents the minimum resources the volume should have.
+                                          Users are allowed to specify resource requirements
+                                          that are lower than previous value but must still be higher than capacity recorded in the
+                                          status field of the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Limits describes the maximum amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Requests describes the minimum amount of compute resources required.
+                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                        type: object
+                                      selector:
+                                        description: selector is a label query over volumes to consider for binding.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      storageClassName:
+                                        description: |-
+                                          storageClassName is the name of the StorageClass required by the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                        type: string
+                                      volumeAttributesClassName:
+                                        description: |-
+                                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                          If specified, the CSI driver will create or update the volume with the attributes defined
+                                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                          this field can be reset to its previous value (including nil) to cancel the modification.
+                                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                          exists.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                        type: string
+                                      volumeMode:
+                                        description: |-
+                                          volumeMode defines what type of volume is required by the claim.
+                                          Value of Filesystem is implied when not included in claim spec.
+                                        type: string
+                                      volumeName:
+                                        description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                        type: string
+                                    type: object
+                                type: object
+                            required:
+                              - path
+                            type: object
+                          type: array
+                        selector:
+                          description: Selector to select PVs.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        size:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: Size of the volume.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        storageClassName:
+                          description: StorageClassName for the PVC.
+                          type: string
+                        type:
+                          default: PersistentVolumeClaim
+                          description: 'Type specifies the volume type: PersistentVolumeClaim (default) or EmptyDir.'
+                          enum:
+                            - PersistentVolumeClaim
+                            - EmptyDir
+                          type: string
+                        volumeClaimTemplateSpec:
+                          description: VolumeClaimTemplateSpec allows full customization of the PVC.
+                          properties:
+                            accessModes:
+                              description: |-
+                                accessModes contains the desired access modes the volume should have.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            dataSource:
+                              description: |-
+                                dataSource field can be used to specify either:
+                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                * An existing PVC (PersistentVolumeClaim)
+                                If the provisioner or an external controller can support the specified data source,
+                                it will create a new volume based on the contents of the specified data source.
+                                When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being referenced
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            dataSourceRef:
+                              description: |-
+                                dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                volume is desired. This may be any object from a non-empty API group (non
+                                core object) or a PersistentVolumeClaim object.
+                                When this field is specified, volume binding will only succeed if the type of
+                                the specified object matches some installed volume populator or dynamic
+                                provisioner.
+                                This field will replace the functionality of the dataSource field and as such
+                                if both fields are non-empty, they must have the same value. For backwards
+                                compatibility, when namespace isn't specified in dataSourceRef,
+                                both fields (dataSource and dataSourceRef) will be set to the same
+                                value automatically if one of them is empty and the other is non-empty.
+                                When namespace is specified in dataSourceRef,
+                                dataSource isn't set to the same value and must be empty.
+                                There are three important differences between dataSource and dataSourceRef:
+                                * While dataSource only allows two specific types of objects, dataSourceRef
+                                  allows any non-core object, as well as PersistentVolumeClaim objects.
+                                * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                  preserves all values, and generates an error if a disallowed value is
+                                  specified.
+                                * While dataSource only allows local objects, dataSourceRef allows objects
+                                  in any namespaces.
+                                (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                              properties:
+                                apiGroup:
+                                  description: |-
+                                    APIGroup is the group for the resource being referenced.
+                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being referenced
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace is the namespace of resource being referenced
+                                    Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                    (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                            resources:
+                              description: |-
+                                resources represents the minimum resources the volume should have.
+                                Users are allowed to specify resource requirements
+                                that are lower than previous value but must still be higher than capacity recorded in the
+                                status field of the claim.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            selector:
+                              description: selector is a label query over volumes to consider for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            storageClassName:
+                              description: |-
+                                storageClassName is the name of the StorageClass required by the claim.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                              type: string
+                            volumeAttributesClassName:
+                              description: |-
+                                volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                If specified, the CSI driver will create or update the volume with the attributes defined
+                                in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                it can be changed after the claim is created. An empty string or nil value indicates that no
+                                VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                this field can be reset to its previous value (including nil) to cancel the modification.
+                                If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                exists.
+                                More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                              type: string
+                            volumeMode:
+                              description: |-
+                                volumeMode defines what type of volume is required by the claim.
+                                Value of Filesystem is implied when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                      type: object
+                    metadataAutoSnapshotInterval:
+                      description: MetadataAutoSnapshotInterval enables automatic metadata snapshots.
+                      pattern: ^(\d+(\.\d+)?\s*(ns|us|ms|s|m|h|d|w|M|y)\s*)+$
+                      type: string
+                    metadataFsync:
+                      description: MetadataFsync enables fsync for metadata transactions.
+                      type: boolean
+                    metadataSnapshotsDir:
+                      description: MetadataSnapshotsDir specifies directory for metadata snapshots
+                      type: string
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: NodeSelector for pod scheduling.
+                      type: object
+                    podAnnotations:
+                      additionalProperties:
+                        type: string
+                      description: PodAnnotations to add to pods.
+                      type: object
+                    podDisruptionBudget:
+                      description: PodDisruptionBudget configures a PDB for the storage StatefulSet.
+                      properties:
+                        enabled:
+                          default: true
+                          description: Enabled enables PodDisruptionBudget creation
+                          type: boolean
+                        maxUnavailable:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: MaxUnavailable specifies the maximum number of pods that can be unavailable.
+                          x-kubernetes-int-or-string: true
+                        minAvailable:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: MinAvailable specifies the minimum number of pods that must be available.
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    podLabels:
+                      additionalProperties:
+                        type: string
+                      description: PodLabels to add to pods.
+                      type: object
+                    priorityClassName:
+                      description: PriorityClassName for pods.
+                      type: string
+                    pvcRetentionPolicy:
+                      description: PVCRetentionPolicy controls PVC lifecycle when the StatefulSet is deleted or scaled down.
+                      properties:
+                        whenDeleted:
+                          default: Retain
+                          description: WhenDeleted specifies what happens to PVCs when the StatefulSet is deleted.
+                          enum:
+                            - Retain
+                            - Delete
+                          type: string
+                        whenScaled:
+                          default: Retain
+                          description: WhenScaled specifies what happens to PVCs when the StatefulSet is scaled down.
+                          enum:
+                            - Retain
+                            - Delete
+                          type: string
+                      type: object
+                    replicas:
+                      default: 3
+                      description: |-
+                        Replicas is the number of storage pods to deploy. Set to 0 to keep the
+                        storage tier declared (config, PVC templates) but stop all pods.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    resources:
+                      description: Resources specifies compute resources for the pod.
+                      properties:
+                        claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
+
+                            This field depends on the
+                            DynamicResourceAllocation feature gate.
+
+                            This field is immutable. It can only be set for containers.
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used. It makes that resource available
+                                  inside a container.
+                                type: string
+                              request:
+                                description: |-
+                                  Request is the name chosen for a request in the referenced claim.
+                                  If empty, everything from the claim is made available, otherwise
+                                  only the result of this request.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                    securityContext:
+                      description: SecurityContext for the pod.
+                      properties:
+                        appArmorProfile:
+                          description: |-
+                            appArmorProfile is the AppArmor options to use by the containers in this pod.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile loaded on the node that should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must match the loaded name of the profile.
+                                Must be set if and only if type is "Localhost".
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of AppArmor profile will be applied.
+                                Valid options are:
+                                  Localhost - a profile pre-loaded on the node.
+                                  RuntimeDefault - the container runtime's default profile.
+                                  Unconfined - no AppArmor enforcement.
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        fsGroup:
+                          description: |-
+                            A special supplemental group that applies to all containers in a pod.
+                            Some volume types allow the Kubelet to change the ownership of that volume
+                            to be owned by the pod:
+
+                            1. The owning GID will be the FSGroup
+                            2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                            3. The permission bits are OR'd with rw-rw----
+
+                            If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          description: |-
+                            fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                            before being exposed inside Pod. This field will only apply to
+                            volume types which support fsGroup based ownership(and permissions).
+                            It will have no effect on ephemeral volume types such as: secret, configmaps
+                            and emptydir.
+                            Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        runAsGroup:
+                          description: |-
+                            The GID to run the entrypoint of the container process.
+                            Uses runtime default if unset.
+                            May also be set in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                            for that container.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: |-
+                            Indicates that the container must run as a non-root user.
+                            If true, the Kubelet will validate the image at runtime to ensure that it
+                            does not run as UID 0 (root) and fail to start the container if it does.
+                            If unset or false, no such validation will be performed.
+                            May also be set in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: |-
+                            The UID to run the entrypoint of the container process.
+                            Defaults to user specified in image metadata if unspecified.
+                            May also be set in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                            for that container.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        seLinuxChangePolicy:
+                          description: |-
+                            seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                            It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                            Valid values are "MountOption" and "Recursive".
+
+                            "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                            This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                            "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                            This requires all Pods that share the same volume to use the same SELinux label.
+                            It is not possible to share the same volume among privileged and unprivileged Pods.
+                            Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                            whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                            CSIDriver instance. Other volumes are always re-labelled recursively.
+                            "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                            If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                            If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                            and "Recursive" for all other volumes.
+
+                            This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                            All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        seLinuxOptions:
+                          description: |-
+                            The SELinux context to be applied to all containers.
+                            If unspecified, the container runtime will allocate a random SELinux context for each
+                            container.  May also be set in SecurityContext.  If set in
+                            both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: |-
+                            The seccomp options to use by the containers in this pod.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of seccomp profile will be applied.
+                                Valid options are:
+
+                                Localhost - a profile defined in a file on the node should be used.
+                                RuntimeDefault - the container runtime default profile should be used.
+                                Unconfined - no profile should be applied.
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        supplementalGroups:
+                          description: |-
+                            A list of groups applied to the first process run in each container, in
+                            addition to the container's primary GID and fsGroup (if specified).  If
+                            the SupplementalGroupsPolicy feature is enabled, the
+                            supplementalGroupsPolicy field determines whether these are in addition
+                            to or instead of any group memberships defined in the container image.
+                            If unspecified, no additional groups are added, though group memberships
+                            defined in the container image may still be used, depending on the
+                            supplementalGroupsPolicy field.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        supplementalGroupsPolicy:
+                          description: |-
+                            Defines how supplemental groups of the first container processes are calculated.
+                            Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                            (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                            and the container runtime must implement support for this feature.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        sysctls:
+                          description: |-
+                            Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                            sysctls (by the container runtime) might fail to launch.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          items:
+                            description: Sysctl defines a kernel parameter to be set
+                            properties:
+                              name:
+                                description: Name of a property to set
+                                type: string
+                              value:
+                                description: Value of a property to set
+                                type: string
+                            required:
+                              - name
+                              - value
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        windowsOptions:
+                          description: |-
+                            The Windows specific settings applied to all containers.
+                            If unspecified, the options within a container's SecurityContext will be used.
+                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is linux.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: |-
+                                GMSACredentialSpec is where the GMSA admission webhook
+                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                GMSA credential spec named by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: |-
+                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                All of a Pod's containers must have the same effective HostProcess value
+                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: |-
+                                The UserName in Windows to run the entrypoint of the container process.
+                                Defaults to the user specified in image metadata if unspecified.
+                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    tolerations:
+                      description: Tolerations for pod scheduling.
+                      items:
+                        description: |-
+                          The pod this Toleration is attached to tolerates any taint that matches
+                          the triple <key,value,effect> using the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: |-
+                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value.
+                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                              Exists is equivalent to wildcard for value, so that a pod can
+                              tolerate all taints of a particular category.
+                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                            type: string
+                          tolerationSeconds:
+                            description: |-
+                              TolerationSeconds represents the period of time the toleration (which must be
+                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                              negative values will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: |-
+                              Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                    topologySpreadConstraints:
+                      description: TopologySpreadConstraints for pod scheduling.
+                      items:
+                        description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                        properties:
+                          labelSelector:
+                            description: |-
+                              LabelSelector is used to find matching pods.
+                              Pods that match this label selector are counted to determine the number of pods
+                              in their corresponding topology domain.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          matchLabelKeys:
+                            description: |-
+                              MatchLabelKeys is a set of pod label keys to select the pods over which
+                              spreading will be calculated. The keys are used to lookup values from the
+                              incoming pod labels, those key-value labels are ANDed with labelSelector
+                              to select the group of existing pods over which spreading will be calculated
+                              for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                              MatchLabelKeys cannot be set when LabelSelector isn't set.
+                              Keys that don't exist in the incoming pod labels will
+                              be ignored. A null or empty list means only match against labelSelector.
+
+                              This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          maxSkew:
+                            description: |-
+                              MaxSkew describes the degree to which pods may be unevenly distributed.
+                              When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                              between the number of matching pods in the target topology and the global minimum.
+                              The global minimum is the minimum number of matching pods in an eligible domain
+                              or zero if the number of eligible domains is less than MinDomains.
+                              For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                              labelSelector spread as 2/2/1:
+                              In this case, the global minimum is 1.
+                              | zone1 | zone2 | zone3 |
+                              |  P P  |  P P  |   P   |
+                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                              scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                              violate MaxSkew(1).
+                              - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                              When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                              to topologies that satisfy it.
+                              It's a required field. Default value is 1 and 0 is not allowed.
+                            format: int32
+                            type: integer
+                          minDomains:
+                            description: |-
+                              MinDomains indicates a minimum number of eligible domains.
+                              When the number of eligible domains with matching topology keys is less than minDomains,
+                              Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                              And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                              this value has no effect on scheduling.
+                              As a result, when the number of eligible domains is less than minDomains,
+                              scheduler won't schedule more than maxSkew Pods to those domains.
+                              If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                              Valid values are integers greater than 0.
+                              When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                              For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                              labelSelector spread as 2/2/2:
+                              | zone1 | zone2 | zone3 |
+                              |  P P  |  P P  |  P P  |
+                              The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                              In this situation, new pod with the same labelSelector cannot be scheduled,
+                              because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                              it will violate MaxSkew.
+                            format: int32
+                            type: integer
+                          nodeAffinityPolicy:
+                            description: |-
+                              NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                              when calculating pod topology spread skew. Options are:
+                              - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                              - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                              If this value is nil, the behavior is equivalent to the Honor policy.
+                            type: string
+                          nodeTaintsPolicy:
+                            description: |-
+                              NodeTaintsPolicy indicates how we will treat node taints when calculating
+                              pod topology spread skew. Options are:
+                              - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                              has a toleration, are included.
+                              - Ignore: node taints are ignored. All nodes are included.
+
+                              If this value is nil, the behavior is equivalent to the Ignore policy.
+                            type: string
+                          topologyKey:
+                            description: |-
+                              TopologyKey is the key of node labels. Nodes that have a label with this key
+                              and identical values are considered to be in the same topology.
+                              We consider each <key, value> as a "bucket", and try to put balanced number
+                              of pods into each bucket.
+                              We define a domain as a particular instance of a topology.
+                              Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                              nodeAffinityPolicy and nodeTaintsPolicy.
+                              e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                              And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                              It's a required field.
+                            type: string
+                          whenUnsatisfiable:
+                            description: |-
+                              WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                              the spread constraint.
+                              - DoNotSchedule (default) tells the scheduler not to schedule it.
+                              - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                but giving higher precedence to topologies that would help reduce the
+                                skew.
+                              A constraint is considered "Unsatisfiable" for an incoming pod
+                              if and only if every possible node assignment for that pod would violate
+                              "MaxSkew" on some topology.
+                              For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                              labelSelector spread as 3/1/1:
+                              | zone1 | zone2 | zone3 |
+                              | P P P |   P   |   P   |
+                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                              to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                              MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                              won't make it *more* imbalanced.
+                              It's a required field.
+                            type: string
+                        required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
+                        type: object
+                      type: array
+                  required:
+                    - data
+                    - metadata
+                    - replicas
+                  type: object
+                webApi:
+                  description: |-
+                    WebAPI configures the static website hosting endpoint.
+                    Enabled by default with rootDomain ".<name>.<namespace>.svc".
+                    Set webApi.enabled: false to turn off.
+                  properties:
+                    addHostToMetrics:
+                      description: AddHostToMetrics adds the domain name to metrics labels for per-domain tracking.
+                      type: boolean
+                    bindAddress:
+                      description: BindAddress is a custom bind address for the Web API.
+                      type: string
+                    bindPort:
+                      default: 3902
+                      description: BindPort is the port to bind for web serving.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    enabled:
+                      description: Enabled controls whether the web endpoint is active. Defaults to true.
+                      type: boolean
+                    rootDomain:
+                      description: RootDomain is the root domain suffix for bucket website access.
+                      type: string
+                  type: object
+                workers:
+                  description: Workers configures Garage background worker behavior.
+                  properties:
+                    resyncTranquility:
+                      description: ResyncTranquility controls how aggressively the block resync worker runs.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    resyncWorkerCount:
+                      description: ResyncWorkerCount sets the number of parallel block resync worker goroutines.
+                      format: int32
+                      maximum: 8
+                      minimum: 1
+                      type: integer
+                    scrubTranquility:
+                      description: ScrubTranquility controls how aggressively the block integrity scrub runs.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                  type: object
+                zone:
+                  description: |-
+                    Zone is the Garage layout zone assigned to all nodes in this cluster.
+                    Each cluster in a federation must have a unique zone name.
+                  type: string
+              type: object
+              x-kubernetes-validations:
+                - message: at least one of spec.storage, spec.gateway, or spec.connectTo must be set
+                  rule: has(self.storage) || has(self.gateway) || has(self.connectTo)
+                - message: spec.gateway requires either spec.storage (unified cluster) or spec.connectTo (edge gateway)
+                  rule: '!has(self.gateway) || has(self.storage) || has(self.connectTo)'
+            status:
+              description: GarageClusterStatus defines the observed state of GarageCluster.
+              properties:
+                activeRepairs:
+                  description: ActiveRepairs contains currently running repair operations.
+                  items:
+                    description: RepairStatus contains status of a repair operation.
+                    properties:
+                      nodeId:
+                        description: NodeID is the node running this repair.
+                        type: string
+                      progress:
+                        description: Progress is a human-readable progress description.
+                        type: string
+                      startedAt:
+                        description: StartedAt is when the repair started.
+                        format: date-time
+                        type: string
+                      type:
+                        description: Type is the repair operation type (Tables, Blocks, Scrub, Rebalance, etc.)
+                        type: string
+                    type: object
+                  type: array
+                blockErrorDetails:
+                  description: BlockErrorDetails provides detailed information about block errors.
+                  properties:
+                    count:
+                      description: Count is the total number of blocks with errors.
+                      format: int32
+                      type: integer
+                    lastErrorAt:
+                      description: LastErrorAt is when the most recent block error occurred.
+                      format: date-time
+                      type: string
+                    topErrors:
+                      description: TopErrors contains details about the most problematic blocks.
+                      items:
+                        description: BlockErrorDetail contains information about a specific block error.
+                        properties:
+                          blockHash:
+                            description: BlockHash is the hash of the affected block.
+                            type: string
+                          errorCount:
+                            description: ErrorCount is the number of times this block failed to sync.
+                            format: int32
+                            type: integer
+                          lastAttempt:
+                            description: LastAttempt is when the last sync attempt occurred.
+                            format: date-time
+                            type: string
+                          lastError:
+                            description: LastError is the most recent error message for this block.
+                            type: string
+                          nextRetry:
+                            description: NextRetry is when the next sync retry is scheduled.
+                            format: date-time
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                blockErrors:
+                  description: BlockErrors is the count of blocks with sync errors across all nodes.
+                  format: int32
+                  type: integer
+                buildInfo:
+                  description: BuildInfo contains Garage build information.
+                  properties:
+                    features:
+                      description: Features lists enabled Cargo features.
+                      items:
+                        type: string
+                      type: array
+                    rustVersion:
+                      description: RustVersion is the Rust compiler version used to build Garage.
+                      type: string
+                    version:
+                      description: Version is the Garage version string.
+                      type: string
+                  type: object
+                clusterId:
+                  description: ClusterID is the unique identifier of the Garage cluster.
+                  type: string
+                conditions:
+                  description: Conditions represent the current state of the cluster.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                drainingNodes:
+                  description: DrainingNodes is the count of nodes that are draining data from an older layout version.
+                  type: integer
+                endpoints:
+                  description: Endpoints contains service endpoints.
+                  properties:
+                    admin:
+                      description: Admin is the admin API endpoint.
+                      type: string
+                    k2v:
+                      description: K2V is the K2V API endpoint.
+                      type: string
+                    metrics:
+                      description: Metrics is the Prometheus metrics endpoint.
+                      type: string
+                    rpc:
+                      description: RPC is the internal RPC endpoint.
+                      type: string
+                    s3:
+                      description: S3 is the S3 API endpoint.
+                      type: string
+                    web:
+                      description: Web is the web hosting endpoint.
+                      type: string
+                  type: object
+                gatewayReadyReplicas:
+                  description: GatewayReadyReplicas is the number of ready gateway-tier pods.
+                  format: int32
+                  type: integer
+                gatewayReplicas:
+                  description: GatewayReplicas is the desired gateway-tier replica count.
+                  format: int32
+                  type: integer
+                health:
+                  description: Health contains cluster health information.
+                  properties:
+                    available:
+                      description: Available indicates if quorum is available.
+                      type: boolean
+                    connectedNodes:
+                      description: ConnectedNodes is the number of currently connected nodes.
+                      type: integer
+                    healthy:
+                      description: Healthy indicates if all nodes are connected.
+                      type: boolean
+                    knownNodes:
+                      description: KnownNodes is the number of nodes seen in cluster.
+                      type: integer
+                    partitions:
+                      description: Partitions is the total partitions in layout.
+                      type: integer
+                    partitionsAllOk:
+                      description: PartitionsAllOK is partitions with all nodes connected.
+                      type: integer
+                    partitionsQuorum:
+                      description: PartitionsQuorum is partitions with quorum connectivity.
+                      type: integer
+                    status:
+                      description: Status is the overall cluster status.
+                      type: string
+                    storageNodes:
+                      description: StorageNodes is the number of storage nodes in layout.
+                      type: integer
+                    storageNodesOk:
+                      description: StorageNodesOK is the number of connected storage nodes.
+                      type: integer
+                  type: object
+                lastOperation:
+                  description: LastOperation records the result of the most recently triggered operational annotation.
+                  properties:
+                    error:
+                      description: Error contains the error message when Succeeded is false.
+                      type: string
+                    succeeded:
+                      description: Succeeded indicates the operation completed without error.
+                      type: boolean
+                    triggeredAt:
+                      description: TriggeredAt is when the operation was triggered.
+                      format: date-time
+                      type: string
+                    type:
+                      description: Type is the operation type.
+                      type: string
+                  type: object
+                layoutHistory:
+                  description: LayoutHistory contains layout version history.
+                  properties:
+                    currentVersion:
+                      description: CurrentVersion is the current layout version.
+                      format: int64
+                      type: integer
+                    minAck:
+                      description: MinAck is the minimum acknowledged layout version by all nodes.
+                      format: int64
+                      type: integer
+                    versions:
+                      description: Versions contains the history of layout versions.
+                      items:
+                        description: LayoutVersionInfo contains information about a layout version.
+                        properties:
+                          gatewayNodes:
+                            description: GatewayNodes is the number of gateway nodes in this version.
+                            type: integer
+                          status:
+                            description: Status is the version status (Current, Draining, Historical).
+                            type: string
+                          storageNodes:
+                            description: StorageNodes is the number of storage nodes in this version.
+                            type: integer
+                          version:
+                            description: Version is the layout version number.
+                            format: int64
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+                layoutPreview:
+                  description: LayoutPreview shows what would change if staged layout is applied.
+                  properties:
+                    dataTransferEstimate:
+                      description: DataTransferEstimate is a human-readable estimate of data movement.
+                      type: string
+                    nodesAdded:
+                      description: NodesAdded shows node IDs that would be added to the layout.
+                      items:
+                        type: string
+                      type: array
+                    nodesModified:
+                      description: NodesModified shows node IDs with changed configuration.
+                      items:
+                        type: string
+                      type: array
+                    nodesRemoved:
+                      description: NodesRemoved shows node IDs that would be removed from the layout.
+                      items:
+                        type: string
+                      type: array
+                    partitionTransfers:
+                      description: PartitionTransfers is the estimated number of partition transfers.
+                      format: int32
+                      type: integer
+                    zonesAffected:
+                      description: ZonesAffected shows which zones would be affected by the changes.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                layoutVersion:
+                  description: LayoutVersion is the current layout version.
+                  format: int64
+                  type: integer
+                lifecycleStatus:
+                  description: LifecycleStatus contains the status of bucket lifecycle operations.
+                  properties:
+                    lastCompleted:
+                      description: LastCompleted is when the last lifecycle worker run completed.
+                      format: date-time
+                      type: string
+                  type: object
+                nodes:
+                  description: Nodes contains status information for each node.
+                  items:
+                    description: NodeStatus contains status information for a Garage node.
+                    properties:
+                      capacity:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: Capacity is the storage capacity of the node.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      connected:
+                        description: Connected indicates if the node is connected to the cluster.
+                        type: boolean
+                      dataDiskAvailable:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: DataDiskAvailable is the available space on data disk.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      dataDiskTotal:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: DataDiskTotal is the total space on data disk.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      gateway:
+                        description: Gateway indicates if the node is gateway-only.
+                        type: boolean
+                      metadataDiskAvailable:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: MetadataDiskAvailable is the available space on metadata disk.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      metadataDiskTotal:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: MetadataDiskTotal is the total space on metadata disk.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      nodeId:
+                        description: NodeID is the public key of the node.
+                        type: string
+                      podName:
+                        description: PodName is the name of the pod running this node.
+                        type: string
+                      tier:
+                        description: Tier is "storage" or "gateway" depending on which tier this node belongs to.
+                        type: string
+                      version:
+                        description: Version is the Garage version running on this node.
+                        type: string
+                      zone:
+                        description: Zone is the zone assignment of the node.
+                        type: string
+                    type: object
+                  type: array
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+                pendingGatewayTombstones:
+                  description: |-
+                    PendingGatewayTombstones lists stale gateway layout entries pending removal.
+                    Populated when gateway tombstone cleanup detects orphaned entries but cannot
+                    remove them automatically (e.g. layoutManagement.autoApply is false).
+                  items:
+                    type: string
+                  type: array
+                phase:
+                  description: Phase represents the current phase of the cluster.
+                  enum:
+                    - Pending
+                    - Creating
+                    - Running
+                    - Ready
+                    - Degraded
+                    - Updating
+                    - Deleting
+                    - Failed
+                    - Unknown
+                  type: string
+                readyReplicas:
+                  description: ReadyReplicas is the number of ready Garage pods.
+                  format: int32
+                  type: integer
+                remoteClusters:
+                  description: RemoteClusters contains status of remote clusters in the federation.
+                  items:
+                    description: RemoteClusterStatus is the status of a remote cluster.
+                    properties:
+                      connected:
+                        description: Connected indicates if we can reach this cluster.
+                        type: boolean
+                      healthyNodes:
+                        description: HealthyNodes is the number of healthy nodes.
+                        type: integer
+                      lastSeen:
+                        description: LastSeen is when we last successfully connected.
+                        format: date-time
+                        type: string
+                      name:
+                        description: Name is the cluster name.
+                        type: string
+                      nodes:
+                        description: Nodes is the number of nodes in this cluster.
+                        type: integer
+                      zone:
+                        description: Zone is the cluster's zone.
+                        type: string
+                    type: object
+                  type: array
+                replicas:
+                  description: |-
+                    Replicas is the total number of Garage pods targeted by this cluster
+                    (storage + gateway tiers combined).
+                  format: int32
+                  type: integer
+                resyncQueueLength:
+                  description: ResyncQueueLength is the total block resync queue depth across all nodes.
+                  format: int64
+                  type: integer
+                scrubStatus:
+                  description: ScrubStatus contains the status of data scrub operations.
+                  properties:
+                    corruptedBlocks:
+                      description: CorruptedBlocks is the number of corrupted blocks found in the last scrub.
+                      format: int32
+                      type: integer
+                    lastCompleted:
+                      description: LastCompleted is when the last scrub completed.
+                      format: date-time
+                      type: string
+                    nextRun:
+                      description: NextRun is when the next scrub is scheduled to run.
+                      format: date-time
+                      type: string
+                    nodeStatuses:
+                      description: NodeStatuses contains per-node scrub status.
+                      items:
+                        description: NodeScrubStatus contains scrub status for a single node.
+                        properties:
+                          errorsFound:
+                            description: ErrorsFound is the number of errors found on this node.
+                            format: int32
+                            type: integer
+                          itemsChecked:
+                            description: ItemsChecked is the number of items checked.
+                            format: int64
+                            type: integer
+                          nodeId:
+                            description: NodeID is the node identifier.
+                            type: string
+                          progress:
+                            description: Progress percentage (0-100).
+                            type: integer
+                          running:
+                            description: Running indicates if scrub is running on this node.
+                            type: boolean
+                        type: object
+                      type: array
+                    paused:
+                      description: Paused indicates if the scrub is paused.
+                      type: boolean
+                    progress:
+                      description: Progress is a human-readable progress description.
+                      type: string
+                    running:
+                      description: Running indicates if a scrub is currently running on any node.
+                      type: boolean
+                    tranquilityLevel:
+                      description: TranquilityLevel is the current tranquility setting.
+                      type: integer
+                  type: object
+                selector:
+                  description: Selector is the serialized label selector for pods managed by this cluster.
+                  type: string
+                stagedLayoutVersion:
+                  description: StagedLayoutVersion is the staged layout version pending application.
+                  format: int64
+                  type: integer
+                stagedRoles:
+                  description: StagedRoles is the number of roles in the staged layout.
+                  format: int32
+                  type: integer
+                storageReadyReplicas:
+                  description: StorageReadyReplicas is the number of ready storage-tier pods.
+                  format: int32
+                  type: integer
+                storageReplicas:
+                  description: StorageReplicas is the desired storage-tier replica count.
+                  format: int32
+                  type: integer
+                storageStats:
+                  description: StorageStats contains cluster-wide storage statistics.
+                  properties:
+                    availableCapacity:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: AvailableCapacity is the available storage across all nodes.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    healthyPartitions:
+                      description: HealthyPartitions is the number of partitions with full redundancy.
+                      format: int32
+                      type: integer
+                    totalCapacity:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: TotalCapacity is the total storage capacity across all nodes.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    totalPartitions:
+                      description: TotalPartitions is the total number of partitions in the layout.
+                      format: int32
+                      type: integer
+                    usedCapacity:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: UsedCapacity is the used storage across all nodes.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                totalNodes:
+                  description: TotalNodes is the total nodes across all clusters (local + remote).
+                  type: integer
+                workerCount:
+                  description: WorkerCount is the total number of background workers.
+                  format: int32
+                  type: integer
+                workers:
+                  description: Workers contains detailed information about background workers.
+                  properties:
+                    busy:
+                      description: Busy is the number of busy/active workers.
+                      format: int32
+                      type: integer
+                    errored:
+                      description: Errored is the number of workers with errors.
+                      format: int32
+                      type: integer
+                    errors:
+                      description: Errors contains details about worker errors.
+                      items:
+                        description: WorkerError contains information about a worker error.
+                        properties:
+                          consecutiveErrors:
+                            description: ConsecutiveErrors is the count of consecutive errors.
+                            format: int32
+                            type: integer
+                          lastError:
+                            description: LastError is the last error message.
+                            type: string
+                          lastErrorSecsAgo:
+                            description: LastErrorSecsAgo is seconds since the last error.
+                            format: int64
+                            type: integer
+                          name:
+                            description: Name is the worker name.
+                            type: string
+                          workerId:
+                            description: WorkerID is the worker identifier.
+                            format: int64
+                            type: integer
+                        type: object
+                      type: array
+                    idle:
+                      description: Idle is the number of idle workers.
+                      format: int32
+                      type: integer
+                    total:
+                      description: Total is the total number of background workers.
+                      format: int32
+                      type: integer
+                    variables:
+                      additionalProperties:
+                        type: string
+                      description: Variables contains runtime worker configuration variables.
+                      type: object
+                  type: object
+                workersFailed:
+                  description: WorkersFailed is the number of failed workers.
+                  format: int32
+                  type: integer
+              required:
+                - replicas
+                - selector
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        scale:
+          labelSelectorPath: .status.selector
+          specReplicasPath: .spec.storage.replicas
+          statusReplicasPath: .status.storageReplicas
+        status: {}

--- a/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-garagekeys-garage-rajsingh-info.yaml
+++ b/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-garagekeys-garage-rajsingh-info.yaml
@@ -1,0 +1,495 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/instance: garage-operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: garage-operator
+    app.kubernetes.io/version: 0.6.2
+    control-plane: controller-manager
+    helm.sh/chart: garage-operator-0.6.2
+  name: garagekeys.garage.rajsingh.info
+spec:
+  group: garage.rajsingh.info
+  names:
+    kind: GarageKey
+    listKind: GarageKeyList
+    plural: garagekeys
+    shortNames:
+      - gk
+    singular: garagekey
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: false
+      storage: false
+    - additionalPrinterColumns:
+        - jsonPath: .spec.clusterRef.name
+          name: Cluster
+          type: string
+        - jsonPath: .status.keyId
+          name: KeyID
+          type: string
+        - jsonPath: .status.accessKeyId
+          name: AccessKeyID
+          type: string
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .status.clusterWide
+          name: ClusterWide
+          type: boolean
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: GarageKey is the Schema for the garagekeys API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: GarageKeySpec defines the desired state of GarageKey
+              properties:
+                allBuckets:
+                  description: |-
+                    AllBuckets grants this key a baseline permission set on every bucket in the cluster.
+                    Useful for admin tools, backup agents, or monitoring that need cluster-wide access.
+
+                    How it works: the operator calls Garage's allow/deny APIs for every bucket to
+                    enforce exactly the flags set here — false actively revokes, not just leaves unset.
+                    BucketPermissions entries are then applied on top, so you can grant broader access
+                    via allBuckets and restrict specific buckets via bucketPermissions.
+
+                    Warning: this applies to ALL Garage buckets, including buckets not managed by the
+                    operator (created directly via the S3 API). Plan accordingly.
+                  properties:
+                    owner:
+                      description: Owner allows bucket owner operations on all buckets
+                      type: boolean
+                    read:
+                      description: Read allows reading objects from all buckets
+                      type: boolean
+                    write:
+                      description: Write allows writing objects to all buckets
+                      type: boolean
+                  type: object
+                bucketPermissions:
+                  description: |-
+                    BucketPermissions grants this key access to buckets.
+
+                    Note: Permissions can be granted from either direction:
+                    - Here (GarageKey.bucketPermissions): Grant this key access to buckets
+                    - On GarageBucket (GarageBucket.keyPermissions): Grant keys access to the bucket
+
+                    Both approaches are equivalent and result in the same Garage API calls.
+                    Use whichever is more convenient for your workflow:
+                    - Key-centric: Define all bucket access on the key
+                    - Bucket-centric: Define all key access on the bucket
+
+                    If the same permission is defined in both places, they are merged (not conflicting).
+                  items:
+                    description: |-
+                      BucketPermission grants access to a bucket.
+                      Exactly one of BucketRef, BucketID, or GlobalAlias must be set.
+                    properties:
+                      bucketId:
+                        description: BucketID references the bucket by its Garage-internal ID.
+                        type: string
+                      bucketRef:
+                        description: |-
+                          BucketRef references a GarageBucket by name (and optionally namespace).
+                          Mutually exclusive with BucketID and GlobalAlias.
+                        properties:
+                          name:
+                            description: Name of the GarageBucket.
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the GarageBucket. Defaults to the GarageKey's namespace.
+                              Cross-namespace references require a GarageReferenceGrant in the target namespace.
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      globalAlias:
+                        description: GlobalAlias references the bucket by its global alias.
+                        type: string
+                      owner:
+                        description: Owner allows bucket owner operations (delete bucket, configure website, etc.)
+                        type: boolean
+                      read:
+                        description: Read allows reading objects from the bucket.
+                        type: boolean
+                      write:
+                        description: Write allows writing objects to the bucket.
+                        type: boolean
+                    type: object
+                    x-kubernetes-validations:
+                      - message: exactly one of bucketRef, bucketId, or globalAlias must be set
+                        rule: '[has(self.bucketRef), has(self.bucketId), has(self.globalAlias)].filter(x, x).size() == 1'
+                  maxItems: 100
+                  type: array
+                clusterRef:
+                  description: ClusterRef references the GarageCluster this key belongs to
+                  properties:
+                    kubeConfigSecretRef:
+                      description: |-
+                        KubeConfigSecretRef references a secret containing a kubeconfig for a remote Kubernetes cluster.
+                        Only needed for multi-cluster federation where the GarageCluster lives in a different
+                        Kubernetes cluster entirely (not just a different namespace).
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    name:
+                      description: Name of the GarageCluster resource.
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the GarageCluster. Defaults to the referencing resource's namespace.
+                        Cross-namespace references require a GarageReferenceGrant in the target namespace.
+                        Not supported on GarageNode.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                expiresAt:
+                  description: |-
+                    ExpiresAt sets when this key expires.
+                    After this time Garage will reject requests using the key. The operator sets the
+                    KeyExpired condition when expired but does NOT automatically delete or rotate the key.
+                    Mutually exclusive with neverExpires.
+                  format: date-time
+                  type: string
+                importKey:
+                  description: ImportKey imports an existing key instead of generating new credentials
+                  properties:
+                    accessKeyId:
+                      description: |-
+                        AccessKeyID is the existing Garage access key ID (must start with "GK").
+                        Use secretRef instead to avoid storing credentials in the CR.
+                      type: string
+                    accessKeyIdKey:
+                      description: |-
+                        AccessKeyIDKey is the key name within secretRef for the access key ID.
+                        Defaults to "access-key-id". Only valid when secretRef is set.
+                      type: string
+                    secretAccessKey:
+                      description: |-
+                        SecretAccessKey is the existing secret access key.
+                        Use secretRef instead to avoid storing credentials in the CR.
+                      type: string
+                    secretAccessKeyKey:
+                      description: |-
+                        SecretAccessKeyKey is the key name within secretRef for the secret access key.
+                        Defaults to "secret-access-key". Only valid when secretRef is set.
+                      type: string
+                    secretRef:
+                      description: |-
+                        SecretRef references a Kubernetes secret containing the credentials.
+                        Mutually exclusive with inline accessKeyId/secretAccessKey.
+                      properties:
+                        name:
+                          description: name is unique within a namespace to reference a secret resource.
+                          type: string
+                        namespace:
+                          description: namespace defines the space within which the secret name must be unique.
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                name:
+                  description: |-
+                    Name is a friendly name for this access key
+                    If not set, metadata.name is used
+                  type: string
+                neverExpires:
+                  description: |-
+                    NeverExpires explicitly marks this key as having no expiration.
+                    Sets the Garage key expiration to "never" rather than leaving it unset.
+                    Mutually exclusive with expiration.
+                  type: boolean
+                permissions:
+                  description: |-
+                    Permissions configures key-level permissions
+                    Note: For admin API access, use admin tokens configured in GarageCluster
+                  properties:
+                    createBucket:
+                      description: CreateBucket allows this key to create new buckets via the S3 CreateBucket API
+                      type: boolean
+                  type: object
+                secretTemplate:
+                  description: SecretTemplate configures how the secret is generated
+                  properties:
+                    accessKeyIdKey:
+                      default: access-key-id
+                      description: AccessKeyIDKey is the key name for the access key ID
+                      type: string
+                    additionalData:
+                      additionalProperties:
+                        type: string
+                      description: AdditionalData includes additional key-value pairs in the secret
+                      type: object
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations to add to the secret
+                      type: object
+                    endpointKey:
+                      default: endpoint
+                      description: EndpointKey is the key name for the S3 endpoint (includes http:// scheme)
+                      type: string
+                    hostKey:
+                      default: host
+                      description: HostKey is the key name for the S3 host (without scheme, e.g., "host:port")
+                      type: string
+                    includeEndpoint:
+                      description: |-
+                        IncludeEndpoint includes the S3 endpoint in the secret
+                        Defaults to true if not specified
+                      type: boolean
+                    includeRegion:
+                      description: |-
+                        IncludeRegion includes the S3 region in the secret
+                        Defaults to true if not specified
+                      type: boolean
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels to add to the secret
+                      type: object
+                    name:
+                      description: |-
+                        Name is the name of the secret to create
+                        Defaults to the GarageKey name
+                      type: string
+                    regionKey:
+                      default: region
+                      description: RegionKey is the key name for the S3 region
+                      type: string
+                    schemeKey:
+                      default: scheme
+                      description: SchemeKey is the key name for the endpoint scheme (http or https)
+                      type: string
+                    secretAccessKeyKey:
+                      default: secret-access-key
+                      description: SecretAccessKeyKey is the key name for the secret access key
+                      type: string
+                    type:
+                      default: Opaque
+                      description: Type is the secret type
+                      type: string
+                  type: object
+              required:
+                - clusterRef
+              type: object
+            status:
+              description: GarageKeyStatus defines the observed state of GarageKey
+              properties:
+                accessKeyId:
+                  description: AccessKeyID is the S3 access key ID
+                  type: string
+                buckets:
+                  description: Buckets lists buckets this key has access to
+                  items:
+                    description: KeyBucketAccess shows bucket access for this key
+                    properties:
+                      bucketId:
+                        description: BucketID is the bucket ID
+                        type: string
+                      globalAlias:
+                        description: GlobalAlias is the bucket's global alias
+                        type: string
+                      localAlias:
+                        description: LocalAlias is this key's local alias for the bucket
+                        type: string
+                      owner:
+                        description: Owner permission
+                        type: boolean
+                      read:
+                        description: Read permission
+                        type: boolean
+                      write:
+                        description: Write permission
+                        type: boolean
+                    type: object
+                  type: array
+                clusterWide:
+                  description: ClusterWide indicates this key has cluster-wide bucket access via allBuckets
+                  type: boolean
+                conditions:
+                  description: Conditions represent the current state
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                createdAt:
+                  description: CreatedAt is when the key was created in Garage
+                  format: date-time
+                  type: string
+                effectivePermissions:
+                  description: EffectivePermissions shows merged permissions from both bucket and key definitions
+                  items:
+                    description: EffectivePermission shows the resolved permission for a bucket
+                    properties:
+                      bucketAlias:
+                        description: BucketAlias is the bucket's global alias (if set)
+                        type: string
+                      bucketId:
+                        description: BucketID is the bucket ID
+                        type: string
+                      owner:
+                        description: Owner permission
+                        type: boolean
+                      read:
+                        description: Read permission
+                        type: boolean
+                      source:
+                        description: Source indicates where this permission was defined ("bucket", "key", or "both")
+                        type: string
+                      write:
+                        description: Write permission
+                        type: boolean
+                    type: object
+                  type: array
+                expiresAt:
+                  description: ExpiresAt is when this key expires (if set)
+                  format: date-time
+                  type: string
+                keyId:
+                  description: KeyID is the Garage-assigned key ID
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation
+                  format: int64
+                  type: integer
+                permissions:
+                  description: Permissions shows the current permissions for this key
+                  properties:
+                    createBucket:
+                      description: CreateBucket allows this key to create new buckets via the S3 CreateBucket API
+                      type: boolean
+                  type: object
+                phase:
+                  description: Phase represents the current phase
+                  enum:
+                    - Pending
+                    - Creating
+                    - Ready
+                    - Deleting
+                    - Failed
+                    - Expired
+                    - Unknown
+                  type: string
+                secretRef:
+                  description: SecretRef references the created secret
+                  properties:
+                    name:
+                      description: name is unique within a namespace to reference a secret resource.
+                      type: string
+                    namespace:
+                      description: namespace defines the space within which the secret name must be unique.
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-garagenodes-garage-rajsingh-info.yaml
+++ b/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-garagenodes-garage-rajsingh-info.yaml
@@ -1,0 +1,2556 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/instance: garage-operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: garage-operator
+    app.kubernetes.io/version: 0.6.2
+    control-plane: controller-manager
+    helm.sh/chart: garage-operator-0.6.2
+  name: garagenodes.garage.rajsingh.info
+spec:
+  group: garage.rajsingh.info
+  names:
+    kind: GarageNode
+    listKind: GarageNodeList
+    plural: garagenodes
+    shortNames:
+      - gn
+    singular: garagenode
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: false
+      storage: false
+    - additionalPrinterColumns:
+        - jsonPath: .spec.clusterRef.name
+          name: Cluster
+          type: string
+        - jsonPath: .spec.zone
+          name: Zone
+          type: string
+        - jsonPath: .spec.capacity
+          name: Capacity
+          type: string
+        - jsonPath: .spec.gateway
+          name: Gateway
+          type: boolean
+        - jsonPath: .status.connected
+          name: Connected
+          type: boolean
+        - jsonPath: .status.inLayout
+          name: InLayout
+          type: boolean
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: GarageNode is the Schema for the garagenodes API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                GarageNodeSpec defines the desired state of GarageNode.
+
+                GarageNode is only used when the parent GarageCluster has layoutPolicy: Manual.
+                In Manual mode, the cluster StatefulSet is not created — instead, each GarageNode
+                creates its own single-replica StatefulSet with independent storage configuration.
+
+                Use Manual layout when you need:
+                  - Heterogeneous storage (different size or storage class per node)
+                  - Per-node CPU/memory resource limits
+                  - Fine-grained zone assignment within a cluster
+                  - External nodes (VMs, bare metal, or nodes in another K8s cluster)
+
+                For uniform clusters, prefer layoutPolicy: Auto — the operator handles everything
+                without creating GarageNode resources.
+
+                Pod configuration fields are inherited from the parent GarageCluster and can be
+                overridden per-node. Fields not specified here fall through to the cluster default.
+              properties:
+                affinity:
+                  description: |-
+                    Affinity overrides pod affinity rules.
+                    If not specified, inherits from GarageCluster.
+                  properties:
+                    nodeAffinity:
+                      description: Describes node affinity scheduling rules for the pod.
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: |-
+                            The scheduler will prefer to schedule pods to nodes that satisfy
+                            the affinity expressions specified by this field, but it may choose
+                            a node that violates one or more of the expressions. The node that is
+                            most preferred is the one with the greatest sum of weights, i.e.
+                            for each node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling affinity expressions, etc.),
+                            compute a sum by iterating through the elements of this field and adding
+                            "weight" to the sum if the node matches the corresponding matchExpressions; the
+                            node(s) with the highest sum are the most preferred.
+                          items:
+                            description: |-
+                              An empty preferred scheduling term matches all objects with implicit weight 0
+                              (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                            properties:
+                              preference:
+                                description: A node selector term, associated with the corresponding weight.
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements by node's labels.
+                                    items:
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchFields:
+                                    description: A list of node selector requirements by node's fields.
+                                    items:
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              weight:
+                                description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - preference
+                              - weight
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: |-
+                            If the affinity requirements specified by this field are not met at
+                            scheduling time, the pod will not be scheduled onto the node.
+                            If the affinity requirements specified by this field cease to be met
+                            at some point during pod execution (e.g. due to an update), the system
+                            may or may not try to eventually evict the pod from its node.
+                          properties:
+                            nodeSelectorTerms:
+                              description: Required. A list of node selector terms. The terms are ORed.
+                              items:
+                                description: |-
+                                  A null or empty node selector term matches no objects. The requirements of
+                                  them are ANDed.
+                                  The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements by node's labels.
+                                    items:
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchFields:
+                                    description: A list of node selector requirements by node's fields.
+                                    items:
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - nodeSelectorTerms
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    podAffinity:
+                      description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: |-
+                            The scheduler will prefer to schedule pods to nodes that satisfy
+                            the affinity expressions specified by this field, but it may choose
+                            a node that violates one or more of the expressions. The node that is
+                            most preferred is the one with the greatest sum of weights, i.e.
+                            for each node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling affinity expressions, etc.),
+                            compute a sum by iterating through the elements of this field and adding
+                            "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                            node(s) with the highest sum are the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  topologyKey:
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                description: |-
+                                  weight associated with matching the corresponding podAffinityTerm,
+                                  in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: |-
+                            If the affinity requirements specified by this field are not met at
+                            scheduling time, the pod will not be scheduled onto the node.
+                            If the affinity requirements specified by this field cease to be met
+                            at some point during pod execution (e.g. due to a pod label update), the
+                            system may or may not try to eventually evict the pod from its node.
+                            When there are multiple elements, the lists of nodes corresponding to each
+                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                          items:
+                            description: |-
+                              Defines a set of pods (namely those matching the labelSelector
+                              relative to the given namespace(s)) that this pod should be
+                              co-located (affinity) or not co-located (anti-affinity) with,
+                              where co-located is defined as running on a node whose value of
+                              the label with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: |-
+                                  A label query over a set of resources, in this case pods.
+                                  If it's null, this PodAffinityTerm matches with no Pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                description: |-
+                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mismatchLabelKeys:
+                                description: |-
+                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              namespaceSelector:
+                                description: |-
+                                  A label query over the set of namespaces that the term applies to.
+                                  The term is applied to the union of the namespaces selected by this field
+                                  and the ones listed in the namespaces field.
+                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                  An empty selector ({}) matches all namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaces:
+                                description: |-
+                                  namespaces specifies a static list of namespace names that the term applies to.
+                                  The term is applied to the union of the namespaces listed in this field
+                                  and the ones selected by namespaceSelector.
+                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              topologyKey:
+                                description: |-
+                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                  selected pods is running.
+                                  Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    podAntiAffinity:
+                      description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: |-
+                            The scheduler will prefer to schedule pods to nodes that satisfy
+                            the anti-affinity expressions specified by this field, but it may choose
+                            a node that violates one or more of the expressions. The node that is
+                            most preferred is the one with the greatest sum of weights, i.e.
+                            for each node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling anti-affinity expressions, etc.),
+                            compute a sum by iterating through the elements of this field and subtracting
+                            "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                            node(s) with the highest sum are the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  topologyKey:
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                description: |-
+                                  weight associated with matching the corresponding podAffinityTerm,
+                                  in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: |-
+                            If the anti-affinity requirements specified by this field are not met at
+                            scheduling time, the pod will not be scheduled onto the node.
+                            If the anti-affinity requirements specified by this field cease to be met
+                            at some point during pod execution (e.g. due to a pod label update), the
+                            system may or may not try to eventually evict the pod from its node.
+                            When there are multiple elements, the lists of nodes corresponding to each
+                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                          items:
+                            description: |-
+                              Defines a set of pods (namely those matching the labelSelector
+                              relative to the given namespace(s)) that this pod should be
+                              co-located (affinity) or not co-located (anti-affinity) with,
+                              where co-located is defined as running on a node whose value of
+                              the label with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: |-
+                                  A label query over a set of resources, in this case pods.
+                                  If it's null, this PodAffinityTerm matches with no Pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                description: |-
+                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mismatchLabelKeys:
+                                description: |-
+                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              namespaceSelector:
+                                description: |-
+                                  A label query over the set of namespaces that the term applies to.
+                                  The term is applied to the union of the namespaces selected by this field
+                                  and the ones listed in the namespaces field.
+                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                  An empty selector ({}) matches all namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaces:
+                                description: |-
+                                  namespaces specifies a static list of namespace names that the term applies to.
+                                  The term is applied to the union of the namespaces listed in this field
+                                  and the ones selected by namespaceSelector.
+                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              topologyKey:
+                                description: |-
+                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                  selected pods is running.
+                                  Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                  type: object
+                capacity:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: |-
+                    Capacity is the storage capacity to report to Garage for this node.
+                    Required unless Gateway is true.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                clusterRef:
+                  description: |-
+                    ClusterRef references the GarageCluster this node belongs to.
+                    The GarageNode inherits configuration from this cluster.
+                  properties:
+                    kubeConfigSecretRef:
+                      description: |-
+                        KubeConfigSecretRef references a secret containing a kubeconfig for a remote Kubernetes cluster.
+                        Only needed for multi-cluster federation where the GarageCluster lives in a different
+                        Kubernetes cluster entirely (not just a different namespace).
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    name:
+                      description: Name of the GarageCluster resource.
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the GarageCluster. Defaults to the referencing resource's namespace.
+                        Cross-namespace references require a GarageReferenceGrant in the target namespace.
+                        Not supported on GarageNode.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                containerSecurityContext:
+                  description: |-
+                    ContainerSecurityContext overrides the container-level security context for this node.
+                    If not specified, inherits from GarageCluster.
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: |-
+                        AllowPrivilegeEscalation controls whether a process can gain more
+                        privileges than its parent process. This bool directly controls if
+                        the no_new_privs flag will be set on the container process.
+                        AllowPrivilegeEscalation is true always when the container is:
+                        1) run as Privileged
+                        2) has CAP_SYS_ADMIN
+                        Note that this field cannot be set when spec.os.name is windows.
+                      type: boolean
+                    appArmorProfile:
+                      description: |-
+                        appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                        overrides the pod's appArmorProfile.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: |-
+                            localhostProfile indicates a profile loaded on the node that should be used.
+                            The profile must be preconfigured on the node to work.
+                            Must match the loaded name of the profile.
+                            Must be set if and only if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of AppArmor profile will be applied.
+                            Valid options are:
+                              Localhost - a profile pre-loaded on the node.
+                              RuntimeDefault - the container runtime's default profile.
+                              Unconfined - no AppArmor enforcement.
+                          type: string
+                      required:
+                        - type
+                      type: object
+                    capabilities:
+                      description: |-
+                        The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the container runtime.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            description: Capability represent POSIX capabilities type
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            description: Capability represent POSIX capabilities type
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    privileged:
+                      description: |-
+                        Run container in privileged mode.
+                        Processes in privileged containers are essentially equivalent to root on the host.
+                        Defaults to false.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      type: boolean
+                    procMount:
+                      description: |-
+                        procMount denotes the type of proc mount to use for the containers.
+                        The default value is Default which uses the container runtime defaults for
+                        readonly paths and masked paths.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: |-
+                        Whether this container has a read-only root filesystem.
+                        Default is false.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      type: boolean
+                    runAsGroup:
+                      description: |-
+                        The GID to run the entrypoint of the container process.
+                        Uses runtime default if unset.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: |-
+                        Indicates that the container must run as a non-root user.
+                        If true, the Kubelet will validate the image at runtime to ensure that it
+                        does not run as UID 0 (root) and fail to start the container if it does.
+                        If unset or false, no such validation will be performed.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: |-
+                        The UID to run the entrypoint of the container process.
+                        Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: |-
+                        The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random SELinux context for each
+                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: |-
+                        The seccomp options to use by this container. If seccomp options are
+                        provided at both the pod & container level, the container options
+                        override the pod options.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: |-
+                            localhostProfile indicates a profile defined in a file on the node should be used.
+                            The profile must be preconfigured on the node to work.
+                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                            Must be set if type is "Localhost". Must NOT be set for any other type.
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied.
+                            Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used.
+                            RuntimeDefault - the container runtime default profile should be used.
+                            Unconfined - no profile should be applied.
+                          type: string
+                      required:
+                        - type
+                      type: object
+                    windowsOptions:
+                      description: |-
+                        The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will be used.
+                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is linux.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: |-
+                            GMSACredentialSpec is where the GMSA admission webhook
+                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                            GMSA credential spec named by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: |-
+                            HostProcess determines if a container should be run as a 'Host Process' container.
+                            All of a Pod's containers must have the same effective HostProcess value
+                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                            In addition, if HostProcess is true then HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: |-
+                            The UserName in Windows to run the entrypoint of the container process.
+                            Defaults to the user specified in image metadata if unspecified.
+                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                env:
+                  description: |-
+                    Env overrides environment variables for this node's container. Merged with
+                    cluster-level env (from spec.storage.env or spec.gateway.env, depending on
+                    tier); per-node entries take precedence on key collision.
+                  items:
+                    description: EnvVar represents an environment variable present in a Container.
+                    properties:
+                      name:
+                        description: |-
+                          Name of the environment variable.
+                          May consist of any printable ASCII characters except '='.
+                        type: string
+                      value:
+                        description: |-
+                          Variable references $(VAR_NAME) are expanded
+                          using the previously defined environment variables in the container and
+                          any service environment variables. If a variable cannot be resolved,
+                          the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                          Escaped references will never be expanded, regardless of whether the variable
+                          exists or not.
+                          Defaults to "".
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value. Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fieldRef:
+                            description: |-
+                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified API version.
+                                type: string
+                            required:
+                              - fieldPath
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fileKeyRef:
+                            description: |-
+                              FileKeyRef selects a key of the env file.
+                              Requires the EnvFiles feature gate to be enabled.
+                            properties:
+                              key:
+                                description: |-
+                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                type: string
+                              optional:
+                                default: false
+                                description: |-
+                                  Specify whether the file or its key must be defined. If the file or key
+                                  does not exist, then the env var is not published.
+                                  If optional is set to true and the specified key does not exist,
+                                  the environment variable will not be set in the Pod's containers.
+
+                                  If optional is set to false and the specified key does not exist,
+                                  an error will be returned during Pod creation.
+                                type: boolean
+                              path:
+                                description: |-
+                                  The path within the volume from which to select the file.
+                                  Must be relative and may not contain the '..' path or start with '..'.
+                                type: string
+                              volumeName:
+                                description: The name of the volume mount containing the env file.
+                                type: string
+                            required:
+                              - key
+                              - path
+                              - volumeName
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          resourceFieldRef:
+                            description: |-
+                              Selects a resource of the container: only resources limits and requests
+                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes, optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                              - resource
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    required:
+                      - name
+                    type: object
+                  type: array
+                envFrom:
+                  description: |-
+                    EnvFrom overrides envFrom sources for this node's container. Replaces (does
+                    not merge) the cluster-level envFrom when set.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      prefix:
+                        description: |-
+                          Optional text to prepend to the name of each environment variable.
+                          May consist of any printable ASCII characters except '='.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  type: array
+                external:
+                  description: |-
+                    External marks this node as an external node (not managed by this operator).
+                    When set, no StatefulSet is created - the node is assumed to exist externally.
+                  properties:
+                    address:
+                      description: Address is the IP or hostname of the external node
+                      minLength: 1
+                      type: string
+                    port:
+                      default: 3901
+                      description: Port is the RPC port of the external node
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    remoteClusterRef:
+                      description: RemoteClusterRef references a GarageCluster in another namespace/cluster
+                      properties:
+                        kubeConfigSecretRef:
+                          description: |-
+                            KubeConfigSecretRef references a secret containing a kubeconfig for a remote Kubernetes cluster.
+                            Only needed for multi-cluster federation where the GarageCluster lives in a different
+                            Kubernetes cluster entirely (not just a different namespace).
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        name:
+                          description: Name of the GarageCluster resource.
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the GarageCluster. Defaults to the referencing resource's namespace.
+                            Cross-namespace references require a GarageReferenceGrant in the target namespace.
+                            Not supported on GarageNode.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                  required:
+                    - address
+                  type: object
+                gateway:
+                  description: |-
+                    Gateway marks this node as a gateway-only node (no storage).
+                    Gateway nodes handle API requests but don't store data blocks.
+                  type: boolean
+                image:
+                  description: |-
+                    Image overrides the Garage container image.
+                    If not specified, inherits from GarageCluster.
+                  type: string
+                imagePullPolicy:
+                  description: |-
+                    ImagePullPolicy overrides the image pull policy for this node's container.
+                    If not specified, inherits from GarageCluster.
+                  enum:
+                    - Always
+                    - Never
+                    - IfNotPresent
+                  type: string
+                imagePullSecrets:
+                  description: |-
+                    ImagePullSecrets overrides the image pull secrets for this node's pod.
+                    If not specified, inherits from GarageCluster.
+                  items:
+                    description: |-
+                      LocalObjectReference contains enough information to let you locate the
+                      referenced object inside the same namespace.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                imageRepository:
+                  description: |-
+                    ImageRepository overrides just the repository portion of the Garage image.
+                    If not specified, inherits from GarageCluster.
+                    Ignored if image is set.
+                  type: string
+                logging:
+                  description: |-
+                    Logging overrides cluster-level spec.logging for this node. A non-nil field
+                    here wins over the cluster value; a nil field falls through to the cluster.
+                  properties:
+                    journald:
+                      description: Journald enables logging to systemd journald. When nil, inherits cluster-level setting.
+                      type: boolean
+                    level:
+                      description: Level sets the log level using RUST_LOG format.
+                      type: string
+                    syslog:
+                      description: Syslog enables logging to syslog. When nil, inherits cluster-level setting.
+                      type: boolean
+                  type: object
+                maintenance:
+                  description: Maintenance configures maintenance mode for this node.
+                  properties:
+                    suspended:
+                      description: Suspended pauses operator reconciliation for this node when true.
+                      type: boolean
+                  type: object
+                network:
+                  description: |-
+                    Network configures per-node RPC address overrides.
+                    Parallel to GarageCluster's spec.network but scoped to this node only.
+                  properties:
+                    rpcPublicAddr:
+                      description: |-
+                        RPCPublicAddr is the externally-routable RPC address for this node (host:port).
+                        Overrides the cluster-level network.rpcPublicAddr for this specific node.
+                        When publicEndpoint is also set to LoadBalancer and this is empty, the operator
+                        derives rpc_public_addr from the assigned LoadBalancer ingress IP automatically.
+                      type: string
+                  type: object
+                nodeId:
+                  description: |-
+                    NodeID is the public key of the Garage node.
+                    If not specified, the operator will auto-discover from the pod.
+                  pattern: ^[a-fA-F0-9]{64}$
+                  type: string
+                nodeSelector:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    NodeSelector overrides node selection constraints.
+                    If not specified, inherits from GarageCluster.
+                  type: object
+                podAnnotations:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    PodAnnotations are additional annotations to add to this node's pod.
+                    Merged with annotations from GarageCluster (node-specific takes precedence).
+                  type: object
+                podLabels:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    PodLabels are additional labels to add to this node's pod.
+                    Merged with labels from GarageCluster (node-specific takes precedence).
+                  type: object
+                priorityClassName:
+                  description: |-
+                    PriorityClassName overrides the priority class for this node's pod.
+                    If not specified, inherits from GarageCluster.
+                  type: string
+                publicEndpoint:
+                  description: |-
+                    PublicEndpoint configures a Kubernetes Service exposing this node's RPC port.
+                    Parallel to GarageCluster's spec.publicEndpoint. When set to LoadBalancer type
+                    without network.rpcPublicAddr, the operator derives rpc_public_addr from the
+                    assigned ingress IP automatically.
+                  properties:
+                    externalIP:
+                      description: ExternalIP configuration
+                      properties:
+                        addressTemplate:
+                          description: |-
+                            AddressTemplate uses go template to generate addresses from pod info
+                            Example: "garage-{{.Index}}.example.com"
+                          type: string
+                        addresses:
+                          additionalProperties:
+                            type: string
+                          description: Addresses maps pod names to external IPs
+                          type: object
+                      type: object
+                    loadBalancer:
+                      description: LoadBalancer configuration
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations to add to the service.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels to add to the service. Operator-managed labels take precedence on conflict.
+                          type: object
+                        perNode:
+                          description: |-
+                            PerNode creates a separate LoadBalancer service per GarageCluster pod instead
+                            of one shared LoadBalancer service. In auto-layout GarageCluster mode, those
+                            services are used for operator-driven reverse ConnectClusterNodes calls; the
+                            pods still share one Garage ConfigMap, so distinct per-pod rpc_public_addr
+                            values are not written into Garage config. Use Manual layout with GarageNode
+                            resources when each node also needs its own advertised rpc_public_addr.
+                          type: boolean
+                      type: object
+                    nodePort:
+                      description: NodePort configuration
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations to add to the service.
+                          type: object
+                        basePort:
+                          description: |-
+                            BasePort is the starting NodePort; Garage pod N is exposed on BasePort+N.
+                            If omitted, the controller allocates starting from the RPC port base (30901).
+                          format: int32
+                          maximum: 32767
+                          minimum: 30000
+                          type: integer
+                        externalAddresses:
+                          description: |-
+                            ExternalAddresses are the externally-reachable IPs or hostnames of the Kubernetes nodes.
+                            The operator maps Garage pod N to ExternalAddresses[N % len(ExternalAddresses)],
+                            so the order should be stable. Must have at least one entry.
+                          items:
+                            type: string
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels to add to the service. Operator-managed labels take precedence on conflict.
+                          type: object
+                      required:
+                        - externalAddresses
+                      type: object
+                    type:
+                      description: Type specifies how nodes are exposed to remote clusters for RPC
+                      enum:
+                        - LoadBalancer
+                        - NodePort
+                        - ExternalIP
+                        - Headless
+                      type: string
+                  required:
+                    - type
+                  type: object
+                resources:
+                  description: |-
+                    Resources overrides compute resources for the Garage container.
+                    If not specified, inherits from GarageCluster.
+                  properties:
+                    claims:
+                      description: |-
+                        Claims lists the names of resources, defined in spec.resourceClaims,
+                        that are used by this container.
+
+                        This field depends on the
+                        DynamicResourceAllocation feature gate.
+
+                        This field is immutable. It can only be set for containers.
+                      items:
+                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                        properties:
+                          name:
+                            description: |-
+                              Name must match the name of one entry in pod.spec.resourceClaims of
+                              the Pod where this field is used. It makes that resource available
+                              inside a container.
+                            type: string
+                          request:
+                            description: |-
+                              Request is the name chosen for a request in the referenced claim.
+                              If empty, everything from the claim is made available, otherwise
+                              only the result of this request.
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: |-
+                        Limits describes the maximum amount of compute resources allowed.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: |-
+                        Requests describes the minimum amount of compute resources required.
+                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      type: object
+                  type: object
+                securityContext:
+                  description: |-
+                    SecurityContext overrides the pod-level security context for this node.
+                    If not specified, inherits from GarageCluster.
+                  properties:
+                    appArmorProfile:
+                      description: |-
+                        appArmorProfile is the AppArmor options to use by the containers in this pod.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: |-
+                            localhostProfile indicates a profile loaded on the node that should be used.
+                            The profile must be preconfigured on the node to work.
+                            Must match the loaded name of the profile.
+                            Must be set if and only if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of AppArmor profile will be applied.
+                            Valid options are:
+                              Localhost - a profile pre-loaded on the node.
+                              RuntimeDefault - the container runtime's default profile.
+                              Unconfined - no AppArmor enforcement.
+                          type: string
+                      required:
+                        - type
+                      type: object
+                    fsGroup:
+                      description: |-
+                        A special supplemental group that applies to all containers in a pod.
+                        Some volume types allow the Kubelet to change the ownership of that volume
+                        to be owned by the pod:
+
+                        1. The owning GID will be the FSGroup
+                        2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                        3. The permission bits are OR'd with rw-rw----
+
+                        If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    fsGroupChangePolicy:
+                      description: |-
+                        fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                        before being exposed inside Pod. This field will only apply to
+                        volume types which support fsGroup based ownership(and permissions).
+                        It will have no effect on ephemeral volume types such as: secret, configmaps
+                        and emptydir.
+                        Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      type: string
+                    runAsGroup:
+                      description: |-
+                        The GID to run the entrypoint of the container process.
+                        Uses runtime default if unset.
+                        May also be set in SecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence
+                        for that container.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: |-
+                        Indicates that the container must run as a non-root user.
+                        If true, the Kubelet will validate the image at runtime to ensure that it
+                        does not run as UID 0 (root) and fail to start the container if it does.
+                        If unset or false, no such validation will be performed.
+                        May also be set in SecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: |-
+                        The UID to run the entrypoint of the container process.
+                        Defaults to user specified in image metadata if unspecified.
+                        May also be set in SecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence
+                        for that container.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    seLinuxChangePolicy:
+                      description: |-
+                        seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                        It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                        Valid values are "MountOption" and "Recursive".
+
+                        "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                        This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                        "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                        This requires all Pods that share the same volume to use the same SELinux label.
+                        It is not possible to share the same volume among privileged and unprivileged Pods.
+                        Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                        whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                        CSIDriver instance. Other volumes are always re-labelled recursively.
+                        "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                        If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                        If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                        and "Recursive" for all other volumes.
+
+                        This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                        All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      type: string
+                    seLinuxOptions:
+                      description: |-
+                        The SELinux context to be applied to all containers.
+                        If unspecified, the container runtime will allocate a random SELinux context for each
+                        container.  May also be set in SecurityContext.  If set in
+                        both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence for that container.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: |-
+                        The seccomp options to use by the containers in this pod.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: |-
+                            localhostProfile indicates a profile defined in a file on the node should be used.
+                            The profile must be preconfigured on the node to work.
+                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                            Must be set if type is "Localhost". Must NOT be set for any other type.
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied.
+                            Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used.
+                            RuntimeDefault - the container runtime default profile should be used.
+                            Unconfined - no profile should be applied.
+                          type: string
+                      required:
+                        - type
+                      type: object
+                    supplementalGroups:
+                      description: |-
+                        A list of groups applied to the first process run in each container, in
+                        addition to the container's primary GID and fsGroup (if specified).  If
+                        the SupplementalGroupsPolicy feature is enabled, the
+                        supplementalGroupsPolicy field determines whether these are in addition
+                        to or instead of any group memberships defined in the container image.
+                        If unspecified, no additional groups are added, though group memberships
+                        defined in the container image may still be used, depending on the
+                        supplementalGroupsPolicy field.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    supplementalGroupsPolicy:
+                      description: |-
+                        Defines how supplemental groups of the first container processes are calculated.
+                        Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                        (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                        and the container runtime must implement support for this feature.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      type: string
+                    sysctls:
+                      description: |-
+                        Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                        sysctls (by the container runtime) might fail to launch.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      items:
+                        description: Sysctl defines a kernel parameter to be set
+                        properties:
+                          name:
+                            description: Name of a property to set
+                            type: string
+                          value:
+                            description: Value of a property to set
+                            type: string
+                        required:
+                          - name
+                          - value
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    windowsOptions:
+                      description: |-
+                        The Windows specific settings applied to all containers.
+                        If unspecified, the options within a container's SecurityContext will be used.
+                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is linux.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: |-
+                            GMSACredentialSpec is where the GMSA admission webhook
+                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                            GMSA credential spec named by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: |-
+                            HostProcess determines if a container should be run as a 'Host Process' container.
+                            All of a Pod's containers must have the same effective HostProcess value
+                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                            In addition, if HostProcess is true then HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: |-
+                            The UserName in Windows to run the entrypoint of the container process.
+                            Defaults to the user specified in image metadata if unspecified.
+                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                serviceAccountName:
+                  description: |-
+                    ServiceAccountName overrides the service account for this node's pod.
+                    If not specified, inherits from GarageCluster.
+                  type: string
+                storage:
+                  description: |-
+                    Storage configures storage volumes for this node's StatefulSet.
+                    Required for managed nodes (not External).
+                  properties:
+                    data:
+                      description: |-
+                        Data volume for block storage. Ignored for gateway nodes.
+                        Mutually exclusive with DataPaths.
+                      properties:
+                        accessModes:
+                          description: |-
+                            AccessModes for the dynamically provisioned PVC.
+                            Defaults to [ReadWriteOnce] if not specified.
+                          items:
+                            type: string
+                          type: array
+                        existingClaim:
+                          description: |-
+                            ExistingClaim references a pre-existing PVC by name in the cluster namespace.
+                            Mutually exclusive with Size.
+                          type: string
+                        size:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: |-
+                            Size creates a dynamically provisioned PVC with this capacity.
+                            Mutually exclusive with ExistingClaim.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        storageClassName:
+                          description: |-
+                            StorageClassName for the dynamically provisioned PVC.
+                            Uses the cluster default if not specified.
+                          type: string
+                        type:
+                          allOf:
+                            - enum:
+                                - PersistentVolumeClaim
+                                - EmptyDir
+                            - enum:
+                                - PVC
+                                - EmptyDir
+                          description: |-
+                            Type specifies the volume type. Defaults to PVC.
+                            Use EmptyDir for ephemeral storage (e.g. testing).
+                          type: string
+                      type: object
+                    dataFsync:
+                      description: |-
+                        DataFsync enables fsync on data block writes for this node.
+                        Overrides the cluster-level storage.dataFsync setting.
+                      type: boolean
+                    dataPaths:
+                      description: |-
+                        DataPaths configures multiple data directories for multi-HDD nodes.
+                        Each entry produces a separate volume/mount/PVC at /var/lib/garage/data-<idx>
+                        and the corresponding garage.toml `data_dir = [...]` array form. Use this for
+                        multi-HDD nodes; mutually exclusive with .data.
+                      items:
+                        description: |-
+                          NodeVolumeConfig defines the source of a storage volume for a GarageNode.
+                          Parallel to GarageCluster's VolumeConfig, extended with existingClaim for
+                          pre-provisioned PVCs. Either ExistingClaim or Size must be specified, not both.
+                        properties:
+                          accessModes:
+                            description: |-
+                              AccessModes for the dynamically provisioned PVC.
+                              Defaults to [ReadWriteOnce] if not specified.
+                            items:
+                              type: string
+                            type: array
+                          existingClaim:
+                            description: |-
+                              ExistingClaim references a pre-existing PVC by name in the cluster namespace.
+                              Mutually exclusive with Size.
+                            type: string
+                          size:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            description: |-
+                              Size creates a dynamically provisioned PVC with this capacity.
+                              Mutually exclusive with ExistingClaim.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          storageClassName:
+                            description: |-
+                              StorageClassName for the dynamically provisioned PVC.
+                              Uses the cluster default if not specified.
+                            type: string
+                          type:
+                            allOf:
+                              - enum:
+                                  - PersistentVolumeClaim
+                                  - EmptyDir
+                              - enum:
+                                  - PVC
+                                  - EmptyDir
+                            description: |-
+                              Type specifies the volume type. Defaults to PVC.
+                              Use EmptyDir for ephemeral storage (e.g. testing).
+                            type: string
+                        type: object
+                      type: array
+                    metadata:
+                      description: Metadata volume for node identity and cluster state.
+                      properties:
+                        accessModes:
+                          description: |-
+                            AccessModes for the dynamically provisioned PVC.
+                            Defaults to [ReadWriteOnce] if not specified.
+                          items:
+                            type: string
+                          type: array
+                        existingClaim:
+                          description: |-
+                            ExistingClaim references a pre-existing PVC by name in the cluster namespace.
+                            Mutually exclusive with Size.
+                          type: string
+                        size:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: |-
+                            Size creates a dynamically provisioned PVC with this capacity.
+                            Mutually exclusive with ExistingClaim.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        storageClassName:
+                          description: |-
+                            StorageClassName for the dynamically provisioned PVC.
+                            Uses the cluster default if not specified.
+                          type: string
+                        type:
+                          allOf:
+                            - enum:
+                                - PersistentVolumeClaim
+                                - EmptyDir
+                            - enum:
+                                - PVC
+                                - EmptyDir
+                          description: |-
+                            Type specifies the volume type. Defaults to PVC.
+                            Use EmptyDir for ephemeral storage (e.g. testing).
+                          type: string
+                      type: object
+                    metadataAutoSnapshotInterval:
+                      description: |-
+                        MetadataAutoSnapshotInterval overrides the cluster-level
+                        storage.metadataAutoSnapshotInterval (garage.toml `metadata_auto_snapshot_interval`)
+                        for this node.
+                      pattern: ^(\d+(\.\d+)?\s*(ns|us|ms|s|m|h|d|w|M|y)\s*)+$
+                      type: string
+                    metadataFsync:
+                      description: |-
+                        MetadataFsync enables fsync on metadata writes for this node.
+                        Overrides the cluster-level storage.metadataFsync setting.
+                      type: boolean
+                    metadataSnapshotsDir:
+                      description: |-
+                        MetadataSnapshotsDir overrides the cluster-level storage.metadataSnapshotsDir
+                        (garage.toml `metadata_snapshots_dir`) for this node.
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                    - message: storage.data and storage.dataPaths are mutually exclusive
+                      rule: '!(has(self.data) && has(self.dataPaths) && size(self.dataPaths) > 0)'
+                tags:
+                  description: Tags are custom tags for this node in the Garage layout.
+                  items:
+                    type: string
+                  type: array
+                tolerations:
+                  description: |-
+                    Tolerations overrides pod tolerations.
+                    If not specified, inherits from GarageCluster.
+                  items:
+                    description: |-
+                      The pod this Toleration is attached to tolerates any taint that matches
+                      the triple <key,value,effect> using the matching operator <operator>.
+                    properties:
+                      effect:
+                        description: |-
+                          Effect indicates the taint effect to match. Empty means match all taint effects.
+                          When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: |-
+                          Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                          If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                        type: string
+                      operator:
+                        description: |-
+                          Operator represents a key's relationship to the value.
+                          Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                          Exists is equivalent to wildcard for value, so that a pod can
+                          tolerate all taints of a particular category.
+                          Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                        type: string
+                      tolerationSeconds:
+                        description: |-
+                          TolerationSeconds represents the period of time the toleration (which must be
+                          of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                          it is not set, which means tolerate the taint forever (do not evict). Zero and
+                          negative values will be treated as 0 (evict immediately) by the system.
+                        format: int64
+                        type: integer
+                      value:
+                        description: |-
+                          Value is the taint value the toleration matches to.
+                          If the operator is Exists, the value should be empty, otherwise just a regular string.
+                        type: string
+                    type: object
+                  type: array
+                topologySpreadConstraints:
+                  description: |-
+                    TopologySpreadConstraints overrides topology spread constraints for this node's pod.
+                    If not specified, inherits from GarageCluster.
+                  items:
+                    description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                    properties:
+                      labelSelector:
+                        description: |-
+                          LabelSelector is used to find matching pods.
+                          Pods that match this label selector are counted to determine the number of pods
+                          in their corresponding topology domain.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      matchLabelKeys:
+                        description: |-
+                          MatchLabelKeys is a set of pod label keys to select the pods over which
+                          spreading will be calculated. The keys are used to lookup values from the
+                          incoming pod labels, those key-value labels are ANDed with labelSelector
+                          to select the group of existing pods over which spreading will be calculated
+                          for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                          MatchLabelKeys cannot be set when LabelSelector isn't set.
+                          Keys that don't exist in the incoming pod labels will
+                          be ignored. A null or empty list means only match against labelSelector.
+
+                          This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      maxSkew:
+                        description: |-
+                          MaxSkew describes the degree to which pods may be unevenly distributed.
+                          When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                          between the number of matching pods in the target topology and the global minimum.
+                          The global minimum is the minimum number of matching pods in an eligible domain
+                          or zero if the number of eligible domains is less than MinDomains.
+                          For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                          labelSelector spread as 2/2/1:
+                          In this case, the global minimum is 1.
+                          | zone1 | zone2 | zone3 |
+                          |  P P  |  P P  |   P   |
+                          - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                          scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                          violate MaxSkew(1).
+                          - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                          When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                          to topologies that satisfy it.
+                          It's a required field. Default value is 1 and 0 is not allowed.
+                        format: int32
+                        type: integer
+                      minDomains:
+                        description: |-
+                          MinDomains indicates a minimum number of eligible domains.
+                          When the number of eligible domains with matching topology keys is less than minDomains,
+                          Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                          And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                          this value has no effect on scheduling.
+                          As a result, when the number of eligible domains is less than minDomains,
+                          scheduler won't schedule more than maxSkew Pods to those domains.
+                          If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                          Valid values are integers greater than 0.
+                          When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                          For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                          labelSelector spread as 2/2/2:
+                          | zone1 | zone2 | zone3 |
+                          |  P P  |  P P  |  P P  |
+                          The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                          In this situation, new pod with the same labelSelector cannot be scheduled,
+                          because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                          it will violate MaxSkew.
+                        format: int32
+                        type: integer
+                      nodeAffinityPolicy:
+                        description: |-
+                          NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                          when calculating pod topology spread skew. Options are:
+                          - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                          - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                          If this value is nil, the behavior is equivalent to the Honor policy.
+                        type: string
+                      nodeTaintsPolicy:
+                        description: |-
+                          NodeTaintsPolicy indicates how we will treat node taints when calculating
+                          pod topology spread skew. Options are:
+                          - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                          has a toleration, are included.
+                          - Ignore: node taints are ignored. All nodes are included.
+
+                          If this value is nil, the behavior is equivalent to the Ignore policy.
+                        type: string
+                      topologyKey:
+                        description: |-
+                          TopologyKey is the key of node labels. Nodes that have a label with this key
+                          and identical values are considered to be in the same topology.
+                          We consider each <key, value> as a "bucket", and try to put balanced number
+                          of pods into each bucket.
+                          We define a domain as a particular instance of a topology.
+                          Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                          nodeAffinityPolicy and nodeTaintsPolicy.
+                          e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                          And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                          It's a required field.
+                        type: string
+                      whenUnsatisfiable:
+                        description: |-
+                          WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                          the spread constraint.
+                          - DoNotSchedule (default) tells the scheduler not to schedule it.
+                          - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                            but giving higher precedence to topologies that would help reduce the
+                            skew.
+                          A constraint is considered "Unsatisfiable" for an incoming pod
+                          if and only if every possible node assignment for that pod would violate
+                          "MaxSkew" on some topology.
+                          For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                          labelSelector spread as 3/1/1:
+                          | zone1 | zone2 | zone3 |
+                          | P P P |   P   |   P   |
+                          If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                          to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                          MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                          won't make it *more* imbalanced.
+                          It's a required field.
+                        type: string
+                    required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
+                    type: object
+                  type: array
+                zone:
+                  description: |-
+                    Zone is the zone assignment for this node.
+                    Used for data placement and fault tolerance.
+                  type: string
+              required:
+                - clusterRef
+                - zone
+              type: object
+              x-kubernetes-validations:
+                - message: capacity is required for non-gateway managed nodes
+                  rule: self.gateway || has(self.external) || has(self.capacity)
+            status:
+              description: GarageNodeStatus defines the observed state of GarageNode
+              properties:
+                address:
+                  description: Address is the node's address in the cluster
+                  type: string
+                blockErrors:
+                  description: BlockErrors is the count of blocks with sync errors on this node
+                  format: int32
+                  type: integer
+                conditions:
+                  description: Conditions represent the current state
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                connected:
+                  description: Connected indicates if the node is currently connected
+                  type: boolean
+                dataPartition:
+                  description: |-
+                    DataPartition contains disk space info for the data partition
+                    Note: Garage reports a single partition even with multiple data paths
+                  properties:
+                    available:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: Available is the available disk space
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    total:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: Total is the total disk space
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    usedPercent:
+                      description: UsedPercent is the percentage of disk space used (0-100)
+                      format: int32
+                      type: integer
+                  type: object
+                dbEngine:
+                  description: DBEngine is the database engine used by this node (lmdb, sqlite, fjall)
+                  type: string
+                garageFeatures:
+                  description: GarageFeatures lists the enabled Cargo features on this node
+                  items:
+                    type: string
+                  type: array
+                hostname:
+                  description: Hostname is the hostname reported by this Garage node
+                  type: string
+                inLayout:
+                  description: InLayout indicates if this node is part of the current layout
+                  type: boolean
+                lastSeen:
+                  description: LastSeen is when the node was last seen connected
+                  format: date-time
+                  type: string
+                layoutVersion:
+                  description: LayoutVersion is the layout version when this node was added
+                  format: int64
+                  type: integer
+                metadataPartition:
+                  description: MetadataPartition contains disk space info for the metadata partition
+                  properties:
+                    available:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: Available is the available disk space
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    total:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: Total is the total disk space
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    usedPercent:
+                      description: UsedPercent is the percentage of disk space used (0-100)
+                      format: int32
+                      type: integer
+                  type: object
+                nodeId:
+                  description: NodeID is the discovered or assigned node ID
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation
+                  format: int64
+                  type: integer
+                partitions:
+                  description: Partitions is the number of partitions assigned to this node
+                  type: integer
+                phase:
+                  description: Phase represents the current phase
+                  enum:
+                    - Pending
+                    - Creating
+                    - Running
+                    - Ready
+                    - Degraded
+                    - Updating
+                    - Deleting
+                    - Failed
+                    - Unknown
+                  type: string
+                repairInProgress:
+                  description: RepairInProgress indicates if a repair operation is running
+                  type: boolean
+                repairProgress:
+                  description: RepairProgress is a human-readable repair progress description
+                  type: string
+                repairType:
+                  description: RepairType is the type of repair operation in progress
+                  type: string
+                storedData:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: StoredData is the amount of data stored on this node
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                tags:
+                  description: Tags are the tags assigned to this node in the layout
+                  items:
+                    type: string
+                  type: array
+                version:
+                  description: Version is the Garage version on this node
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-garagereferencegrants-garage-rajsingh-info.yaml
+++ b/generated/manifests/prod-axon/bootstrap/CustomResourceDefinition-garagereferencegrants-garage-rajsingh-info.yaml
@@ -1,0 +1,218 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/instance: garage-operator
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: garage-operator
+    app.kubernetes.io/version: 0.6.2
+    control-plane: controller-manager
+    helm.sh/chart: garage-operator-0.6.2
+  name: garagereferencegrants.garage.rajsingh.info
+spec:
+  group: garage.rajsingh.info
+  names:
+    kind: GarageReferenceGrant
+    listKind: GarageReferenceGrantList
+    plural: garagereferencegrants
+    shortNames:
+      - grg
+    singular: garagereferencegrant
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=='InUse')].status
+          name: InUse
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            GarageReferenceGrant grants permission for resources in other namespaces to
+            reference GarageCluster or GarageBucket resources in this namespace.
+
+            This resource must be created in the destination namespace (where the
+            GarageCluster or GarageBucket lives). Only admins of that namespace can
+            create it, so tenants cannot self-grant cross-namespace access.
+
+            Example: allow GarageKey objects in namespace "team-b" to reference
+            GarageCluster "my-cluster" in namespace "storage-admin":
+
+            	apiVersion: garage.rajsingh.info/v1beta1
+            	kind: GarageReferenceGrant
+            	metadata:
+            	  namespace: storage-admin
+            	spec:
+            	  from:
+            	    - kind: GarageKey
+            	      namespace: team-b
+            	  to:
+            	    - kind: GarageCluster
+            	      name: my-cluster
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                GarageReferenceGrantSpec defines which namespaces and resource kinds are
+                permitted to make cross-namespace references to resources in this namespace.
+              properties:
+                from:
+                  description: From lists the permitted sources of cross-namespace references.
+                  items:
+                    description: ReferenceGrantFrom specifies a permitted source namespace and resource kind.
+                    properties:
+                      kind:
+                        description: Kind is the resource kind allowed to make cross-namespace references.
+                        enum:
+                          - GarageKey
+                          - GarageBucket
+                          - GarageAdminToken
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace from which cross-namespace references are allowed.
+                        minLength: 1
+                        type: string
+                    required:
+                      - kind
+                      - namespace
+                    type: object
+                  minItems: 1
+                  type: array
+                to:
+                  description: |-
+                    To lists the target resource kinds (and optionally specific names) that
+                    may be referenced. If omitted, all GarageCluster and GarageBucket resources
+                    in this namespace are accessible.
+                  items:
+                    description: ReferenceGrantTo specifies a target resource kind and optionally a specific name.
+                    properties:
+                      kind:
+                        description: Kind is the target resource kind.
+                        enum:
+                          - GarageCluster
+                          - GarageBucket
+                          - GarageKey
+                        type: string
+                      name:
+                        description: |-
+                          Name restricts access to a specific resource. If omitted, all resources of
+                          the given kind in this namespace are accessible.
+                        minLength: 1
+                        type: string
+                    required:
+                      - kind
+                    type: object
+                  type: array
+              required:
+                - from
+              type: object
+            status:
+              description: GarageReferenceGrantStatus reflects which resources are currently using this grant.
+              properties:
+                conditions:
+                  description: Conditions represent the current state.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                inUseBy:
+                  description: |-
+                    InUseBy lists resources currently referencing through this grant.
+                    Rebuilt on every reconcile — safe to delete when this is empty.
+                  items:
+                    description: ReferenceGrantUser identifies a resource using this grant.
+                    properties:
+                      kind:
+                        description: Kind of the referencing resource.
+                        type: string
+                      name:
+                        description: Name of the referencing resource.
+                        type: string
+                      namespace:
+                        description: Namespace of the referencing resource.
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/generated/manifests/prod-axon/bootstrap/Namespace-garage.yaml
+++ b/generated/manifests/prod-axon/bootstrap/Namespace-garage.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+  name: garage

--- a/generated/manifests/prod-axon/bootstrap/Namespace-reflector.yaml
+++ b/generated/manifests/prod-axon/bootstrap/Namespace-reflector.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+  name: reflector

--- a/generated/manifests/prod-axon/cert-manager/Certificate-s3-json64-dev-wildcard-certificate.yaml
+++ b/generated/manifests/prod-axon/cert-manager/Certificate-s3-json64-dev-wildcard-certificate.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  annotations:
+    cert-manager.io/issue-temporary-certificate: "true"
+  name: s3-json64-dev-wildcard-certificate
+  namespace: certs
+spec:
+  dnsNames:
+    - s3.json64.dev
+    - '*.s3.json64.dev'
+  issuerRef:
+    kind: ClusterIssuer
+    name: json64-dev-issuer
+  secretName: s3-json64-dev-wildcard-tls

--- a/generated/manifests/prod-axon/envoy-gateway-proxy/Gateway-default-gateway.yaml
+++ b/generated/manifests/prod-axon/envoy-gateway-proxy/Gateway-default-gateway.yaml
@@ -77,6 +77,27 @@ spec:
     - allowedRoutes:
         namespaces:
           from: All
+      hostname: '*.s3.json64.dev'
+      name: s3-json64-dev-http
+      port: 80
+      protocol: HTTP
+    - allowedRoutes:
+        namespaces:
+          from: All
+      hostname: '*.s3.json64.dev'
+      name: s3-json64-dev-https
+      port: 443
+      protocol: HTTPS
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: s3-json64-dev-wildcard-tls
+            namespace: certs
+        mode: Terminate
+    - allowedRoutes:
+        namespaces:
+          from: All
       hostname: '*.sinistar.io'
       name: sinistar-io-http
       port: 80

--- a/generated/manifests/prod-axon/envoy-gateway-proxy/ReferenceGrant-allow-gateway-to-cert-tls.yaml
+++ b/generated/manifests/prod-axon/envoy-gateway-proxy/ReferenceGrant-allow-gateway-to-cert-tls.yaml
@@ -20,6 +20,9 @@ spec:
       name: json64-net-wildcard-tls
     - group: ""
       kind: Secret
+      name: s3-json64-dev-wildcard-tls
+    - group: ""
+      kind: Secret
       name: sinistar-io-wildcard-tls
     - group: ""
       kind: Secret

--- a/generated/manifests/prod-axon/garage-operator/ClusterRole-garage-operator-manager-role.yaml
+++ b/generated/manifests/prod-axon/garage-operator/ClusterRole-garage-operator-manager-role.yaml
@@ -1,0 +1,130 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: garage-operator
+    app.kubernetes.io/name: garage-operator
+    control-plane: controller-manager
+  name: garage-operator-manager-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - persistentvolumeclaims
+      - secrets
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - garage.rajsingh.info
+    resources:
+      - garageadmintokens
+      - garagebuckets
+      - garageclusters
+      - garagekeys
+      - garagenodes
+      - garagereferencegrants
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - garage.rajsingh.info
+    resources:
+      - garageadmintokens/finalizers
+      - garagebuckets/finalizers
+      - garageclusters/finalizers
+      - garagekeys/finalizers
+      - garagenodes/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - garage.rajsingh.info
+    resources:
+      - garageadmintokens/status
+      - garagebuckets/status
+      - garageclusters/status
+      - garagekeys/status
+      - garagenodes/status
+      - garagereferencegrants/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch

--- a/generated/manifests/prod-axon/garage-operator/ClusterRole-garage-operator-metrics-auth-role.yaml
+++ b/generated/manifests/prod-axon/garage-operator/ClusterRole-garage-operator-metrics-auth-role.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: garage-operator
+    app.kubernetes.io/name: garage-operator
+    control-plane: controller-manager
+  name: garage-operator-metrics-auth-role
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create

--- a/generated/manifests/prod-axon/garage-operator/ClusterRole-garage-operator-metrics-reader.yaml
+++ b/generated/manifests/prod-axon/garage-operator/ClusterRole-garage-operator-metrics-reader.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: garage-operator
+    app.kubernetes.io/name: garage-operator
+    control-plane: controller-manager
+  name: garage-operator-metrics-reader
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get

--- a/generated/manifests/prod-axon/garage-operator/ClusterRoleBinding-garage-operator-manager-rolebinding.yaml
+++ b/generated/manifests/prod-axon/garage-operator/ClusterRoleBinding-garage-operator-manager-rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: garage-operator
+    app.kubernetes.io/name: garage-operator
+    control-plane: controller-manager
+  name: garage-operator-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: garage-operator-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: garage-operator
+    namespace: garage

--- a/generated/manifests/prod-axon/garage-operator/ClusterRoleBinding-garage-operator-metrics-auth-rolebinding.yaml
+++ b/generated/manifests/prod-axon/garage-operator/ClusterRoleBinding-garage-operator-metrics-auth-rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: garage-operator
+    app.kubernetes.io/name: garage-operator
+    control-plane: controller-manager
+  name: garage-operator-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: garage-operator-metrics-auth-role
+subjects:
+  - kind: ServiceAccount
+    name: garage-operator
+    namespace: garage

--- a/generated/manifests/prod-axon/garage-operator/Deployment-garage-operator.yaml
+++ b/generated/manifests/prod-axon/garage-operator/Deployment-garage-operator.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: garage-operator
+    app.kubernetes.io/name: garage-operator
+    control-plane: controller-manager
+  name: garage-operator
+  namespace: garage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: garage-operator
+      app.kubernetes.io/name: garage-operator
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/instance: garage-operator
+        app.kubernetes.io/name: garage-operator
+        control-plane: controller-manager
+    spec:
+      containers:
+        - args:
+            - --zap-log-level=info
+            - --metrics-bind-address=:8443
+            - --leader-elect
+            - --health-probe-bind-address=:8081
+          command:
+            - /manager
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          image: ghcr.io/rajsinghtech/garage-operator:v0.6.2
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: manager
+          ports:
+            - containerPort: 8443
+              name: metrics
+              protocol: TCP
+            - containerPort: 8081
+              name: health
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+            requests:
+              cpu: 10m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: garage-operator
+      terminationGracePeriodSeconds: 10

--- a/generated/manifests/prod-axon/garage-operator/Role-garage-operator-leader-election-role.yaml
+++ b/generated/manifests/prod-axon/garage-operator/Role-garage-operator-leader-election-role.yaml
@@ -1,0 +1,41 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: garage-operator
+    app.kubernetes.io/name: garage-operator
+    control-plane: controller-manager
+  name: garage-operator-leader-election-role
+  namespace: garage
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch

--- a/generated/manifests/prod-axon/garage-operator/RoleBinding-garage-operator-leader-election-rolebinding.yaml
+++ b/generated/manifests/prod-axon/garage-operator/RoleBinding-garage-operator-leader-election-rolebinding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: garage-operator
+    app.kubernetes.io/name: garage-operator
+    control-plane: controller-manager
+  name: garage-operator-leader-election-rolebinding
+  namespace: garage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: garage-operator-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: garage-operator
+    namespace: garage

--- a/generated/manifests/prod-axon/garage-operator/Service-garage-operator-metrics.yaml
+++ b/generated/manifests/prod-axon/garage-operator/Service-garage-operator-metrics.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: garage-operator
+    app.kubernetes.io/name: garage-operator
+    control-plane: controller-manager
+  name: garage-operator-metrics
+  namespace: garage
+spec:
+  ports:
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: metrics
+  selector:
+    app.kubernetes.io/instance: garage-operator
+    app.kubernetes.io/name: garage-operator
+    control-plane: controller-manager
+  type: ClusterIP

--- a/generated/manifests/prod-axon/garage-operator/ServiceAccount-garage-operator.yaml
+++ b/generated/manifests/prod-axon/garage-operator/ServiceAccount-garage-operator.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: garage-operator
+    app.kubernetes.io/name: garage-operator
+    control-plane: controller-manager
+  name: garage-operator
+  namespace: garage

--- a/generated/manifests/prod-axon/garage/CiliumNetworkPolicy-allow-garage-admin-ingress.yaml
+++ b/generated/manifests/prod-axon/garage/CiliumNetworkPolicy-allow-garage-admin-ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-garage-admin-ingress
+  namespace: garage
+spec:
+  description: Admin API (3903) ingress from garage-ui only.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: garage
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: garage-ui
+      toPorts:
+        - ports:
+            - port: "3903"
+              protocol: TCP

--- a/generated/manifests/prod-axon/garage/CiliumNetworkPolicy-allow-garage-apiserver-egress.yaml
+++ b/generated/manifests/prod-axon/garage/CiliumNetworkPolicy-allow-garage-apiserver-egress.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: allow-garage-apiserver-egress
+  namespace: garage
+spec:
+  description: garage-ns pods (Garage + operator) to kube-apiserver.
+  egress:
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "6443"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      k8s:io.kubernetes.pod.namespace: garage

--- a/generated/manifests/prod-axon/garage/CiliumNetworkPolicy-allow-garage-dns-egress.yaml
+++ b/generated/manifests/prod-axon/garage/CiliumNetworkPolicy-allow-garage-dns-egress.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-garage-dns-egress
+  namespace: garage
+spec:
+  description: garage-ns pods resolve via kube-dns.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      k8s:io.kubernetes.pod.namespace: garage

--- a/generated/manifests/prod-axon/garage/CiliumNetworkPolicy-allow-garage-rpc-mesh.yaml
+++ b/generated/manifests/prod-axon/garage/CiliumNetworkPolicy-allow-garage-rpc-mesh.yaml
@@ -1,0 +1,26 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-garage-rpc-mesh
+  namespace: garage
+spec:
+  description: Garage inter-node RPC mesh (3901) within the garage namespace.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: garage
+      toPorts:
+        - ports:
+            - port: "3901"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: garage
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: garage
+      toPorts:
+        - ports:
+            - port: "3901"
+              protocol: TCP

--- a/generated/manifests/prod-axon/garage/CiliumNetworkPolicy-allow-garage-s3-ingress.yaml
+++ b/generated/manifests/prod-axon/garage/CiliumNetworkPolicy-allow-garage-s3-ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-garage-s3-ingress
+  namespace: garage
+spec:
+  description: S3 API (3900) ingress from gateways + consumer namespaces.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: garage
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: gateways
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: burrito
+      toPorts:
+        - ports:
+            - port: "3900"
+              protocol: TCP

--- a/generated/manifests/prod-axon/garage/CiliumNetworkPolicy-allow-garage-ui-admin-egress.yaml
+++ b/generated/manifests/prod-axon/garage/CiliumNetworkPolicy-allow-garage-ui-admin-egress.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-garage-ui-admin-egress
+  namespace: garage
+spec:
+  description: garage-ui to the Garage admin API (3903).
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: garage
+      toPorts:
+        - ports:
+            - port: "3903"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: garage-ui

--- a/generated/manifests/prod-axon/garage/ConfigMap-garage-ui-config.yaml
+++ b/generated/manifests/prod-axon/garage/ConfigMap-garage-ui-config.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    auth:
+      admin:
+        enabled: false
+        existingSecret:
+          key: admin-password
+          name: ""
+        username: admin
+      oidc:
+        admin_role: admin
+        admin_roles: []
+        client_id: garage-ui
+        cookie_http_only: true
+        cookie_name: garage_session
+        cookie_same_site: lax
+        cookie_secure: true
+        email_attribute: email
+        enabled: false
+        existingSecret:
+          key: client-secret
+          name: ""
+        issuer_url: https://keycloak.example.com/realms/master
+        name_attribute: name
+        provider_name: Keycloak
+        role_attribute_path: resource_access.garage-ui.roles
+        scopes:
+        - openid
+        - email
+        - profile
+        session_max_age: 86400
+        skip_expiry_check: false
+        skip_issuer_check: false
+        tls_skip_verify: false
+        username_attribute: preferred_username
+    cors:
+      allow_credentials: false
+      allowed_headers:
+      - Origin
+      - Content-Type
+      - Accept
+      - Authorization
+      allowed_methods:
+      - GET
+      - POST
+      - PUT
+      - DELETE
+      - OPTIONS
+      allowed_origins:
+      - '*'
+      enabled: true
+      max_age: 3600
+    garage:
+      admin_endpoint: http://garage-admin.garage.svc:3903
+      endpoint: http://garage.garage.svc:3900
+      existingSecret:
+        key: admin-token
+        name: garage-admin-token
+      region: garage
+    logging:
+      format: json
+      level: info
+    server:
+      domain: garage.json64.dev
+      environment: production
+      host: '::'
+      max_body_size: 314572800
+      max_header_size: 1048576
+      port: 8080
+      protocol: http
+      read_buffer_size: 4096
+      root_url: https://garage.json64.dev
+      write_buffer_size: 4096
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: garage-ui
+    app.kubernetes.io/name: garage-ui
+  name: garage-ui-config
+  namespace: garage

--- a/generated/manifests/prod-axon/garage/Deployment-garage-ui.yaml
+++ b/generated/manifests/prod-axon/garage/Deployment-garage-ui.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: garage-ui
+    app.kubernetes.io/name: garage-ui
+  name: garage-ui
+  namespace: garage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: garage-ui
+      app.kubernetes.io/name: garage-ui
+  template:
+    metadata:
+      annotations:
+        checksum/config: fc86ae3ba820061482a7c966951a62ea15cf38f8e7114f2b6355fecc45b20577
+      labels:
+        app.kubernetes.io/instance: garage-ui
+        app.kubernetes.io/name: garage-ui
+    spec:
+      containers:
+        - env:
+            - name: GARAGE_UI_GARAGE_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: admin-token
+                  name: garage-admin-token
+            - name: GARAGE_UI_AUTH_JWT_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: jwt-key.pem
+                  name: garage-ui-jwt-key
+          image: noooste/garage-ui:v0.8.4
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+          name: garage-ui
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: false
+          volumeMounts:
+            - mountPath: /app/config.yaml
+              name: config
+              readOnly: true
+              subPath: config.yaml
+      securityContext:
+        fsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      volumes:
+        - configMap:
+            name: garage-ui-config
+          name: config

--- a/generated/manifests/prod-axon/garage/GarageBucket-burrito.yaml
+++ b/generated/manifests/prod-axon/garage/GarageBucket-burrito.yaml
@@ -1,0 +1,8 @@
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: burrito
+  namespace: garage
+spec:
+  clusterRef:
+    name: garage

--- a/generated/manifests/prod-axon/garage/GarageBucket-opentofu-state.yaml
+++ b/generated/manifests/prod-axon/garage/GarageBucket-opentofu-state.yaml
@@ -1,0 +1,8 @@
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageBucket
+metadata:
+  name: opentofu-state
+  namespace: garage
+spec:
+  clusterRef:
+    name: garage

--- a/generated/manifests/prod-axon/garage/GarageCluster-garage.yaml
+++ b/generated/manifests/prod-axon/garage/GarageCluster-garage.yaml
@@ -1,0 +1,42 @@
+apiVersion: garage.rajsingh.info/v1beta2
+kind: GarageCluster
+metadata:
+  name: garage
+  namespace: garage
+spec:
+  admin:
+    adminTokenSecretRef:
+      key: admin-token
+      name: garage-admin-token
+    bindPort: 3903
+  database:
+    engine: lmdb
+  discovery:
+    kubernetes:
+      enabled: true
+  layoutManagement:
+    autoApply: true
+    minNodesHealthy: 2
+  layoutPolicy: Auto
+  network:
+    rpcBindPort: 3901
+    rpcSecretRef:
+      key: rpc-secret
+      name: garage-rpc-secret
+    service:
+      type: ClusterIP
+  replication:
+    factor: 3
+  s3Api:
+    bindPort: 3900
+    region: garage
+    rootDomain: .s3.json64.dev
+  storage:
+    data:
+      size: 50Gi
+      storageClassName: longhorn-single
+    metadata:
+      size: 5Gi
+      storageClassName: longhorn-single
+    replicas: 3
+  zone: axon

--- a/generated/manifests/prod-axon/garage/GarageKey-burrito.yaml
+++ b/generated/manifests/prod-axon/garage/GarageKey-burrito.yaml
@@ -1,0 +1,23 @@
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: burrito
+  namespace: garage
+spec:
+  bucketPermissions:
+    - bucketRef:
+        name: burrito
+      owner: true
+      read: true
+      write: true
+  clusterRef:
+    name: garage
+  secretTemplate:
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: burrito
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: burrito
+    name: burrito-s3
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY

--- a/generated/manifests/prod-axon/garage/GarageKey-opentofu-state.yaml
+++ b/generated/manifests/prod-axon/garage/GarageKey-opentofu-state.yaml
@@ -1,0 +1,23 @@
+apiVersion: garage.rajsingh.info/v1beta1
+kind: GarageKey
+metadata:
+  name: opentofu-state
+  namespace: garage
+spec:
+  bucketPermissions:
+    - bucketRef:
+        name: opentofu-state
+      owner: true
+      read: true
+      write: true
+  clusterRef:
+    name: garage
+  secretTemplate:
+    accessKeyIdKey: AWS_ACCESS_KEY_ID
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: burrito
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: burrito
+    name: opentofu-state-s3
+    secretAccessKeyKey: AWS_SECRET_ACCESS_KEY

--- a/generated/manifests/prod-axon/garage/HTTPRoute-garage-s3-path.yaml
+++ b/generated/manifests/prod-axon/garage/HTTPRoute-garage-s3-path.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: garage-s3-path
+  namespace: garage
+spec:
+  hostnames:
+    - s3.json64.dev
+  parentRefs:
+    - name: default-gateway
+      namespace: gateways
+      sectionName: json64-dev-https
+  rules:
+    - backendRefs:
+        - name: garage
+          port: 3900

--- a/generated/manifests/prod-axon/garage/HTTPRoute-garage-s3-vhost.yaml
+++ b/generated/manifests/prod-axon/garage/HTTPRoute-garage-s3-vhost.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: garage-s3-vhost
+  namespace: garage
+spec:
+  hostnames:
+    - '*.s3.json64.dev'
+  parentRefs:
+    - name: default-gateway
+      namespace: gateways
+      sectionName: s3-json64-dev-https
+  rules:
+    - backendRefs:
+        - name: garage
+          port: 3900

--- a/generated/manifests/prod-axon/garage/HTTPRoute-garage-ui.yaml
+++ b/generated/manifests/prod-axon/garage/HTTPRoute-garage-ui.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: garage-ui
+  namespace: garage
+spec:
+  hostnames:
+    - garage.json64.dev
+  parentRefs:
+    - name: default-gateway
+      namespace: gateways
+      sectionName: json64-dev-https
+  rules:
+    - backendRefs:
+        - name: garage-ui
+          port: 80

--- a/generated/manifests/prod-axon/garage/SecurityPolicy-garage-ui-oidc.yaml
+++ b/generated/manifests/prod-axon/garage/SecurityPolicy-garage-ui-oidc.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: garage-ui-oidc
+  namespace: garage
+spec:
+  oidc:
+    clientID: garage-ui
+    clientSecret:
+      name: garage-ui-oidc-client-secret
+    forwardAccessToken: true
+    provider:
+      issuer: https://idm.json64.dev/oauth2/openid/garage-ui
+    scopes:
+      - email
+      - openid
+      - profile
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: garage-ui

--- a/generated/manifests/prod-axon/garage/Service-garage-admin.yaml
+++ b/generated/manifests/prod-axon/garage/Service-garage-admin.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: garage-admin
+  namespace: garage
+spec:
+  ports:
+    - name: admin
+      port: 3903
+      targetPort: 3903
+  selector:
+    app.kubernetes.io/instance: garage
+    app.kubernetes.io/name: garage
+  type: ClusterIP

--- a/generated/manifests/prod-axon/garage/Service-garage-ui.yaml
+++ b/generated/manifests/prod-axon/garage/Service-garage-ui.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: garage-ui
+    app.kubernetes.io/name: garage-ui
+  name: garage-ui
+  namespace: garage
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+  selector:
+    app.kubernetes.io/instance: garage-ui
+    app.kubernetes.io/name: garage-ui
+  type: ClusterIP

--- a/generated/manifests/prod-axon/garage/Service-garage.yaml
+++ b/generated/manifests/prod-axon/garage/Service-garage.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: garage
+  namespace: garage
+spec:
+  ports:
+    - name: s3
+      port: 3900
+      targetPort: 3900
+  selector:
+    app.kubernetes.io/instance: garage
+    app.kubernetes.io/name: garage
+  type: ClusterIP

--- a/generated/manifests/prod-axon/reflector/ClusterRole-reflector.yaml
+++ b/generated/manifests/prod-axon/reflector/ClusterRole-reflector.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: reflector
+    app.kubernetes.io/name: reflector
+  name: reflector
+  namespace: reflector
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - watch
+      - list

--- a/generated/manifests/prod-axon/reflector/ClusterRoleBinding-reflector.yaml
+++ b/generated/manifests/prod-axon/reflector/ClusterRoleBinding-reflector.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: reflector
+    app.kubernetes.io/name: reflector
+  name: reflector
+  namespace: reflector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: reflector
+subjects:
+  - kind: ServiceAccount
+    name: reflector
+    namespace: reflector

--- a/generated/manifests/prod-axon/reflector/Deployment-reflector.yaml
+++ b/generated/manifests/prod-axon/reflector/Deployment-reflector.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: reflector
+    app.kubernetes.io/name: reflector
+  name: reflector
+  namespace: reflector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: reflector
+      app.kubernetes.io/name: reflector
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: reflector
+        app.kubernetes.io/name: reflector
+    spec:
+      containers:
+        - env:
+            - name: ES_Serilog__MinimumLevel__Default
+              value: Information
+            - name: ES_Reflector__Watcher__Timeout
+              value: ""
+            - name: ES_Reflector__Watcher__ExcludedNamespaces
+              value: ""
+            - name: ES_Ignite__KubernetesClient__SkipTlsVerify
+              value: "false"
+          image: docker.io/emberstack/kubernetes-reflector:10.0.54
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /health/live
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 10
+          name: reflector
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /health/ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 10
+          resources: {}
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          startupProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /health/ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 10
+          volumeMounts: []
+      securityContext:
+        fsGroup: 2000
+      serviceAccountName: reflector

--- a/generated/manifests/prod-axon/reflector/ServiceAccount-reflector.yaml
+++ b/generated/manifests/prod-axon/reflector/ServiceAccount-reflector.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: reflector
+    app.kubernetes.io/name: reflector
+  name: reflector
+  namespace: reflector

--- a/modules/den/aspects/kubernetes/services/network/gateway/envoy-gateway/envoy-gateway.nix
+++ b/modules/den/aspects/kubernetes/services/network/gateway/envoy-gateway/envoy-gateway.nix
@@ -296,11 +296,13 @@
                 ];
                 to =
                   domains
-                  |> mapAttrsToList (domain: args: {
-                    group = "";
-                    kind = "Secret";
-                    name = "${resourceNameFor domain args}-wildcard-tls";
-                  });
+                  |> mapAttrsToList (
+                    domain: args: {
+                      group = "";
+                      kind = "Secret";
+                      name = "${resourceNameFor domain args}-wildcard-tls";
+                    }
+                  );
               };
             };
 

--- a/modules/den/aspects/kubernetes/services/network/gateway/envoy-gateway/envoy-gateway.nix
+++ b/modules/den/aspects/kubernetes/services/network/gateway/envoy-gateway/envoy-gateway.nix
@@ -34,12 +34,21 @@
       let
         inherit (lib)
           flatten
-          map
+          mapAttrsToList
           optionalAttrs
           ;
 
         numReplicas = if cluster.hosts != null then builtins.length cluster.hosts else 3;
         domains = environment.certificates.domains;
+
+        # Resolve a domain's k8s resource-name stem: an explicit per-domain
+        # resourceName (for nested wildcards that would otherwise collide on
+        # their last-two-labels) takes precedence over the default derivation.
+        # Note the explicit `if … != null`: resourceName defaults to null and
+        # the attr always exists, so `or` would never fall back.
+        resourceNameFor =
+          domain: args:
+          if args.resourceName != null then args.resourceName else cluster.resourceForDomain domain;
         default-gateway-address = cluster.getAssignment "default-gateway";
       in
       {
@@ -185,11 +194,10 @@
               };
               listeners =
                 domains
-                |> builtins.attrNames
-                |> map (
-                  domain:
+                |> mapAttrsToList (
+                  domain: args:
                   let
-                    domainResourceName = cluster.resourceForDomain domain;
+                    domainResourceName = resourceNameFor domain args;
                   in
                   [
                     {
@@ -288,11 +296,10 @@
                 ];
                 to =
                   domains
-                  |> builtins.attrNames
-                  |> map (domain: {
+                  |> mapAttrsToList (domain: args: {
                     group = "";
                     kind = "Secret";
-                    name = "${cluster.resourceForDomain domain}-wildcard-tls";
+                    name = "${resourceNameFor domain args}-wildcard-tls";
                   });
               };
             };

--- a/modules/den/aspects/kubernetes/services/security/cert-manager/cert-manager.nix
+++ b/modules/den/aspects/kubernetes/services/security/cert-manager/cert-manager.nix
@@ -63,6 +63,15 @@ in
       }:
       let
         inherit (environment.certificates) domains issuers;
+
+        # Resolve a domain's k8s resource-name stem: an explicit per-domain
+        # resourceName (for nested wildcards that would otherwise collide on
+        # their last-two-labels) takes precedence over the default derivation.
+        # Note the explicit `if … != null`: resourceName defaults to null and
+        # the attr always exists, so `or` would never fall back.
+        resourceNameFor =
+          domain: args:
+          if args.resourceName != null then args.resourceName else cluster.resourceForDomain domain;
       in
       {
         applications.cert-manager = {
@@ -134,14 +143,14 @@ in
               domains
               |> mapAttrs' (
                 domain: args: {
-                  name = (cluster.resourceForDomain domain) + "-wildcard-certificate";
+                  name = (resourceNameFor domain args) + "-wildcard-certificate";
                   value = {
                     metadata = {
                       namespace = "certs";
                       annotations."cert-manager.io/issue-temporary-certificate" = "true";
                     };
                     spec = {
-                      secretName = "${cluster.resourceForDomain domain}-wildcard-tls";
+                      secretName = "${resourceNameFor domain args}-wildcard-tls";
                       issuerRef = {
                         name = "${args.issuer}-issuer";
                         kind = "ClusterIssuer";

--- a/modules/den/aspects/kubernetes/services/security/reflector/reflector.nix
+++ b/modules/den/aspects/kubernetes/services/security/reflector/reflector.nix
@@ -1,0 +1,20 @@
+# Emberstack reflector — cross-namespace Secret/ConfigMap replication.
+#
+# Required by the garage stack: GarageKey-minted S3 credential Secrets carry
+# reflector annotations (storage/garage/buckets.nix) that replicate them into
+# consumer namespaces (e.g. burrito). Deploy ahead of any GarageKey.
+{
+  den.aspects.kubernetes.services.security.reflector = {
+    k8s-manifests =
+      { charts, ... }:
+      {
+        applications.reflector = {
+          namespace = "reflector";
+
+          helm.releases.reflector = {
+            chart = charts.emberstack.reflector;
+          };
+        };
+      };
+  };
+}

--- a/modules/den/aspects/kubernetes/services/storage/garage/buckets.nix
+++ b/modules/den/aspects/kubernetes/services/storage/garage/buckets.nix
@@ -1,0 +1,71 @@
+# Garage buckets + keys for the terranix foundation (opentofu state backend +
+# Burrito datastore). Co-located in the garage namespace; the operator mints the
+# access keys into k8s Secrets, reflector (security/reflector) replicates them to
+# the burrito consumer namespace. Future services copy this pattern. Operator-
+# minted keys are NOT agenix — the only delivery is reflector.
+#
+# Field paths follow the storage versions of the CRDs (both v1beta1 — the only
+# `storage: true` versions after T4 stripped the conversion webhooks). GarageKey
+# v1alpha1 is served=false and GarageBucket v1alpha1 is storage=false, so v1beta1
+# is authoritative for both. The nixidy typed accessors (`resources.garageBuckets`
+# / `resources.garageKeys`, from the T4 crds bridge) derive the apiVersion from
+# the registered CRD, so these write only the spec.
+{
+  den.aspects.kubernetes.services.storage.garage.buckets = {
+    k8s-manifests =
+      { ... }:
+      let
+        # emberstack reflector: allow + auto-replicate the minted Secret into the
+        # named consumer namespace.
+        reflectTo = ns: {
+          "reflector.v1.k8s.emberstack.com/reflection-allowed" = "true";
+          "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces" = ns;
+          "reflector.v1.k8s.emberstack.com/reflection-auto-enabled" = "true";
+          "reflector.v1.k8s.emberstack.com/reflection-auto-namespaces" = ns;
+        };
+      in
+      {
+        applications.garage.resources = {
+          # --- opentofu state backend ---
+          garageBuckets.opentofu-state.spec.clusterRef.name = "garage";
+          garageKeys.opentofu-state.spec = {
+            clusterRef.name = "garage";
+            bucketPermissions = [
+              {
+                bucketRef.name = "opentofu-state";
+                read = true;
+                write = true;
+                owner = true;
+              }
+            ];
+            secretTemplate = {
+              name = "opentofu-state-s3";
+              accessKeyIdKey = "AWS_ACCESS_KEY_ID";
+              secretAccessKeyKey = "AWS_SECRET_ACCESS_KEY";
+              annotations = reflectTo "burrito";
+            };
+          };
+
+          # --- Burrito datastore (SP2.3 wires the consumer) ---
+          garageBuckets.burrito.spec.clusterRef.name = "garage";
+          garageKeys.burrito.spec = {
+            clusterRef.name = "garage";
+            bucketPermissions = [
+              {
+                bucketRef.name = "burrito";
+                read = true;
+                write = true;
+                owner = true;
+              }
+            ];
+            secretTemplate = {
+              name = "burrito-s3";
+              accessKeyIdKey = "AWS_ACCESS_KEY_ID";
+              secretAccessKeyKey = "AWS_SECRET_ACCESS_KEY";
+              annotations = reflectTo "burrito";
+            };
+          };
+        };
+      };
+  };
+}

--- a/modules/den/aspects/kubernetes/services/storage/garage/garage-cluster.nix
+++ b/modules/den/aspects/kubernetes/services/storage/garage/garage-cluster.nix
@@ -1,0 +1,108 @@
+# GarageCluster — 3-node, RF=3, auto-layout, k8s peer discovery, ClusterIP.
+# The operator (garage-operator.nix) reconciles this single CR into the storage
+# StatefulSet, Services, garage.toml, and PodDisruptionBudget.
+#
+# Field paths follow the storage version of the GarageCluster CRD (v1beta2 — the
+# only `storage: true` version after T4 stripped the conversion webhooks). The
+# nixidy typed accessor (`resources.garageClusters`, from the T4 crds bridge)
+# derives the apiVersion from the registered CRD, so this file writes only the
+# spec.
+{
+  den.aspects.kubernetes.services.storage.garage.garage-cluster = {
+    k8s-manifests =
+      { cluster, ... }:
+      let
+        inherit (cluster.settings.kubernetes.services.storage.garage.garage) storageBackend;
+        # spec §5.3: Garage RF=3 owns redundancy, so never the 2-replica default
+        # class (would be 6 copies under RF3).
+        #   longhorn   -> data+meta longhorn-single
+        #   hybrid     -> data longhorn-single, meta local-path
+        #   local-path -> data+meta local-path
+        dataClass = if storageBackend == "local-path" then "local-path" else "longhorn-single";
+        metaClass = if storageBackend == "longhorn" then "longhorn-single" else "local-path";
+      in
+      {
+        # Anchor the shared app namespace here (every garage aspect merges into
+        # applications.garage — secrets.nix adds resources.secrets; this file adds
+        # the cluster CR + Services. Identical-string namespace is conflict-free).
+        applications.garage.namespace = "garage";
+        applications.garage.resources = {
+          garageClusters.garage.spec = {
+            zone = "axon";
+            storage = {
+              replicas = 3;
+              data = {
+                size = "50Gi";
+                storageClassName = dataClass;
+              };
+              metadata = {
+                size = "5Gi";
+                storageClassName = metaClass;
+              };
+            };
+            database.engine = "lmdb"; # CRD enum: lmdb (default) | sqlite | fjall.
+            replication.factor = 3;
+            discovery.kubernetes.enabled = true;
+            layoutManagement = {
+              autoApply = true;
+              minNodesHealthy = 2;
+            };
+            layoutPolicy = "Auto";
+            network = {
+              rpcBindPort = 3901;
+              service.type = "ClusterIP";
+              # rpc-secret / admin-token from secrets.nix (T3): 32-byte hex.
+              rpcSecretRef = {
+                name = "garage-rpc-secret";
+                key = "rpc-secret";
+              };
+            };
+            admin = {
+              bindPort = 3903;
+              adminTokenSecretRef = {
+                name = "garage-admin-token";
+                key = "admin-token";
+              };
+            };
+            s3Api = {
+              bindPort = 3900;
+              region = "garage";
+              # Leading dot enables vhost-style (bucket.<rootDomain>) Host matching.
+              rootDomain = ".s3.json64.dev";
+            };
+          };
+
+          # Stable ClusterIP Services that consumers / routes / the UI reference by
+          # name (http://garage.garage.svc:3900, garage-admin.garage.svc:3903).
+          services.garage.spec = {
+            type = "ClusterIP";
+            selector = {
+              "app.kubernetes.io/name" = "garage";
+              "app.kubernetes.io/instance" = "garage";
+            };
+            ports = [
+              {
+                name = "s3";
+                port = 3900;
+                targetPort = 3900;
+              }
+            ];
+          };
+          services.garage-admin.spec = {
+            type = "ClusterIP";
+            selector = {
+              "app.kubernetes.io/name" = "garage";
+              "app.kubernetes.io/instance" = "garage";
+            };
+            ports = [
+              {
+                name = "admin";
+                port = 3903;
+                targetPort = 3903;
+              }
+            ];
+          };
+        };
+      };
+  };
+}

--- a/modules/den/aspects/kubernetes/services/storage/garage/garage-operator.nix
+++ b/modules/den/aspects/kubernetes/services/storage/garage/garage-operator.nix
@@ -1,0 +1,74 @@
+# Garage operator (rajsinghtech) — owns the GarageCluster StatefulSet/Services/
+# garage.toml/PDB reconciliation and the six Garage* CRDs (GarageCluster,
+# GarageNode, GarageBucket, GarageKey, GarageAdminToken, GarageReferenceGrant).
+#
+# CRDs are registered through the crds bridge (early sync-wave -1), and the
+# controller chart's own CRD install is disabled so the bridge is the sole CRD
+# owner — the cnpg precedent (cloudnative-pg.nix). The local chart is built in
+# pkgs/charts (charts.rajsinghtech.garage-operator); the crds quirk has no
+# `charts` arg, so it reaches the chart via inputs.self.chartsDerivations.
+#
+# Webhooks (admission + multi-version conversion) are DISABLED on both the CRD
+# extraction and the release. The chart's conversion webhooks rewire each CRD's
+# conversion.clientConfig at `$.Release.Namespace` and stamp a
+# `cert-manager.io/inject-ca-from` annotation — but the crds bridge runs
+# `helm template` with no `--namespace` (Release.Namespace = "default") and the
+# bridge spec can't thread the real `garage` namespace, so an enabled extraction
+# would bake a conversion config pointing at the wrong namespace + a cert-manager
+# Certificate that lives elsewhere. Disabling webhooks makes the chart drop the
+# conversion stanza and mark non-storage CRD versions served=false, yielding
+# clean, namespace-independent CRDs with the storage version served. Keeping the
+# release's webhooks off too avoids an orphaned webhook Service / cert-manager
+# Certificate whose CA wouldn't line up with the conversion-stripped CRDs.
+# (See render-time verify note: re-enabling conversion webhooks for HA across
+# multiple Garage* API versions needs the bridge to template at the `garage`
+# namespace — out of scope here.)
+{
+  den.aspects.kubernetes.services.storage.garage.garage-operator = {
+    # CRD scope has no `charts` arg — reach the local chart via inputs/system
+    # like longhorn/cnpg. No kindFilter: register all six Garage* CRDs. The
+    # chart emits them from templates/crds.yaml (gated on crds.install, default
+    # true) reading crd-bases/*.yaml, so `helm template` extracts them with no
+    # extraOpts — the bridge filters the rendered output to the CRD objects.
+    crds =
+      { inputs, system, ... }:
+      {
+        name = "garage-operator";
+        chart = inputs.self.chartsDerivations.${system}.rajsinghtech.garage-operator;
+        # Conversion webhooks off (see header): self-contained CRDs, no
+        # cert-manager / namespace coupling baked into the definitions.
+        values.webhooks.enabled = false;
+      };
+
+    k8s-manifests =
+      { charts, ... }:
+      {
+        applications.garage-operator = {
+          namespace = "garage";
+
+          # Operator + CRDs before any Garage* CR (the GarageCluster lives in the
+          # `garage` app at the default wave 0).
+          annotations."argocd.argoproj.io/sync-wave" = "-1";
+
+          helm.releases.garage-operator = {
+            chart = charts.rajsinghtech.garage-operator;
+            values = {
+              # CRDs are deployed via the bootstrap app (crds bridge), not the
+              # operator chart, to keep them out of the helm release lifecycle.
+              crds.install = false;
+
+              # Single active reconciler. Leader election stays on (chart default)
+              # so rolling updates hand off cleanly; >1 replica would only add
+              # standbys, so 1 avoids needless duplicate pods racing the layout/
+              # key admin APIs on lease churn.
+              replicaCount = 1;
+
+              # Webhooks off — consistent with the conversion-stripped CRDs above;
+              # avoids a hard cert-manager dependency for the operator itself.
+              webhooks.enabled = false;
+            };
+          };
+        };
+      };
+  };
+}

--- a/modules/den/aspects/kubernetes/services/storage/garage/garage-ui.nix
+++ b/modules/den/aspects/kubernetes/services/storage/garage/garage-ui.nix
@@ -1,0 +1,159 @@
+# Garage web UI (noooste/garage-ui) — the operator/bucket/key admin console.
+# The chart's own auth (config.auth.oidc / config.auth.admin) is left DISABLED
+# (values defaults): the UI serves unauthenticated and the Envoy Gateway kanidm
+# OIDC SecurityPolicy below is the sole security boundary (spec §5.7). The UI
+# drives the Garage admin API (3903) with the shared admin token (T3/T5).
+#
+# Chart surface pinned against garage-ui v0.8.4 (Step 3):
+#   - admin endpoint  -> config.garage.admin_endpoint (NOT the plan's apiAdminUrl)
+#   - admin token     -> env GARAGE_UI_GARAGE_ADMIN_TOKEN from
+#                        config.garage.existingSecret.{name,key} (default key
+#                        "admin-token"), satisfied by the garage-admin-token
+#                        Secret (T3, key admin-token)
+#   - Service         -> name "garage-ui" (release/fullname), port 80
+#   - pod label       -> app.kubernetes.io/name = garage-ui (matches the T7 CNP
+#                        selector — no reconciliation needed)
+{
+  den.aspects.kubernetes.services.storage.garage.garage-ui = {
+    service-domains = [ "garage-ui" ];
+
+    age-secrets =
+      { environment, ... }:
+      {
+        # Shares its rekeyFile + generator with the kanidm garage-ui client's
+        # basicSecretFile, so both sides resolve to the same value (the longhorn
+        # idiom). The host-side age secret is auto-derived by kanidm.nix for every
+        # non-public client; this declares the cluster (sops) half.
+        age.secrets.garage-ui-oidc-client-secret = {
+          rekeyFile = environment.secretPath + "/oidc/garage-ui-oidc-client-secret.age";
+          generator = {
+            tags = [ "oidc" ];
+            script = "rfc3986-secret";
+          };
+          sopsOutput = {
+            file = "oidc";
+            key = "garage-ui";
+          };
+        };
+      };
+
+    k8s-manifests =
+      {
+        config,
+        cluster,
+        charts,
+        ...
+      }:
+      let
+        uiHost = cluster.domainFor "garage-ui";
+      in
+      {
+        # Merges into the shared garage application (namespace anchored in
+        # garage-cluster.nix). This aspect is the first to add a helm release to it.
+        applications.garage = {
+          helm.releases.garage-ui = {
+            chart = charts.noooste.garage-ui;
+            values = {
+              config = {
+                server = {
+                  # Informational external URL (the chart only requires it for its
+                  # own OIDC, which we leave off; set correctly for hygiene).
+                  root_url = "https://${uiHost}";
+                  domain = uiHost;
+                };
+                garage = {
+                  endpoint = "http://garage.garage.svc:3900";
+                  region = "garage";
+                  admin_endpoint = "http://garage-admin.garage.svc:3903";
+                  # Admin bearer token from the agenix->sops garage-admin-token
+                  # Secret (T3); chart injects it as GARAGE_UI_GARAGE_ADMIN_TOKEN.
+                  existingSecret = {
+                    name = "garage-admin-token";
+                    key = "admin-token";
+                  };
+                };
+              };
+            };
+          };
+
+          resources = {
+            # garage.json64.dev rides the existing *.json64.dev wildcard listener
+            # (domainForResource "garage-ui" = json64-dev), so it attaches to the
+            # existing json64-dev-https listener — no new cert.
+            httpRoutes.garage-ui.spec = {
+              hostnames = [ uiHost ];
+              parentRefs = [
+                {
+                  name = "default-gateway";
+                  namespace = "gateways";
+                  sectionName = "${cluster.domainForResource "garage-ui"}-https";
+                }
+              ];
+              rules = [
+                {
+                  backendRefs = [
+                    {
+                      name = "garage-ui";
+                      port = 80;
+                    }
+                  ];
+                }
+              ];
+            };
+
+            securityPolicies."garage-ui-oidc".spec = {
+              targetRefs = [
+                {
+                  group = "gateway.networking.k8s.io";
+                  kind = "HTTPRoute";
+                  name = "garage-ui";
+                }
+              ];
+
+              oidc = {
+                provider.issuer = cluster.secrets.oidcIssuerFor "garage-ui";
+                clientID = "garage-ui";
+                clientSecret.name = "garage-ui-oidc-client-secret";
+                scopes = [
+                  "email"
+                  "openid"
+                  "profile"
+                ];
+                forwardAccessToken = true;
+              };
+            };
+
+            secrets.garage-ui-oidc-client-secret = {
+              type = "Opaque";
+              stringData.client-secret = config.age.secrets.garage-ui-oidc-client-secret.sopsRef;
+            };
+
+            # garage-ui drives the Garage admin API only (3903). Once any egress
+            # policy selects these pods they default-deny egress; DNS is covered by
+            # the namespace-wide kube-dns egress policy in network-policy.nix (T7).
+            ciliumNetworkPolicies.allow-garage-ui-admin-egress.spec = {
+              description = "garage-ui to the Garage admin API (3903).";
+              endpointSelector.matchLabels."app.kubernetes.io/name" = "garage-ui";
+              egress = [
+                {
+                  toEndpoints = [
+                    { matchLabels."app.kubernetes.io/name" = "garage"; }
+                  ];
+                  toPorts = [
+                    {
+                      ports = [
+                        {
+                          port = "3903";
+                          protocol = "TCP";
+                        }
+                      ];
+                    }
+                  ];
+                }
+              ];
+            };
+          };
+        };
+      };
+  };
+}

--- a/modules/den/aspects/kubernetes/services/storage/garage/network-policy.nix
+++ b/modules/den/aspects/kubernetes/services/storage/garage/network-policy.nix
@@ -14,13 +14,31 @@
             ingress = [
               {
                 fromEndpoints = [ { matchLabels."app.kubernetes.io/name" = "garage"; } ];
-                toPorts = [ { ports = [ { port = "3901"; protocol = "TCP"; } ]; } ];
+                toPorts = [
+                  {
+                    ports = [
+                      {
+                        port = "3901";
+                        protocol = "TCP";
+                      }
+                    ];
+                  }
+                ];
               }
             ];
             egress = [
               {
                 toEndpoints = [ { matchLabels."app.kubernetes.io/name" = "garage"; } ];
-                toPorts = [ { ports = [ { port = "3901"; protocol = "TCP"; } ]; } ];
+                toPorts = [
+                  {
+                    ports = [
+                      {
+                        port = "3901";
+                        protocol = "TCP";
+                      }
+                    ];
+                  }
+                ];
               }
             ];
           };
@@ -36,7 +54,16 @@
                   { matchLabels."k8s:io.kubernetes.pod.namespace" = "gateways"; }
                   { matchLabels."k8s:io.kubernetes.pod.namespace" = "burrito"; }
                 ];
-                toPorts = [ { ports = [ { port = "3900"; protocol = "TCP"; } ]; } ];
+                toPorts = [
+                  {
+                    ports = [
+                      {
+                        port = "3900";
+                        protocol = "TCP";
+                      }
+                    ];
+                  }
+                ];
               }
             ];
           };
@@ -48,7 +75,16 @@
             ingress = [
               {
                 fromEndpoints = [ { matchLabels."app.kubernetes.io/name" = "garage-ui"; } ];
-                toPorts = [ { ports = [ { port = "3903"; protocol = "TCP"; } ]; } ];
+                toPorts = [
+                  {
+                    ports = [
+                      {
+                        port = "3903";
+                        protocol = "TCP";
+                      }
+                    ];
+                  }
+                ];
               }
             ];
           };

--- a/modules/den/aspects/kubernetes/services/storage/garage/network-policy.nix
+++ b/modules/den/aspects/kubernetes/services/storage/garage/network-policy.nix
@@ -1,0 +1,119 @@
+# CiliumNetworkPolicies for the garage namespace. Default-deny once any policy
+# selects a pod, so every legitimate flow is enumerated. NO world egress —
+# Garage needs none.
+{
+  den.aspects.kubernetes.services.storage.garage.network-policy = {
+    k8s-manifests =
+      { ... }:
+      {
+        applications.garage.resources.ciliumNetworkPolicies = {
+          # RPC mesh: Garage pods talk to each other on 3901 (ingress + egress).
+          allow-garage-rpc-mesh.spec = {
+            description = "Garage inter-node RPC mesh (3901) within the garage namespace.";
+            endpointSelector.matchLabels."app.kubernetes.io/name" = "garage";
+            ingress = [
+              {
+                fromEndpoints = [ { matchLabels."app.kubernetes.io/name" = "garage"; } ];
+                toPorts = [ { ports = [ { port = "3901"; protocol = "TCP"; } ]; } ];
+              }
+            ];
+            egress = [
+              {
+                toEndpoints = [ { matchLabels."app.kubernetes.io/name" = "garage"; } ];
+                toPorts = [ { ports = [ { port = "3901"; protocol = "TCP"; } ]; } ];
+              }
+            ];
+          };
+
+          # S3 ingress on 3900 from the gateways namespace (public route backend)
+          # and in-cluster consumer namespaces (burrito).
+          allow-garage-s3-ingress.spec = {
+            description = "S3 API (3900) ingress from gateways + consumer namespaces.";
+            endpointSelector.matchLabels."app.kubernetes.io/name" = "garage";
+            ingress = [
+              {
+                fromEndpoints = [
+                  { matchLabels."k8s:io.kubernetes.pod.namespace" = "gateways"; }
+                  { matchLabels."k8s:io.kubernetes.pod.namespace" = "burrito"; }
+                ];
+                toPorts = [ { ports = [ { port = "3900"; protocol = "TCP"; } ]; } ];
+              }
+            ];
+          };
+
+          # Admin API (3903) ingress from garage-ui ONLY (same namespace).
+          allow-garage-admin-ingress.spec = {
+            description = "Admin API (3903) ingress from garage-ui only.";
+            endpointSelector.matchLabels."app.kubernetes.io/name" = "garage";
+            ingress = [
+              {
+                fromEndpoints = [ { matchLabels."app.kubernetes.io/name" = "garage-ui"; } ];
+                toPorts = [ { ports = [ { port = "3903"; protocol = "TCP"; } ]; } ];
+              }
+            ];
+          };
+
+          # kube-apiserver egress: Garage k8s peer discovery + operator CR
+          # reconciliation (toEntities, NOT world — the coder-pg precedent).
+          allow-garage-apiserver-egress = {
+            metadata.annotations."argocd.argoproj.io/sync-wave" = "-1";
+            spec = {
+              description = "garage-ns pods (Garage + operator) to kube-apiserver.";
+              endpointSelector.matchLabels."k8s:io.kubernetes.pod.namespace" = "garage";
+              egress = [
+                {
+                  toEntities = [ "kube-apiserver" ];
+                  toPorts = [
+                    {
+                      ports = [
+                        {
+                          port = "443";
+                          protocol = "TCP";
+                        }
+                        {
+                          port = "6443";
+                          protocol = "TCP";
+                        }
+                      ];
+                    }
+                  ];
+                }
+              ];
+            };
+          };
+
+          # DNS egress for service-name resolution.
+          allow-garage-dns-egress.spec = {
+            description = "garage-ns pods resolve via kube-dns.";
+            endpointSelector.matchLabels."k8s:io.kubernetes.pod.namespace" = "garage";
+            egress = [
+              {
+                toEndpoints = [
+                  {
+                    matchLabels = {
+                      "k8s:io.kubernetes.pod.namespace" = "kube-system";
+                      "k8s-app" = "kube-dns";
+                    };
+                  }
+                ];
+                toPorts = [
+                  {
+                    ports = [
+                      {
+                        port = "53";
+                        protocol = "UDP";
+                      }
+                      {
+                        port = "53";
+                        protocol = "TCP";
+                      }
+                    ];
+                  }
+                ];
+              }
+            ];
+          };
+        };
+      };
+  };
+}

--- a/modules/den/aspects/kubernetes/services/storage/garage/routes.nix
+++ b/modules/den/aspects/kubernetes/services/storage/garage/routes.nix
@@ -1,0 +1,63 @@
+# Public S3 exposure. Path-style on the shared *.json64.dev listener; vhost-style
+# on the dedicated s3-json64-dev listener (T1 + the prod.nix resourceName entry).
+# No OIDC SecurityPolicy — SigV4 key-auth is the gate.
+#
+# DNS (manual, doc-only): s3.json64.dev and *.s3.json64.dev must be created in
+# Cloudflare as DNS-only (grey-cloud) records — proxied mode's 100 MB upload cap
+# breaks S3 multipart. SP2.4's Cloudflare stack adopts these records later.
+{
+  den.aspects.kubernetes.services.storage.garage.routes = {
+    k8s-manifests =
+      { cluster, ... }:
+      {
+        applications.garage.resources.httpRoutes = {
+          # Path-style: s3.json64.dev rides the existing *.json64.dev wildcard
+          # listener (domainForResource "garage-s3" = json64-dev).
+          garage-s3-path.spec = {
+            hostnames = [ (cluster.domainFor "garage-s3") ];
+            parentRefs = [
+              {
+                name = "default-gateway";
+                namespace = "gateways";
+                sectionName = "${cluster.domainForResource "garage-s3"}-https";
+              }
+            ];
+            rules = [
+              {
+                backendRefs = [
+                  {
+                    name = "garage";
+                    port = 3900;
+                  }
+                ];
+              }
+            ];
+          };
+
+          # Vhost-style: *.s3.json64.dev on the dedicated s3-json64-dev listener
+          # (needs T1 + the prod.nix resourceName entry). s3Api.rootDomain =
+          # ".s3.json64.dev" makes Garage match the bucket from the Host header.
+          garage-s3-vhost.spec = {
+            hostnames = [ "*.${cluster.domainFor "garage-s3"}" ];
+            parentRefs = [
+              {
+                name = "default-gateway";
+                namespace = "gateways";
+                sectionName = "s3-json64-dev-https";
+              }
+            ];
+            rules = [
+              {
+                backendRefs = [
+                  {
+                    name = "garage";
+                    port = 3900;
+                  }
+                ];
+              }
+            ];
+          };
+        };
+      };
+  };
+}

--- a/modules/den/aspects/kubernetes/services/storage/garage/secrets.nix
+++ b/modules/den/aspects/kubernetes/services/storage/garage/secrets.nix
@@ -1,0 +1,49 @@
+# Garage rpc_secret + admin_token — agenix-rekey hex generators rekeyed into the
+# cluster sops store, consumed by GarageCluster.network.rpcSecretRef /
+# admin.adminTokenSecretRef (garage-cluster.nix) and garage-ui (garage-ui.nix).
+# Operator-minted S3 access keys do NOT come through here — they are GarageKey
+# secretTemplates (buckets.nix).
+{
+  den.aspects.kubernetes.services.storage.garage.secrets = {
+    age-secrets =
+      { cluster, config, ... }:
+      {
+        age.secrets = {
+          garage-rpc-secret = {
+            rekeyFile = cluster.secretPath + "/garage/rpc-secret.age";
+            # 32 bytes -> 64 hex chars: Garage rpc_secret requires exactly 32 bytes.
+            generator.script = "hex";
+            settings.length = 32;
+            sopsOutput = {
+              file = "garage";
+              key = "rpc-secret";
+            };
+          };
+          garage-admin-token = {
+            rekeyFile = cluster.secretPath + "/garage/admin-token.age";
+            generator.script = "hex";
+            settings.length = 32;
+            sopsOutput = {
+              file = "garage";
+              key = "admin-token";
+            };
+          };
+        };
+      };
+
+    k8s-manifests =
+      { config, ... }:
+      {
+        applications.garage.resources.secrets = {
+          garage-rpc-secret = {
+            type = "Opaque";
+            stringData.rpc-secret = config.age.secrets.garage-rpc-secret.sopsRef;
+          };
+          garage-admin-token = {
+            type = "Opaque";
+            stringData.admin-token = config.age.secrets.garage-admin-token.sopsRef;
+          };
+        };
+      };
+  };
+}

--- a/modules/den/aspects/kubernetes/services/storage/garage/settings.nix
+++ b/modules/den/aspects/kubernetes/services/storage/garage/settings.nix
@@ -1,0 +1,26 @@
+# Settings for the garage aspect group. Surfaced onto the cluster as
+# `cluster.settings.kubernetes.services.storage.garage.garage.*`; set per
+# cluster via
+# `den.clusters.<name>.settings.kubernetes.services.storage.garage.garage.<key>`.
+{ lib, ... }:
+{
+  den.aspects.kubernetes.services.storage.garage.garage.settings.storageBackend = lib.mkOption {
+    type = lib.types.enum [
+      "longhorn"
+      "hybrid"
+      "local-path"
+    ];
+    default = "longhorn";
+    description = ''
+      Garage backing storage. Garage RF=3 owns cross-node redundancy, so the
+      volume must NOT double-replicate (the default `longhorn` StorageClass is
+      2-replica = 6 copies under RF3 — deliberately avoided).
+        longhorn   = data+meta on longhorn-single (1 Longhorn replica; off-cluster
+                     NFS backup; survives reset-axon).
+        hybrid     = data on longhorn-single (backed up); LMDB meta on node-local
+                     local-path (peer-protected, not in the backup set).
+        local-path = both node-local; Garage RF=3 the only redundancy; NO volume
+                     backup (DR needs a backup cluster).
+    '';
+  };
+}

--- a/modules/den/aspects/services/security/kanidm.nix
+++ b/modules/den/aspects/services/security/kanidm.nix
@@ -271,6 +271,18 @@ let
         ];
       };
 
+      garage-ui = {
+        displayName = "Garage UI";
+        originUrl = [ "https://${domain "garage-ui"}/oauth2/callback" ];
+        originLanding = "https://${domain "garage-ui"}/";
+        basicSecretFile = secretPaths.garage-ui-oidc-client-secret;
+        scopeMaps."admins" = [
+          "openid"
+          "email"
+          "profile"
+        ];
+      };
+
       oauth2-proxy = {
         displayName = "OAuth2-Proxy";
         originUrl = "https://${domain "oauth2-proxy"}/oauth2/callback";

--- a/modules/den/clusters/axon.nix
+++ b/modules/den/clusters/axon.nix
@@ -136,6 +136,16 @@
       # dev — Coder workspace platform (SP1 control plane)
       services.dev.coder.coder-pg
       services.dev.coder.coder
+
+      # storage — Garage S3 (operator-managed, 3-node; public S3 + OIDC UI)
+      services.security.reflector
+      services.storage.garage.secrets
+      services.storage.garage.garage-operator
+      services.storage.garage.garage-cluster
+      services.storage.garage.buckets
+      services.storage.garage.network-policy
+      services.storage.garage.routes
+      services.storage.garage.garage-ui
     ];
   };
 }

--- a/modules/den/environments/prod.nix
+++ b/modules/den/environments/prod.nix
@@ -11,6 +11,13 @@
         "json64.dev" = {
           issuer = "json64-dev";
         };
+        "s3.json64.dev" = {
+          issuer = "json64-dev";
+          # Distinct stem: without it resourceForDomain "s3.json64.dev" = json64-dev,
+          # colliding with the json64.dev wildcard. Enables the *.s3.json64.dev
+          # listener + s3-json64-dev-wildcard-tls cert (T1 resourceName extension).
+          resourceName = "s3-json64-dev";
+        };
         "json64.com" = {
           issuer = "global";
         };
@@ -46,6 +53,8 @@
       longhorn.domain = "longhorn.zeroday.run";
       attic.domain = "attic.json64.dev";
       forgejo.domain = "git.json64.dev";
+      garage-s3.domain = "s3.json64.dev";
+      garage-ui.domain = "garage.json64.dev";
       grafana.domain = "grafana.json64.dev";
       headscale.domain = "hs.json64.dev";
       homepage.domain = "homepage.json64.dev";

--- a/modules/den/schema/environment.nix
+++ b/modules/den/schema/environment.nix
@@ -99,6 +99,18 @@ let
                 type = types.str;
                 description = "The issuer name to use for this domain";
               };
+
+              resourceName = mkOption {
+                type = types.nullOr types.str;
+                default = null;
+                description = ''
+                  Explicit k8s resource-name stem for this domain's wildcard certificate +
+                  gateway listener, overriding the default last-two-labels derivation
+                  (resourceNameOf in schema/cluster.nix). REQUIRED for a nested wildcard
+                  (e.g. *.s3.json64.dev) whose last-two-labels (json64-dev) would collide
+                  with its parent registrable domain. null = derive from the domain (back-compat).
+                '';
+              };
             };
           }
         );


### PR DESCRIPTION
## Summary

Adds **Garage** (S3-compatible object storage) to the cluster as the reusable object-store foundation, managed declaratively via the rajsinghtech garage-operator:

- **Operator-managed cluster** — a `GarageCluster` CR drives a 3-node, replication-factor-3 deployment with automatic layout management; the operator's CRDs are owned by the bootstrap CRD bridge (chart CRD-install disabled), with conversion webhooks off so the definitions are namespace-independent.
- **Declarative buckets/keys** — each bucket and access key is a `GarageBucket`/`GarageKey` CR; the operator mints credentials into Secrets, which emberstack **reflector** (new shared aspect) replicates to consumer namespaces. The first two buckets (object-store state backend + the runner datastore) land this way; future services copy the pattern.
- **Public + internal access** — internal consumers use the in-cluster ClusterIP endpoint; a public, key-authenticated S3 endpoint (path- and vhost-style) is exposed via Envoy Gateway + cert-manager, and an OIDC-gated admin UI sits behind a kanidm SecurityPolicy.
- **Storage policy as config** — a per-cluster `storageBackend` enum (`longhorn`/`hybrid`/`local-path`, default single-replica Longhorn) selects the backing class without double-replicating under Garage's own redundancy.
- **Shared infra** — a small, additive `certificates.domains.<domain>.resourceName` extension lets a nested wildcard get its own cert + gateway listener (existing domains render byte-identical); rpc/admin secrets via agenix→sops; default-deny CiliumNetworkPolicies (no world egress).

Renders purely additively — no churn on existing manifests.

## Test plan

- [x] `nix build .#nixidyEnvs.x86_64-linux.axon.environmentPackage` succeeds
- [x] Full render is additive; all CRDs register in bootstrap; operator at sync-wave `-1` (CRDs/operator before CRs)
- [x] Committed manifests match a fresh `nixidy-sync` render (no drift)
- [x] `treefmt` clean
- [ ] **Deploy-time:** materialize the rpc/admin/OIDC secrets (`agenix generate`/`rekey` with the hardware identity)
- [ ] **Deploy-time:** create the public S3 DNS records as DNS-only (grey-cloud) before apply
- [ ] **Deploy-time:** ArgoCD apply; confirm layout converges, pods healthy, minted creds reflect to the consumer namespace

> Note: two unrelated `nix flake check` items (a temporary flake input pin and a stale secrets manifest) are pre-existing on `main` and untouched by this branch.