### PR TITLE
fix(registry): stream large image-layer uploads

### DIFF
--- a/modules/den/aspects/services/web/container-registry.nix
+++ b/modules/den/aspects/services/web/container-registry.nix
@@ -44,6 +44,15 @@
             basicAuthFile = config.age.secrets.registry-htpasswd.path;
             extraConfig = ''
               client_max_body_size 0;
+              # Stream large image-layer uploads straight to the registry instead
+              # of buffering the request body to a temp file (nginx's default,
+              # capped at proxy_max_temp_file_size) — multi-hundred-MB layers
+              # otherwise 502. Raise the proxy timeouts so slow large pushes have
+              # room. (DNS for this host bypasses the Cloudflare proxy so CF's
+              # upload cap doesn't also clip pushes.)
+              proxy_request_buffering off;
+              proxy_read_timeout 900s;
+              proxy_send_timeout 900s;
             '';
           };
         };


### PR DESCRIPTION
Disable nginx proxy request buffering + raise proxy timeouts on the container-registry vhost so large image layers stream to the registry instead of buffering to a temp file (which 502s on multi-hundred-MB layers).