### PR TITLE
feat(media): tdarr kube-native AV1 transcoding

### DIFF
--- a/generated/manifests/prod-axon/apps/Application-tdarr-node.yaml
+++ b/generated/manifests/prod-axon/apps/Application-tdarr-node.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tdarr-node
+  namespace: argocd
+spec:
+  destination:
+    namespace: media
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/tdarr-node
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/apps/Application-tdarr.yaml
+++ b/generated/manifests/prod-axon/apps/Application-tdarr.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tdarr
+  namespace: argocd
+spec:
+  destination:
+    namespace: media
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./generated/manifests/prod-axon/tdarr
+    repoURL: https://github.com/sini/nix-config.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/generated/manifests/prod-axon/grafana/ConfigMap-dashboard-media-tdarr.yaml
+++ b/generated/manifests/prod-axon/grafana/ConfigMap-dashboard-media-tdarr.yaml
@@ -1,0 +1,7253 @@
+apiVersion: v1
+data:
+  media-tdarr.json: |
+    {
+      "__inputs": [
+        {
+          "name": "DS_PROMETHEUS",
+          "label": "Prometheus",
+          "description": "",
+          "type": "datasource",
+          "pluginId": "prometheus",
+          "pluginName": "Prometheus"
+        }
+      ],
+      "__elements": {},
+      "__requires": [
+        {
+          "type": "panel",
+          "id": "bargauge",
+          "name": "Bar gauge",
+          "version": ""
+        },
+        {
+          "type": "grafana",
+          "id": "grafana",
+          "name": "Grafana",
+          "version": "12.0.1"
+        },
+        {
+          "type": "panel",
+          "id": "piechart",
+          "name": "Pie chart",
+          "version": ""
+        },
+        {
+          "type": "datasource",
+          "id": "prometheus",
+          "name": "Prometheus",
+          "version": "1.0.0"
+        },
+        {
+          "type": "panel",
+          "id": "stat",
+          "name": "Stat",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "table",
+          "name": "Table",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "timeseries",
+          "name": "Time series",
+          "version": ""
+        }
+      ],
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 103,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Tdarr server self-reported health from /api/v2/status: 1 = good (Healthy), 0 = problem. Raw status string is on tdarr_server_status_info.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "0": {
+                          "index": 0,
+                          "text": "Problem"
+                        },
+                        "1": {
+                          "index": 1,
+                          "text": "Healthy"
+                        }
+                      },
+                      "type": "value"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red"
+                      },
+                      {
+                        "color": "green",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 6,
+                "x": 0,
+                "y": 1
+              },
+              "id": 64,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_server_healthy{tdarr_instance=~\"$tdarr_instance\"}",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "A"
+                }
+              ],
+              "title": "Server Status",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Tdarr server process uptime from /api/v2/status (Node.js process.uptime, seconds).",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 6,
+                "x": 6,
+                "y": 1
+              },
+              "id": 63,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_server_uptime_seconds{tdarr_instance=~\"$tdarr_instance\"}",
+                  "instant": false,
+                  "legendFormat": "uptime",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Server Uptime",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Tdarr server version reported by /api/v2/status.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 6,
+                "x": 12,
+                "y": 1
+              },
+              "id": 61,
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "name",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_server_info{tdarr_instance=~\"$tdarr_instance\"}",
+                  "instant": true,
+                  "legendFormat": "{{version}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Tdarr Version",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Tdarr server operating system reported by /api/v2/status.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 6,
+                "x": 18,
+                "y": 1
+              },
+              "id": 62,
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "name",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_server_info{tdarr_instance=~\"$tdarr_instance\"}",
+                  "instant": true,
+                  "legendFormat": "{{os}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Tdarr OS",
+              "type": "stat"
+            }
+          ],
+          "title": "Tdarr Server",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "id": 104,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Filters by Prometheus job, not tdarr_instance — multi-deployment users may see all jobs.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "0": {
+                          "color": "red",
+                          "index": 1,
+                          "text": "DOWN"
+                        },
+                        "1": {
+                          "color": "green",
+                          "index": 0,
+                          "text": "UP"
+                        }
+                      },
+                      "type": "value"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red"
+                      },
+                      {
+                        "color": "green",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 6,
+                "x": 0,
+                "y": 2
+              },
+              "id": 2,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "up{job=~\".*tdarr.*\"}",
+                  "instant": true,
+                  "legendFormat": "{{job}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Exporter Up",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Custom gauge — 1 if the last collection cycle succeeded, 0 if any failure occurred (Tdarr API error, response parse error, or partial pie-stats fetch). Check exporter logs for root cause when 0.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "0": {
+                          "color": "red",
+                          "index": 1,
+                          "text": "FAIL"
+                        },
+                        "1": {
+                          "color": "green",
+                          "index": 0,
+                          "text": "OK"
+                        }
+                      },
+                      "type": "value"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red"
+                      },
+                      {
+                        "color": "green",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 6,
+                "x": 6,
+                "y": 2
+              },
+              "id": 3,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_up{tdarr_instance=~\"$tdarr_instance\"}",
+                  "instant": true,
+                  "legendFormat": "{{tdarr_instance}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Tdarr Collector Success",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 5
+                      },
+                      {
+                        "color": "red",
+                        "value": 15
+                      }
+                    ]
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 6,
+                "x": 12,
+                "y": 2
+              },
+              "id": 4,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_scrape_duration_seconds{tdarr_instance=~\"$tdarr_instance\"}",
+                  "instant": false,
+                  "legendFormat": "scrape duration",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Scrape Duration",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Rate of /metrics endpoint requests returning non-2xx (handler errors, misroutes, panics). Distinct from Tdarr API failures.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "from": 0,
+                        "result": {
+                          "color": "green",
+                          "index": 0,
+                          "text": "None"
+                        },
+                        "to": 0
+                      },
+                      "type": "range"
+                    },
+                    {
+                      "options": {
+                        "from": 0.001,
+                        "result": {
+                          "color": "yellow",
+                          "index": 1
+                        },
+                        "to": 1000000
+                      },
+                      "type": "range"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 6,
+                "x": 18,
+                "y": 2
+              },
+              "id": 5,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum(rate(promhttp_metric_handler_requests_total{tdarr_instance=~\"$tdarr_instance\",code!~\"2..\"}[5m]))",
+                  "instant": true,
+                  "legendFormat": "handler errors",
+                  "refId": "A"
+                }
+              ],
+              "title": "Handler Errors (5m)",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 2,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "reqps"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 6,
+                "x": 0,
+                "y": 272
+              },
+              "id": 101,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (code)(rate(promhttp_metric_handler_requests_total{tdarr_instance=~\"$tdarr_instance\"}[$__rate_interval]))",
+                  "instant": false,
+                  "legendFormat": "{{code}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "HTTP Request Rate",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 2,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "reqps"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 6,
+                "x": 6,
+                "y": 272
+              },
+              "id": 102,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (cause)(rate(promhttp_metric_handler_errors_total{tdarr_instance=~\"$tdarr_instance\"}[$__rate_interval]))",
+                  "instant": false,
+                  "legendFormat": "{{cause}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Handler Error Rate",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Exporter build version from tdarr_exporter_build_info (set at build time via ldflags).",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 6,
+                "x": 12,
+                "y": 272
+              },
+              "id": 65,
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "name",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_exporter_build_info",
+                  "instant": true,
+                  "legendFormat": "{{version}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Exporter Version",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 6,
+                "x": 18,
+                "y": 272
+              },
+              "id": 100,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "promhttp_metric_handler_requests_in_flight{tdarr_instance=~\"$tdarr_instance\"}",
+                  "instant": true,
+                  "legendFormat": "{{tdarr_instance}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Requests In-Flight",
+              "type": "stat"
+            }
+          ],
+          "title": "Exporter / Scrape Health",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 2
+          },
+          "id": 59,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Percent of all media files successfully transcoded (successful ÷ total files).",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 0,
+                "y": 3
+              },
+              "id": 11,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_score_ratio{tdarr_instance=~\"$tdarr_instance\"}",
+                  "instant": true,
+                  "legendFormat": "tdarr score",
+                  "refId": "A"
+                }
+              ],
+              "title": "Tdarr Score (%)",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Files currently in an error state (point-in-time, from the per-status breakdown) — not a lifetime total.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 3,
+                "y": 3
+              },
+              "id": 42,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum(tdarr_library_transcodes{tdarr_instance=~\"$tdarr_instance\", status=\"error\"}) by (tdarr_instance)",
+                  "instant": true,
+                  "legendFormat": "transcode errors",
+                  "refId": "A"
+                }
+              ],
+              "title": "Transcode Errors",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 2,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 9,
+                "x": 6,
+                "y": 3
+              },
+              "id": 37,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (status) (tdarr_library_transcodes{tdarr_instance=~\"$tdarr_instance\"})",
+                  "instant": false,
+                  "legendFormat": "{{status}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Transcode Status Over Time",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 2,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 9,
+                "x": 15,
+                "y": 3
+              },
+              "id": 38,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (status) (tdarr_library_health_checks{tdarr_instance=~\"$tdarr_instance\"})",
+                  "instant": false,
+                  "legendFormat": "{{status}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Health Check Status Over Time",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Percent of all media files successfully health-checked (successful ÷ total files).",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 0,
+                "y": 7
+              },
+              "id": 12,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_health_check_score_ratio{tdarr_instance=~\"$tdarr_instance\"}",
+                  "instant": true,
+                  "legendFormat": "health check score",
+                  "refId": "A"
+                }
+              ],
+              "title": "Health Check Score (%)",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Files currently in an error state (point-in-time, from the per-status breakdown) — not a lifetime total.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 3,
+                "y": 7
+              },
+              "id": 43,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum(tdarr_library_health_checks{tdarr_instance=~\"$tdarr_instance\", status=\"error\"}) by (tdarr_instance)",
+                  "instant": true,
+                  "legendFormat": "health check errors",
+                  "refId": "A"
+                }
+              ],
+              "title": "Health Check Errors",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Current number of files in the library.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 6,
+                "x": 0,
+                "y": 11
+              },
+              "id": 47,
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sort_desc(sum by (library_name) (tdarr_library_files{tdarr_instance=~\"$tdarr_instance\"} * on (library_id, tdarr_instance) group_left(library_name) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\"}))",
+                  "instant": true,
+                  "legendFormat": "{{library_name}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Files by Library",
+              "type": "bargauge"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Cumulative completed transcodes over the library's lifetime. A file is counted again each time a transcode alters it (e.g. after a flow/process change), so this can exceed the file count. Failed jobs excluded. Per-status breakdown: tdarr_library_transcodes.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 6,
+                "x": 6,
+                "y": 11
+              },
+              "id": 48,
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sort_desc(sum by (library_name) (tdarr_library_transcodes_completed_total{tdarr_instance=~\"$tdarr_instance\"} * on (library_id, tdarr_instance) group_left(library_name) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\"}))",
+                  "instant": true,
+                  "legendFormat": "{{library_name}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Transcodes by Library",
+              "type": "bargauge"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Cumulative completed health checks over the library's lifetime. A file can be checked more than once, so this can exceed the file count. Failed jobs excluded. Per-status breakdown: tdarr_library_health_checks.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 6,
+                "x": 12,
+                "y": 11
+              },
+              "id": 49,
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sort_desc(sum by (library_name) (tdarr_library_health_checks_completed_total{tdarr_instance=~\"$tdarr_instance\"} * on (library_id, tdarr_instance) group_left(library_name) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\"}))",
+                  "instant": true,
+                  "legendFormat": "{{library_name}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Health Checks by Library",
+              "type": "bargauge"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Lifetime net space saved per library. Positive = saved, negative = grew. Includes size differences from any deleted or replaced files. Live server total: see 'Size Difference (Server Total)'.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 6,
+                "x": 18,
+                "y": 11
+              },
+              "id": 116,
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sort_desc(sum by (library_name) (tdarr_library_size_diff_bytes{tdarr_instance=~\"$tdarr_instance\"} * on (library_id, tdarr_instance) group_left(library_name) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\"}))",
+                  "instant": true,
+                  "legendFormat": "{{library_name}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Size Diff by Library",
+              "type": "bargauge"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Current net space saved across files on disk now. Positive = saved, negative = grew. Live - excludes deleted files, so lower than the sum of per-library values.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 4,
+                "x": 0,
+                "y": 19
+              },
+              "id": 117,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_size_diff_bytes{tdarr_instance=~\"$tdarr_instance\"}",
+                  "instant": true,
+                  "legendFormat": "server total",
+                  "refId": "A"
+                }
+              ],
+              "title": "Size Difference (Server Total)",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 4,
+                "y": 19
+              },
+              "id": 45,
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (stat_type) (tdarr_stream_stats_bit_rate{tdarr_instance=~\"$tdarr_instance\"})",
+                  "instant": true,
+                  "legendFormat": "{{stat_type}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Stream Bit Rates",
+              "type": "bargauge"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 10,
+                "y": 19
+              },
+              "id": 46,
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (stat_type) (tdarr_stream_stats_duration_seconds{tdarr_instance=~\"$tdarr_instance\"})",
+                  "instant": true,
+                  "legendFormat": "{{stat_type}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Stream Durations",
+              "type": "bargauge"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 6,
+                "x": 16,
+                "y": 19
+              },
+              "id": 50,
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (stat_type) (tdarr_stream_stats_num_frames{tdarr_instance=~\"$tdarr_instance\"})",
+                  "instant": true,
+                  "legendFormat": "{{stat_type}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Stream Stats Num Frames",
+              "type": "bargauge"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 2,
+                "x": 22,
+                "y": 19
+              },
+              "id": 44,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_avg_num_streams{tdarr_instance=~\"$tdarr_instance\"}",
+                  "instant": true,
+                  "legendFormat": "avg streams",
+                  "refId": "A"
+                }
+              ],
+              "title": "Average Num Streams",
+              "type": "stat"
+            }
+          ],
+          "title": "Overview",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 3
+          },
+          "id": 6,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Current number of files in the library.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 4,
+                "x": 0,
+                "y": 4
+              },
+              "id": 7,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum(tdarr_library_files{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+                  "instant": true,
+                  "legendFormat": "files",
+                  "refId": "A"
+                }
+              ],
+              "title": "Total Files",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Cumulative completed transcodes over the library's lifetime. A file is counted again each time a transcode alters it (e.g. after a flow/process change), so this can exceed the file count. Failed jobs excluded. Per-status breakdown: tdarr_library_transcodes.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 4,
+                "x": 4,
+                "y": 4
+              },
+              "id": 8,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum(tdarr_library_transcodes_completed_total{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+                  "instant": true,
+                  "legendFormat": "transcodes",
+                  "refId": "A"
+                }
+              ],
+              "title": "Total Transcodes",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Cumulative completed health checks over the library's lifetime. A file can be checked more than once, so this can exceed the file count. Failed jobs excluded. Per-status breakdown: tdarr_library_health_checks.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 4,
+                "x": 8,
+                "y": 4
+              },
+              "id": 9,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum(tdarr_library_health_checks_completed_total{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+                  "instant": true,
+                  "legendFormat": "health checks",
+                  "refId": "A"
+                }
+              ],
+              "title": "Total Health Checks",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Files currently in an error state (point-in-time, from the per-status breakdown) — not a lifetime total.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 4,
+                "x": 12,
+                "y": 4
+              },
+              "id": 118,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum(tdarr_library_transcodes{tdarr_instance=~\"$tdarr_instance\", status=\"error\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"}) by (tdarr_instance)",
+                  "instant": true,
+                  "legendFormat": "transcode errors",
+                  "refId": "A"
+                }
+              ],
+              "title": "Transcode Errors",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Files currently in an error state (point-in-time, from the per-status breakdown) — not a lifetime total.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 4,
+                "x": 16,
+                "y": 4
+              },
+              "id": 119,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum(tdarr_library_health_checks{tdarr_instance=~\"$tdarr_instance\", status=\"error\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"}) by (tdarr_instance)",
+                  "instant": true,
+                  "legendFormat": "health check errors",
+                  "refId": "A"
+                }
+              ],
+              "title": "Health Check Errors",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Lifetime net space saved for the selected library(ies). Positive = saved, negative = grew. Includes size differences from any deleted or replaced files. Server live-current total: see 'Size Difference (Server Total)'.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 4,
+                "x": 20,
+                "y": 4
+              },
+              "id": 10,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum(tdarr_library_size_diff_bytes{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+                  "instant": true,
+                  "legendFormat": "size diff",
+                  "refId": "A"
+                }
+              ],
+              "title": "Size Difference",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  },
+                  "mappings": []
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 8
+              },
+              "id": 13,
+              "options": {
+                "displayLabels": [
+                  "name",
+                  "percent"
+                ],
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true,
+                  "values": [
+                    "value"
+                  ]
+                },
+                "pieType": "pie",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (status) (tdarr_library_transcodes{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+                  "instant": true,
+                  "legendFormat": "{{status}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Transcodes by Status",
+              "type": "piechart"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  },
+                  "mappings": []
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 8
+              },
+              "id": 14,
+              "options": {
+                "displayLabels": [
+                  "name",
+                  "percent"
+                ],
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true,
+                  "values": [
+                    "value"
+                  ]
+                },
+                "pieType": "pie",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (status) (tdarr_library_health_checks{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+                  "instant": true,
+                  "legendFormat": "{{status}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Health Checks by Status",
+              "type": "piechart"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  },
+                  "mappings": []
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 8
+              },
+              "id": 15,
+              "options": {
+                "displayLabels": [
+                  "name",
+                  "percent"
+                ],
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true,
+                  "values": [
+                    "value"
+                  ]
+                },
+                "pieType": "pie",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (codec) (tdarr_library_video_codecs{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+                  "instant": true,
+                  "legendFormat": "{{codec}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Video Codecs",
+              "type": "piechart"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 6,
+                "x": 0,
+                "y": 16
+              },
+              "id": 19,
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (resolution) (tdarr_library_video_resolutions{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+                  "instant": true,
+                  "legendFormat": "{{resolution}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Video Resolutions",
+              "type": "bargauge"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 6,
+                "x": 6,
+                "y": 16
+              },
+              "id": 17,
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (container_type) (tdarr_library_video_containers{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+                  "instant": true,
+                  "legendFormat": "{{container_type}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Video Containers",
+              "type": "bargauge"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 6,
+                "x": 12,
+                "y": 16
+              },
+              "id": 16,
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (codec) (tdarr_library_audio_codecs{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+                  "instant": true,
+                  "legendFormat": "{{codec}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Audio Codecs",
+              "type": "bargauge"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 6,
+                "x": 18,
+                "y": 16
+              },
+              "id": 18,
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (container_type) (tdarr_library_audio_containers{tdarr_instance=~\"$tdarr_instance\"} and on (library_id, tdarr_instance) tdarr_library_info{tdarr_instance=~\"$tdarr_instance\", library_name=~\"$library\"})",
+                  "instant": true,
+                  "legendFormat": "{{container_type}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Audio Containers",
+              "type": "bargauge"
+            }
+          ],
+          "title": "Library Overview:  ${library} ",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 4
+          },
+          "id": 28,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "inspect": false
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Progress %"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red"
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 0.25
+                            },
+                            {
+                              "color": "green",
+                              "value": 0.75
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "color-background"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "FPS"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red"
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 100
+                            },
+                            {
+                              "color": "green",
+                              "value": 1000
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "ETA"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Orig Size"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Est Size"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Out Size"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Job Start"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "dateTimeFromNow"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Last Status Update"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "dateTimeFromNow"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "node_id"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hidden",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "flow_worker"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hidden",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "worker_connected"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hidden",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "tdarr_instance"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hidden",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Idle"
+                    },
+                    "properties": [
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "0": {
+                                "index": 0,
+                                "text": "false"
+                              },
+                              "1": {
+                                "index": 1,
+                                "text": "true"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Step Start"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "dateTimeFromNow"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 578
+              },
+              "id": 29,
+              "options": {
+                "cellHeight": "sm",
+                "footer": {
+                  "countRows": false,
+                  "fields": "",
+                  "reducer": [
+                    "sum"
+                  ],
+                  "show": false
+                },
+                "showHeader": true,
+                "sortBy": []
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", flow_worker=\"true\", node_name=~\"$node_name\"}",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_ratio{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"true\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "B"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_fps{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"true\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "C"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_eta_seconds{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"true\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "D"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_original_file_size_bytes{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"true\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "E"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_est_file_size_bytes{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"true\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "F"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_output_file_size_bytes{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"true\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "G"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_job_start_timestamp_seconds{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"true\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "H"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_status_timestamp_seconds{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"true\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "I"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id, worker_status) (tdarr_node_worker_status{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"true\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "J"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_idle{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"true\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "L"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_step_start_timestamp_seconds{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"true\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "M"
+                }
+              ],
+              "title": "Flow Workers",
+              "transformations": [
+                {
+                  "id": "joinByField",
+                  "options": {
+                    "byField": "worker_id",
+                    "mode": "outer"
+                  }
+                },
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "include": {
+                      "names": [
+                        "worker_id",
+                        "node_name",
+                        "worker_type",
+                        "compute_type",
+                        "worker_status",
+                        "worker_file",
+                        "worker_connected",
+                        "flow_worker",
+                        "Value #B",
+                        "Value #C",
+                        "Value #D",
+                        "Value #E",
+                        "Value #F",
+                        "Value #G",
+                        "Value #H",
+                        "Value #I",
+                        "Value #L",
+                        "Value #M"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {},
+                    "indexByName": {
+                      "Value #B": 3,
+                      "Value #C": 4,
+                      "Value #D": 5,
+                      "Value #E": 7,
+                      "Value #F": 8,
+                      "Value #G": 9,
+                      "Value #H": 13,
+                      "Value #I": 11,
+                      "Value #L": 18,
+                      "Value #M": 12,
+                      "compute_type": 15,
+                      "flow_worker": 17,
+                      "node_name": 0,
+                      "worker_connected": 19,
+                      "worker_file": 10,
+                      "worker_id": 1,
+                      "worker_status": 6,
+                      "worker_type": 14
+                    },
+                    "renameByName": {
+                      "Value #B": "Progress %",
+                      "Value #C": "FPS",
+                      "Value #D": "ETA",
+                      "Value #E": "Orig Size",
+                      "Value #F": "Est Size",
+                      "Value #G": "Out Size",
+                      "Value #H": "Job Start",
+                      "Value #I": "Last Status Update",
+                      "Value #L": "Idle",
+                      "Value #M": "Step Start"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "inspect": false
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Progress %"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red"
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 0.25
+                            },
+                            {
+                              "color": "green",
+                              "value": 0.75
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "color-background"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "FPS"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red"
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 100
+                            },
+                            {
+                              "color": "green",
+                              "value": 1000
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "ETA"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Orig Size"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Est Size"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Out Size"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Job Start"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "dateTimeFromNow"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Last Status Update"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "dateTimeFromNow"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "node_id"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hidden",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "flow_worker"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hidden",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "worker_connected"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hidden",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "tdarr_instance"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hidden",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Idle"
+                    },
+                    "properties": [
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "0": {
+                                "index": 0,
+                                "text": "false"
+                              },
+                              "1": {
+                                "index": 1,
+                                "text": "true"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 586
+              },
+              "id": 31,
+              "options": {
+                "cellHeight": "sm",
+                "footer": {
+                  "countRows": false,
+                  "fields": "",
+                  "reducer": [
+                    "sum"
+                  ],
+                  "show": false
+                },
+                "showHeader": true,
+                "sortBy": []
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", flow_worker=\"false\", worker_type=\"healthcheck\", node_name=~\"$node_name\"}",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_ratio{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"healthcheck\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "B"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_fps{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"healthcheck\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "C"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_eta_seconds{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"healthcheck\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "D"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_original_file_size_bytes{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"healthcheck\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "E"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_est_file_size_bytes{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"healthcheck\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "F"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_output_file_size_bytes{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"healthcheck\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "G"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_job_start_timestamp_seconds{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"healthcheck\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "H"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_status_timestamp_seconds{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"healthcheck\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "I"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id, worker_status) (tdarr_node_worker_status{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"healthcheck\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "J"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_idle{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"healthcheck\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "L"
+                }
+              ],
+              "title": "Health Check Workers",
+              "transformations": [
+                {
+                  "id": "joinByField",
+                  "options": {
+                    "byField": "worker_id",
+                    "mode": "outer"
+                  }
+                },
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "include": {
+                      "names": [
+                        "node_name",
+                        "worker_id",
+                        "Value #B",
+                        "Value #C",
+                        "Value #D",
+                        "worker_status",
+                        "worker_file",
+                        "Value #E",
+                        "Value #I",
+                        "Value #H",
+                        "worker_type",
+                        "compute_type",
+                        "worker_connected",
+                        "Value #L"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {},
+                    "indexByName": {
+                      "Value #B": 3,
+                      "Value #C": 4,
+                      "Value #D": 5,
+                      "Value #E": 8,
+                      "Value #H": 10,
+                      "Value #I": 9,
+                      "Value #L": 13,
+                      "compute_type": 12,
+                      "node_name": 0,
+                      "worker_connected": 14,
+                      "worker_file": 7,
+                      "worker_id": 1,
+                      "worker_status": 6,
+                      "worker_type": 11
+                    },
+                    "renameByName": {
+                      "Value #B": "Progress %",
+                      "Value #C": "FPS",
+                      "Value #D": "ETA",
+                      "Value #E": "Orig Size",
+                      "Value #F": "Est Size",
+                      "Value #G": "Out Size",
+                      "Value #H": "Job Start",
+                      "Value #I": "Last Status Update",
+                      "Value #L": "Idle"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "inspect": false
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Progress %"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red"
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 0.25
+                            },
+                            {
+                              "color": "green",
+                              "value": 0.75
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "color-background"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "FPS"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red"
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 100
+                            },
+                            {
+                              "color": "green",
+                              "value": 1000
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "ETA"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Orig Size"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Est Size"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Out Size"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Job Start"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "dateTimeFromNow"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Last Status Update"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "dateTimeFromNow"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "node_id"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hidden",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "flow_worker"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hidden",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "worker_connected"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hidden",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "tdarr_instance"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hidden",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Idle"
+                    },
+                    "properties": [
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "0": {
+                                "index": 0,
+                                "text": "false"
+                              },
+                              "1": {
+                                "index": 1,
+                                "text": "true"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Step Start"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "dateTimeFromNow"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 594
+              },
+              "id": 30,
+              "options": {
+                "cellHeight": "sm",
+                "footer": {
+                  "countRows": false,
+                  "fields": "",
+                  "reducer": [
+                    "sum"
+                  ],
+                  "show": false
+                },
+                "showHeader": true,
+                "sortBy": []
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", flow_worker=\"false\", worker_type=\"transcode\", node_name=~\"$node_name\"}",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_ratio{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"transcode\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "B"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_fps{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"transcode\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "C"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_eta_seconds{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"transcode\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "D"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_original_file_size_bytes{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"transcode\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "E"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_est_file_size_bytes{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"transcode\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "F"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_output_file_size_bytes{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"transcode\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "G"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_job_start_timestamp_seconds{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"transcode\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "H"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_status_timestamp_seconds{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"transcode\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "I"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id, worker_status) (tdarr_node_worker_status{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"transcode\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "J"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id, worker_plugin_id, worker_plugin_position) (tdarr_node_worker_plugin{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"transcode\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "K"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_idle{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"transcode\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "L"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (worker_id) (tdarr_node_worker_step_start_timestamp_seconds{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"} and on (worker_id) tdarr_node_worker_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\", flow_worker=\"false\", worker_type=\"transcode\"})",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "M"
+                }
+              ],
+              "title": "Classic Plugin Workers",
+              "transformations": [
+                {
+                  "id": "joinByField",
+                  "options": {
+                    "byField": "worker_id",
+                    "mode": "outer"
+                  }
+                },
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "include": {
+                      "names": [
+                        "worker_id",
+                        "node_name",
+                        "worker_type",
+                        "compute_type",
+                        "worker_status",
+                        "worker_file",
+                        "worker_plugin_id",
+                        "worker_plugin_position",
+                        "worker_connected",
+                        "flow_worker",
+                        "Value #B",
+                        "Value #C",
+                        "Value #D",
+                        "Value #E",
+                        "Value #F",
+                        "Value #G",
+                        "Value #H",
+                        "Value #I",
+                        "Value #L",
+                        "Value #M"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {},
+                    "indexByName": {
+                      "Value #B": 3,
+                      "Value #C": 4,
+                      "Value #D": 5,
+                      "Value #E": 9,
+                      "Value #F": 10,
+                      "Value #G": 11,
+                      "Value #H": 15,
+                      "Value #I": 13,
+                      "Value #L": 19,
+                      "Value #M": 14,
+                      "compute_type": 17,
+                      "flow_worker": 18,
+                      "node_name": 0,
+                      "worker_connected": 20,
+                      "worker_file": 12,
+                      "worker_id": 1,
+                      "worker_plugin_id": 7,
+                      "worker_plugin_position": 8,
+                      "worker_status": 6,
+                      "worker_type": 16
+                    },
+                    "renameByName": {
+                      "Value #B": "Progress %",
+                      "Value #C": "FPS",
+                      "Value #D": "ETA",
+                      "Value #E": "Orig Size",
+                      "Value #F": "Est Size",
+                      "Value #G": "Out Size",
+                      "Value #H": "Job Start",
+                      "Value #I": "Last Status Update",
+                      "Value #L": "Idle",
+                      "Value #M": "Step Start"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            }
+          ],
+          "title": "Workers",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 5
+          },
+          "id": 32,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 2,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 195
+              },
+              "id": 33,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (node_name, worker_type, compute_type) (tdarr_node_worker_count{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"})",
+                  "instant": false,
+                  "legendFormat": "{{node_name}} / {{worker_type}}-{{compute_type}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Active Workers by Node and Type",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 2,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 195
+              },
+              "id": 34,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum by (node_name, worker_type, compute_type) (tdarr_node_queue_length{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"})",
+                  "instant": false,
+                  "legendFormat": "{{node_name}} / {{worker_type}}-{{compute_type}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Queue Depth by Node and Type",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "description": "Sum of all active worker FPS. Variance reflects content mix (4K HDR vs 720p), but trend over time indicates fleet encoding throughput.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 2,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 195
+              },
+              "id": 35,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "sum(tdarr_node_worker_fps{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"})",
+                  "instant": false,
+                  "legendFormat": "total fps",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Fleet Throughput (FPS)",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "description": "Per-worker progress percentage over time. Useful for spotting stuck workers.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 2,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 223
+              },
+              "id": 56,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_node_worker_ratio{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"}",
+                  "instant": false,
+                  "legendFormat": "{{node_name}} / {{worker_id}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Worker Progress (%)",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "description": "Per-worker frames-per-second over time. Complements fleet throughput by surfacing individual worker performance degradation.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 2,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 223
+              },
+              "id": 57,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_node_worker_fps{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"}",
+                  "instant": false,
+                  "legendFormat": "{{node_name}} / {{worker_id}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Worker FPS",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "description": "Per-worker estimated time remaining over time. Useful for tracking long-running encodes.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 2,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 223
+              },
+              "id": 58,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_node_worker_eta_seconds{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"}",
+                  "instant": false,
+                  "legendFormat": "{{node_name}} / {{worker_id}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Worker ETA (seconds)",
+              "type": "timeseries"
+            }
+          ],
+          "title": "Fleet Activity",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 6
+          },
+          "id": 20,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "description": "Whether the Tdarr node is paused. Paused = the node stops spawning new transcode/health-check workers (in-progress jobs may still finish). NO = ready or actively processing.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "0": {
+                          "color": "green",
+                          "index": 0,
+                          "text": "NO"
+                        },
+                        "1": {
+                          "color": "orange",
+                          "index": 1,
+                          "text": "PAUSED"
+                        }
+                      },
+                      "type": "value"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 5,
+                "x": 0,
+                "y": 196
+              },
+              "id": 21,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_node_paused{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"}",
+                  "instant": true,
+                  "legendFormat": "{{node_name}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Node Paused",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "0": {
+                          "color": "yellow",
+                          "index": 0,
+                          "text": "OFF"
+                        },
+                        "1": {
+                          "color": "green",
+                          "index": 1,
+                          "text": "ON"
+                        }
+                      },
+                      "type": "value"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "yellow"
+                      },
+                      {
+                        "color": "green",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 4,
+                "x": 5,
+                "y": 196
+              },
+              "id": 22,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_node_schedule_enabled{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"}",
+                  "instant": true,
+                  "legendFormat": "{{node_name}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Schedule Enabled",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "description": "Time since this node's worker process last started.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue"
+                      }
+                    ]
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 5,
+                "x": 9,
+                "y": 196
+              },
+              "id": 115,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_node_uptime_seconds{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"}",
+                  "instant": true,
+                  "legendFormat": "{{node_name}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Node Uptime",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "description": "GPU device this node targets for transcodes, from the node's GPU config. Auto = Tdarr picks the GPU; any other value is the specific GPU the node is pinned to.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "displayName": "${__field.labels.gpu_select}",
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 5,
+                "x": 14,
+                "y": 196
+              },
+              "id": 113,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "name",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "label_replace(tdarr_node_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"}, \"gpu_select\", \"Auto\", \"gpu_select\", \"-\")",
+                  "instant": true,
+                  "legendFormat": "{{gpu_select}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "GPU Select",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "displayName": "ID: ${__field.labels.node_id} | PID: ${__field.labels.node_pid}",
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 5,
+                "x": 19,
+                "y": 196
+              },
+              "id": 25,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "name",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_node_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"}",
+                  "instant": true,
+                  "legendFormat": " ID: {{node_id}} | PID: {{node_pid}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Node ID / PID",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "description": "Node scheduling priority from the node's config (the node_priority label on tdarr_node_info). Lower number = higher priority.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "displayName": "${__field.labels.node_priority}",
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 5,
+                "x": 0,
+                "y": 200
+              },
+              "id": 114,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "name",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_node_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"}",
+                  "instant": true,
+                  "legendFormat": "{{node_priority}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Node Priority",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "displayName": "${__field.labels.gpu_can_do_cpu}",
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 5,
+                "x": 5,
+                "y": 200
+              },
+              "id": 24,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "name",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_node_info{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"}",
+                  "instant": true,
+                  "legendFormat": "{{gpu_can_do_cpu}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "GPU Does CPU",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue"
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 5,
+                "x": 10,
+                "y": 200
+              },
+              "id": 23,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_node_max_gpu_workers{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"}",
+                  "instant": true,
+                  "legendFormat": "{{node_name}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Max GPU Workers",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "description": "If Node is GPU worker that has \"CPU Tasks\" enabled, \"CPU/GPU\" tasks will be the same",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "from": 0,
+                        "result": {
+                          "color": "green",
+                          "index": 0
+                        },
+                        "to": 0
+                      },
+                      "type": "range"
+                    },
+                    {
+                      "options": {
+                        "from": 1,
+                        "result": {
+                          "color": "yellow",
+                          "index": 1
+                        },
+                        "to": 1000000
+                      },
+                      "type": "range"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 9,
+                "x": 15,
+                "y": 200
+              },
+              "id": 27,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_node_queue_length{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"}",
+                  "instant": false,
+                  "legendFormat": "{{worker_type}}-{{compute_type}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Queue Depth by Type",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "mappings": [],
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 0,
+                "y": 204
+              },
+              "id": 26,
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_node_worker_count{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"}",
+                  "instant": true,
+                  "legendFormat": "Active: {{worker_type}}-{{compute_type}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Worker Utilization",
+              "type": "bargauge"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "mappings": [],
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 204
+              },
+              "id": 60,
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_node_worker_limit{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"}",
+                  "instant": true,
+                  "legendFormat": "Limit: {{worker_type}}-{{compute_type}}",
+                  "refId": "B"
+                }
+              ],
+              "title": "Worker Limits",
+              "type": "bargauge"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 2,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 0.7
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.9
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 210
+              },
+              "id": 51,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_node_host_cpu_ratio{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"}",
+                  "instant": false,
+                  "legendFormat": "{{node_name}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Host CPU %",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 2,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 210
+              },
+              "id": 52,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_node_host_mem_used_bytes{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"}",
+                  "instant": false,
+                  "legendFormat": "used",
+                  "range": true,
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_node_host_mem_total_bytes{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"}",
+                  "instant": false,
+                  "legendFormat": "total",
+                  "range": true,
+                  "refId": "B"
+                }
+              ],
+              "title": "Host Memory",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 1,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 210
+              },
+              "id": 53,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_node_heap_used_bytes{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"}",
+                  "instant": false,
+                  "legendFormat": "used",
+                  "range": true,
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_node_heap_total_bytes{tdarr_instance=~\"$tdarr_instance\", node_name=~\"$node_name\"}",
+                  "instant": false,
+                  "legendFormat": "total",
+                  "range": true,
+                  "refId": "B"
+                }
+              ],
+              "title": "Tdarr Heap",
+              "type": "timeseries"
+            }
+          ],
+          "repeat": "node_name",
+          "title": "Node: $node_name",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 216
+          },
+          "id": 54,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "description": "Counter bumps when Tdarr returns a status string not in the exporter's known enum. Non-zero values indicate Tdarr added/renamed a status — file an issue at homeylab/tdarr-exporter to update the enum. Status is still emitted under a normalized label; this is a maintainer signal, not an operator alert.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "inspect": false
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Time"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hidden",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "tdarr_instance"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hidden",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "job"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hidden",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "instance"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hidden",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "__name__"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hidden",
+                        "value": true
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 1118
+              },
+              "id": 55,
+              "options": {
+                "cellHeight": "sm",
+                "footer": {
+                  "countRows": false,
+                  "fields": "",
+                  "reducer": [
+                    "sum"
+                  ],
+                  "show": false
+                },
+                "showHeader": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "expr": "tdarr_unknown_status_total{tdarr_instance=~\"$tdarr_instance\"}",
+                  "instant": true,
+                  "legendFormat": "",
+                  "refId": "A"
+                }
+              ],
+              "title": "Unknown Tdarr Statuses",
+              "transformations": [
+                {
+                  "id": "labelsToFields",
+                  "options": {
+                    "keepLabels": [
+                      "job_kind",
+                      "status"
+                    ],
+                    "mode": "columns",
+                    "valueLabel": ""
+                  }
+                },
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {},
+                    "indexByName": {
+                      "Value": 2,
+                      "job_kind": 0,
+                      "status": 1
+                    },
+                    "renameByName": {}
+                  }
+                }
+              ],
+              "type": "table"
+            }
+          ],
+          "title": "Debug",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 217
+          },
+          "id": 111,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 1127
+              },
+              "id": 105,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "go_goroutines{job=~\".*tdarr.*\"}",
+                  "instant": false,
+                  "legendFormat": "{{job}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Goroutines",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 1127
+              },
+              "id": 106,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "go_memstats_heap_inuse_bytes{job=~\".*tdarr.*\"}",
+                  "instant": false,
+                  "legendFormat": "{{job}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Heap In-Use",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 1135
+              },
+              "id": 107,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "process_resident_memory_bytes{job=~\".*tdarr.*\"}",
+                  "instant": false,
+                  "legendFormat": "{{job}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Resident Memory (RSS)",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 1135
+              },
+              "id": 108,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "rate(process_cpu_seconds_total{job=~\".*tdarr.*\"}[$__rate_interval])",
+                  "instant": false,
+                  "legendFormat": "{{job}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Process CPU",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 1143
+              },
+              "id": 109,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "process_open_fds{job=~\".*tdarr.*\"}",
+                  "instant": false,
+                  "legendFormat": "used {{job}}",
+                  "range": true,
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "process_max_fds{job=~\".*tdarr.*\"}",
+                  "instant": false,
+                  "legendFormat": "limit {{job}}",
+                  "range": true,
+                  "refId": "B"
+                }
+              ],
+              "title": "File Descriptors (used vs limit)",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "description": "Current open file descriptors as a fraction of the process limit (process_open_fds / process_max_fds). The limit is often the container default (~1M), so this normally reads near zero; watch for sustained climbs (descriptor leak) or values approaching 1.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 0.8
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.95
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 4,
+                "x": 8,
+                "y": 1143
+              },
+              "id": 112,
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "process_open_fds{job=~\".*tdarr.*\"} / process_max_fds{job=~\".*tdarr.*\"}",
+                  "instant": true,
+                  "legendFormat": "{{job}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "File Descriptors (% of limit)",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 1143
+              },
+              "id": 110,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "pluginVersion": "12.0.1",
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                  },
+                  "editorMode": "code",
+                  "expr": "go_gc_duration_seconds{quantile=\"0.75\",job=~\".*tdarr.*\"}",
+                  "instant": false,
+                  "legendFormat": "{{job}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "GC Pause (p75)",
+              "type": "timeseries"
+            }
+          ],
+          "title": "Exporter Internals (Go runtime)",
+          "type": "row"
+        }
+      ],
+      "refresh": "5s",
+      "schemaVersion": 41,
+      "tags": [
+        "tdarr",
+        "prometheus"
+      ],
+      "templating": {
+        "list": [
+          {
+            "current": {},
+            "includeAll": false,
+            "label": "Datasource",
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "type": "datasource"
+          },
+          {
+            "current": {},
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "definition": "label_values(tdarr_up, tdarr_instance)",
+            "includeAll": true,
+            "label": "Instance",
+            "multi": true,
+            "name": "tdarr_instance",
+            "options": [],
+            "query": {
+              "query": "label_values(tdarr_up, tdarr_instance)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "current": {},
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "definition": "label_values(tdarr_library_info{tdarr_instance=~\"$tdarr_instance\"}, library_name)",
+            "includeAll": true,
+            "label": "Library",
+            "multi": true,
+            "name": "library",
+            "options": [],
+            "query": {
+              "query": "label_values(tdarr_library_info{tdarr_instance=~\"$tdarr_instance\"}, library_name)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "current": {},
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "definition": "label_values(tdarr_node_info{tdarr_instance=~\"$tdarr_instance\"}, node_name)",
+            "includeAll": true,
+            "label": "Node",
+            "multi": true,
+            "name": "node_name",
+            "options": [],
+            "query": {
+              "query": "label_values(tdarr_node_info{tdarr_instance=~\"$tdarr_instance\"}, node_name)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-5m",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "Tdarr",
+      "uid": "7d103297-1876-4d26-8e2a-a02e119fb36e",
+      "version": 5,
+      "weekStart": ""
+    }
+kind: ConfigMap
+metadata:
+  annotations:
+    grafana_folder: Media
+  labels:
+    grafana_dashboard: "1"
+  name: dashboard-media-tdarr
+  namespace: monitoring

--- a/generated/manifests/prod-axon/tdarr-node/CiliumNetworkPolicy-allow-dns-egress-tdarr-node.yaml
+++ b/generated/manifests/prod-axon/tdarr-node/CiliumNetworkPolicy-allow-dns-egress-tdarr-node.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-dns-egress-tdarr-node
+  namespace: media
+spec:
+  description: Allow tdarr-node to resolve via kube-dns.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: tdarr-node

--- a/generated/manifests/prod-axon/tdarr-node/CiliumNetworkPolicy-allow-nodeconn-egress-tdarr-node.yaml
+++ b/generated/manifests/prod-axon/tdarr-node/CiliumNetworkPolicy-allow-nodeconn-egress-tdarr-node.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-nodeconn-egress-tdarr-node
+  namespace: media
+spec:
+  description: Allow tdarr-node workers to reach the tdarr server node port (8266).
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: tdarr
+      toPorts:
+        - ports:
+            - port: "8266"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: tdarr-node

--- a/generated/manifests/prod-axon/tdarr-node/CiliumNetworkPolicy-deny-ingress-tdarr-node.yaml
+++ b/generated/manifests/prod-axon/tdarr-node/CiliumNetworkPolicy-deny-ingress-tdarr-node.yaml
@@ -1,0 +1,15 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: deny-ingress-tdarr-node
+  namespace: media
+spec:
+  description: Default-deny ingress for tdarr-node (host-only).
+  enableDefaultDeny:
+    ingress: true
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: tdarr-node
+  ingress:
+    - fromEntities:
+        - host

--- a/generated/manifests/prod-axon/tdarr-node/DaemonSet-tdarr-node.yaml
+++ b/generated/manifests/prod-axon/tdarr-node/DaemonSet-tdarr-node.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: tdarr-node
+    app.kubernetes.io/name: tdarr-node
+  name: tdarr-node
+  namespace: media
+spec:
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/controller: main
+      app.kubernetes.io/instance: tdarr-node
+      app.kubernetes.io/name: tdarr-node
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/controller: main
+        app.kubernetes.io/instance: tdarr-node
+        app.kubernetes.io/name: tdarr-node
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: PGID
+              value: "65536"
+            - name: PUID
+              value: "1027"
+            - name: TZ
+              value: America/Los_Angeles
+            - name: healthcheckcpuWorkers
+              value: "0"
+            - name: healthcheckgpuWorkers
+              value: "0"
+            - name: inContainer
+              value: "true"
+            - name: nodeName
+              value: axon-tdarr
+            - name: nodeType
+              value: mapped
+            - name: serverIP
+              value: tdarr.media.svc.cluster.local
+            - name: serverPort
+              value: "8266"
+            - name: transcodecpuWorkers
+              value: "0"
+            - name: transcodegpuWorkers
+              value: "1"
+          image: registry.json64.dev/tdarr-node@sha256:9283db46056f42f7efca590cf91d9dc89fad1f73310c2fda37107822236f38b6
+          name: main
+          resources:
+            limits:
+              amd.com/gpu: 1
+            requests:
+              amd.com/gpu: 1
+          volumeMounts:
+            - mountPath: /data
+              name: data
+            - mountPath: /temp
+              name: temp
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      nodeSelector:
+        node.kubernetes.io/amd-gpu: "true"
+      serviceAccountName: tdarr-node
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: media-data-nfs
+        - emptyDir: {}
+          name: temp

--- a/generated/manifests/prod-axon/tdarr-node/ServiceAccount-tdarr-node.yaml
+++ b/generated/manifests/prod-axon/tdarr-node/ServiceAccount-tdarr-node.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: tdarr-node
+    app.kubernetes.io/name: tdarr-node
+  name: tdarr-node
+  namespace: media

--- a/generated/manifests/prod-axon/tdarr/CiliumNetworkPolicy-allow-dns-egress-tdarr.yaml
+++ b/generated/manifests/prod-axon/tdarr/CiliumNetworkPolicy-allow-dns-egress-tdarr.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-dns-egress-tdarr
+  namespace: media
+spec:
+  description: Allow tdarr to resolve via kube-dns.
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: tdarr

--- a/generated/manifests/prod-axon/tdarr/CiliumNetworkPolicy-allow-gateway-ingress-tdarr.yaml
+++ b/generated/manifests/prod-axon/tdarr/CiliumNetworkPolicy-allow-gateway-ingress-tdarr.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-gateway-ingress-tdarr
+  namespace: media
+spec:
+  description: Allow Envoy Gateway proxies to reach tdarr's webUI.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: tdarr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: gateways
+      toPorts:
+        - ports:
+            - port: "8265"
+              protocol: TCP

--- a/generated/manifests/prod-axon/tdarr/CiliumNetworkPolicy-allow-metrics-ingress-tdarr.yaml
+++ b/generated/manifests/prod-axon/tdarr/CiliumNetworkPolicy-allow-metrics-ingress-tdarr.yaml
@@ -1,0 +1,19 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-metrics-ingress-tdarr
+  namespace: media
+spec:
+  description: Allow Prometheus to scrape tdarr's exporter sidecar (9090).
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: tdarr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: prometheus
+            k8s:io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP

--- a/generated/manifests/prod-axon/tdarr/CiliumNetworkPolicy-allow-nodeconn-ingress-tdarr.yaml
+++ b/generated/manifests/prod-axon/tdarr/CiliumNetworkPolicy-allow-nodeconn-ingress-tdarr.yaml
@@ -1,0 +1,18 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-nodeconn-ingress-tdarr
+  namespace: media
+spec:
+  description: Allow tdarr-node workers to reach the tdarr server's node port (8266).
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: tdarr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: tdarr-node
+      toPorts:
+        - ports:
+            - port: "8266"
+              protocol: TCP

--- a/generated/manifests/prod-axon/tdarr/Deployment-tdarr.yaml
+++ b/generated/manifests/prod-axon/tdarr/Deployment-tdarr.yaml
@@ -1,0 +1,110 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: tdarr
+    app.kubernetes.io/name: tdarr
+  name: tdarr
+  namespace: media
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/controller: main
+      app.kubernetes.io/instance: tdarr
+      app.kubernetes.io/name: tdarr
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/controller: main
+        app.kubernetes.io/instance: tdarr
+        app.kubernetes.io/name: tdarr
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: LOG_LEVEL
+              value: warn
+            - name: PROMETHEUS_PORT
+              value: "9090"
+            - name: TDARR_URL
+              value: http://localhost:8265
+          image: docker.io/homeylab/tdarr-exporter@sha256:07bfc1b72ecec73a343be2007c22373b6e15acbdbecdd29545ab5a03ca21ca69
+          name: exportarr
+          ports:
+            - containerPort: 9090
+              name: metrics
+          volumeMounts:
+            - mountPath: /app/server
+              name: config
+            - mountPath: /app/configs
+              name: config
+            - mountPath: /app/logs
+              name: config
+            - mountPath: /data
+              name: data
+              readOnly: true
+        - env:
+            - name: PGID
+              value: "65536"
+            - name: PUID
+              value: "1027"
+            - name: TZ
+              value: America/Los_Angeles
+            - name: inContainer
+              value: "true"
+            - name: internalNode
+              value: "false"
+            - name: serverIP
+              value: 0.0.0.0
+            - name: serverPort
+              value: "8266"
+            - name: webUIPort
+              value: "8265"
+          image: ghcr.io/haveagitgat/tdarr@sha256:71360670ac0c39e1bb8daf2b0c5c9ebb92b5d41e79c54128f2cea5bbdc32ddf2
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: 8265
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          name: main
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: 8265
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /app/server
+              name: config
+            - mountPath: /app/configs
+              name: config
+            - mountPath: /app/logs
+              name: config
+            - mountPath: /data
+              name: data
+              readOnly: true
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      serviceAccountName: tdarr
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: tdarr
+        - name: data
+          persistentVolumeClaim:
+            claimName: media-data-nfs

--- a/generated/manifests/prod-axon/tdarr/HTTPRoute-tdarr.yaml
+++ b/generated/manifests/prod-axon/tdarr/HTTPRoute-tdarr.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tdarr
+  namespace: media
+spec:
+  hostnames:
+    - tdarr.json64.dev
+  parentRefs:
+    - name: default-gateway
+      namespace: gateways
+      sectionName: json64-dev-https
+  rules:
+    - backendRefs:
+        - name: tdarr
+          port: 8265

--- a/generated/manifests/prod-axon/tdarr/PersistentVolumeClaim-tdarr.yaml
+++ b/generated/manifests/prod-axon/tdarr/PersistentVolumeClaim-tdarr.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/instance: tdarr
+    app.kubernetes.io/name: tdarr
+    recurring-job-group.longhorn.io/media-config: enabled
+  name: tdarr
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: longhorn

--- a/generated/manifests/prod-axon/tdarr/PodMonitor-tdarr.yaml
+++ b/generated/manifests/prod-axon/tdarr/PodMonitor-tdarr.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: tdarr
+  namespace: media
+spec:
+  podMetricsEndpoints:
+    - interval: 30s
+      path: /metrics
+      port: metrics
+      relabelings:
+        - sourceLabels:
+            - __meta_kubernetes_pod_label_app_kubernetes_io_name
+          targetLabel: instance
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tdarr

--- a/generated/manifests/prod-axon/tdarr/SecurityPolicy-tdarr-oidc.yaml
+++ b/generated/manifests/prod-axon/tdarr/SecurityPolicy-tdarr-oidc.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: tdarr-oidc
+  namespace: media
+spec:
+  oidc:
+    clientID: tdarr
+    clientSecret:
+      name: tdarr-oidc-client-secret
+    forwardAccessToken: true
+    provider:
+      issuer: https://idm.json64.dev/oauth2/openid/tdarr
+    scopes:
+      - email
+      - openid
+      - profile
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: tdarr

--- a/generated/manifests/prod-axon/tdarr/Service-tdarr.yaml
+++ b/generated/manifests/prod-axon/tdarr/Service-tdarr.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: tdarr
+    app.kubernetes.io/name: tdarr
+    app.kubernetes.io/service: tdarr
+  name: tdarr
+  namespace: media
+spec:
+  ports:
+    - name: http
+      port: 8265
+      protocol: TCP
+      targetPort: 8265
+    - name: node
+      port: 8266
+      protocol: TCP
+      targetPort: 8266
+  selector:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: tdarr
+    app.kubernetes.io/name: tdarr
+  type: ClusterIP

--- a/generated/manifests/prod-axon/tdarr/ServiceAccount-tdarr.yaml
+++ b/generated/manifests/prod-axon/tdarr/ServiceAccount-tdarr.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: tdarr
+    app.kubernetes.io/name: tdarr
+  name: tdarr
+  namespace: media

--- a/images/haveagitgat/tdarr/default.nix
+++ b/images/haveagitgat/tdarr/default.nix
@@ -1,0 +1,9 @@
+{
+  imageName = "ghcr.io/haveagitgat/tdarr";
+  imageTag = "latest";
+  imageDigest = "sha256:71360670ac0c39e1bb8daf2b0c5c9ebb92b5d41e79c54128f2cea5bbdc32ddf2";
+  imageHash = "sha256-qQo5HhWrxq+TyVamN5m0lKEOLLrVf0wVzmlCbWo08VM=";
+  arch = "amd64";
+  os = "linux";
+  pinned = false;
+}

--- a/images/homeylab/tdarr-exporter/default.nix
+++ b/images/homeylab/tdarr-exporter/default.nix
@@ -1,0 +1,9 @@
+{
+  imageName = "docker.io/homeylab/tdarr-exporter";
+  imageTag = "3.0.0";
+  imageDigest = "sha256:07bfc1b72ecec73a343be2007c22373b6e15acbdbecdd29545ab5a03ca21ca69";
+  imageHash = "sha256-XDrey2PhSTbYNto9oM81VPJ5oGy32LyJYkK2XioAtHY=";
+  arch = "amd64";
+  os = "linux";
+  pinned = true;
+}

--- a/images/json64/tdarr-node/default.nix
+++ b/images/json64/tdarr-node/default.nix
@@ -1,0 +1,16 @@
+{
+  imageName = "registry.json64.dev/tdarr-node";
+  imageTag = "av1";
+  imageDigest = "sha256:9283db46056f42f7efca590cf91d9dc89fad1f73310c2fda37107822236f38b6";
+  # Unused for this image: imageRefs (what the aspect consumes) reads only
+  # imageName+imageDigest; the k3s node pulls it at runtime via registries.yaml.
+  # Only `images`/`imagesDerivations` (dockerTools.pullImage) read imageHash, and
+  # neither is built for a private-registry entry. Placeholder avoids an authed
+  # prefetch. Rebuild flow: nix build .#tdarr-node-vaapi --option sandbox true →
+  # nix copy to uplink → skopeo copy docker-archive:… docker://localhost:5000/… →
+  # update imageDigest here.
+  imageHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  arch = "amd64";
+  os = "linux";
+  pinned = true;
+}

--- a/modules/den/aspects/kubernetes/services/media/tdarr.nix
+++ b/modules/den/aspects/kubernetes/services/media/tdarr.nix
@@ -1,8 +1,9 @@
-# Tdarr — distributed media transcoding stack (SERVER half).
+# Tdarr — distributed media transcoding stack (server + node workers).
 #
-# Tdarr splits into a *server* (this aspect) and a fleet of *node* workers (a
-# later DaemonSet aspect in this file's sibling). The server runs the UI, the
-# library DB, and the job orchestrator; it does NOT transcode itself
+# Tdarr splits into a *server* (`applications.tdarr`) and a fleet of *node*
+# workers (`applications.tdarr-node`, the DaemonSet sibling below). The server
+# runs the UI, the library DB, and the job orchestrator; it does NOT transcode
+# itself
 # (`internalNode = false`). It scans the NAS library over NFS (read-only /data)
 # and hands transcode jobs to the external nodes, which connect back on the
 # server's node port (8266).
@@ -346,6 +347,135 @@
             secrets.tdarr-oidc-client-secret = {
               type = "Opaque";
               stringData.client-secret = config.age.secrets.tdarr-oidc-client-secret.sopsRef;
+            };
+          };
+        };
+
+        # Node-worker DaemonSet: one pod per AMD-APU axon node (nodeSelector
+        # node.kubernetes.io/amd-gpu), each claiming the node's GPU (amd.com/gpu:
+        # 1) to hardware-encode AV1 with the custom registry image. It reads the
+        # library over NFS at /data (writable — the node writes the transcode
+        # back) and caches the in-flight transcode on a node-local emptyDir at
+        # /temp. The node dials the server's control channel
+        # (tdarr.media.svc:8266) to register and pull jobs.
+        applications.tdarr-node = {
+          namespace = "media";
+
+          helm.releases.tdarr-node = {
+            chart = charts.bjw-s-labs.app-template;
+            values = {
+              controllers.main = {
+                type = "daemonset";
+                pod.nodeSelector."node.kubernetes.io/amd-gpu" = "true";
+
+                containers.main = {
+                  image = {
+                    inherit (images."json64/tdarr-node") repository digest;
+                  };
+                  env = {
+                    TZ = "America/Los_Angeles";
+                    PUID = "1027";
+                    PGID = "65536";
+                    inContainer = "true";
+                    serverIP = "tdarr.media.svc.cluster.local";
+                    serverPort = "8266";
+                    nodeName = "axon-tdarr";
+                    nodeType = "mapped";
+                    transcodegpuWorkers = "1";
+                    transcodecpuWorkers = "0";
+                    healthcheckgpuWorkers = "0";
+                    healthcheckcpuWorkers = "0";
+                  };
+                  resources = {
+                    requests."amd.com/gpu" = 1;
+                    limits."amd.com/gpu" = 1;
+                  };
+                };
+              };
+
+              persistence = {
+                # NAS library over NFS, writable: the node writes the finished
+                # transcode back into the library.
+                data = {
+                  type = "persistentVolumeClaim";
+                  existingClaim = "media-data-nfs";
+                  globalMounts = [ { path = "/data"; } ];
+                };
+                # Node-local transcode scratch — in-flight work cache, never
+                # leaves the node.
+                temp = {
+                  type = "emptyDir";
+                  globalMounts = [ { path = "/temp"; } ];
+                };
+              };
+            };
+          };
+
+          resources.ciliumNetworkPolicies = {
+            # tdarr-node dials the server's node-worker control port (8266) in
+            # the same media namespace to register and pull jobs.
+            allow-nodeconn-egress-tdarr-node.spec = {
+              description = "Allow tdarr-node workers to reach the tdarr server node port (8266).";
+              endpointSelector.matchLabels."app.kubernetes.io/name" = "tdarr-node";
+              egress = [
+                {
+                  toEndpoints = [
+                    { matchLabels."app.kubernetes.io/name" = "tdarr"; }
+                  ];
+                  toPorts = [
+                    {
+                      ports = [
+                        {
+                          port = "8266";
+                          protocol = "TCP";
+                        }
+                      ];
+                    }
+                  ];
+                }
+              ];
+            };
+
+            allow-dns-egress-tdarr-node.spec = {
+              description = "Allow tdarr-node to resolve via kube-dns.";
+              endpointSelector.matchLabels."app.kubernetes.io/name" = "tdarr-node";
+              egress = [
+                {
+                  toEndpoints = [
+                    {
+                      matchLabels = {
+                        "k8s:io.kubernetes.pod.namespace" = "kube-system";
+                        "k8s-app" = "kube-dns";
+                      };
+                    }
+                  ];
+                  toPorts = [
+                    {
+                      ports = [
+                        {
+                          port = "53";
+                          protocol = "UDP";
+                        }
+                        {
+                          port = "53";
+                          protocol = "TCP";
+                        }
+                      ];
+                    }
+                  ];
+                }
+              ];
+            };
+
+            # Ingress lockdown: network-policy.nix doesn't manage tdarr-node, so
+            # restore the default-deny it would otherwise inherit (mirrors
+            # unpackerr). The node takes no real inbound; only the host entity
+            # (kubelet probes / node-local) is allowed.
+            deny-ingress-tdarr-node.spec = {
+              description = "Default-deny ingress for tdarr-node (host-only).";
+              endpointSelector.matchLabels."app.kubernetes.io/name" = "tdarr-node";
+              enableDefaultDeny.ingress = true;
+              ingress = [ { fromEntities = [ "host" ]; } ];
             };
           };
         };

--- a/modules/den/aspects/kubernetes/services/media/tdarr.nix
+++ b/modules/den/aspects/kubernetes/services/media/tdarr.nix
@@ -1,0 +1,354 @@
+# Tdarr — distributed media transcoding stack (SERVER half).
+#
+# Tdarr splits into a *server* (this aspect) and a fleet of *node* workers (a
+# later DaemonSet aspect in this file's sibling). The server runs the UI, the
+# library DB, and the job orchestrator; it does NOT transcode itself
+# (`internalNode = false`). It scans the NAS library over NFS (read-only /data)
+# and hands transcode jobs to the external nodes, which connect back on the
+# server's node port (8266).
+#
+# Ports:
+#   8265  webUI  — the React UI + REST, routed + OIDC-protected on tdarr.<domain>
+#   8266  node   — node-worker control channel (tdarr-node pods dial in here)
+# The Service publishes both; `http` is primary (a multi-port app-template
+# Service needs exactly one `primary = true`).
+#
+# Storage:
+#   config  longhorn RWO — the server DB + configs + logs live on three subdirs
+#           of one PVC (/app/server, /app/configs, /app/logs).
+#   data    media-data-nfs (RWX) mounted read-only at /data — the server only
+#           SCANS the library; transcode IO happens on the nodes.
+#
+# Networking: gateway-ingress (8265) flips the pod to default-deny ingress, so
+# the node-worker control channel (8266) needs its own explicit ingress CNP
+# (allow-nodeconn-ingress-tdarr) or the nodes can't register. No NFS-egress CNP:
+# NFS mounts in the host netns, outside pod policy (mirrors the arrs).
+#
+# Metrics: the homeylab/tdarr-exporter v3 sidecar scrapes the server over pod
+# loopback and re-exports on :9090 for kube-prometheus-stack (PodMonitor below).
+{
+  den.aspects.kubernetes.services.media.tdarr = {
+    service-domains = [ "tdarr" ];
+
+    age-secrets =
+      { environment, ... }:
+      {
+        age.secrets.tdarr-oidc-client-secret = {
+          rekeyFile = environment.secretPath + "/oidc/tdarr-oidc-client-secret.age";
+          generator = {
+            tags = [ "oidc" ];
+            script = "rfc3986-secret";
+          };
+          sopsOutput = {
+            file = "oidc";
+            key = "tdarr";
+          };
+        };
+      };
+
+    k8s-manifests =
+      {
+        config,
+        cluster,
+        charts,
+        images,
+        ...
+      }:
+      {
+        applications.tdarr = {
+          namespace = "media";
+
+          helm.releases.tdarr = {
+            chart = charts.bjw-s-labs.app-template;
+            values = {
+              controllers.main = {
+                type = "deployment";
+                # Single-writer DB on an RWO PVC: tear the old pod down before the
+                # new one mounts /app/server.
+                strategy = "Recreate";
+
+                containers.main = {
+                  image = {
+                    inherit (images."haveagitgat/tdarr") repository digest;
+                  };
+                  env = {
+                    TZ = "America/Los_Angeles";
+                    PUID = "1027";
+                    PGID = "65536";
+                    inContainer = "true";
+                    # Server orchestrates only — transcoding is the nodes' job.
+                    internalNode = "false";
+                    serverIP = "0.0.0.0";
+                    serverPort = "8266";
+                    webUIPort = "8265";
+                  };
+                  probes = {
+                    liveness = {
+                      enabled = true;
+                      type = "HTTP";
+                      path = "/";
+                      port = 8265;
+                    };
+                    readiness = {
+                      enabled = true;
+                      type = "HTTP";
+                      path = "/";
+                      port = 8265;
+                    };
+                  };
+                };
+
+                # Prometheus metrics sidecar (homeylab/tdarr-exporter v3): scrapes
+                # the tdarr server API over pod loopback and re-exports on :9090.
+                containers.exportarr = {
+                  image = {
+                    inherit (images."homeylab/tdarr-exporter") repository digest;
+                  };
+                  env = {
+                    TDARR_URL = "http://localhost:8265";
+                    PROMETHEUS_PORT = "9090";
+                    LOG_LEVEL = "warn";
+                  };
+                  ports = [
+                    {
+                      name = "metrics";
+                      containerPort = 9090;
+                    }
+                  ];
+                };
+              };
+
+              service.main = {
+                controller = "main";
+                ports.http = {
+                  port = 8265;
+                  primary = true;
+                };
+                ports.node = {
+                  port = 8266;
+                };
+              };
+
+              persistence = {
+                # Server DB + configs + logs on one longhorn RWO PVC.
+                config = {
+                  type = "persistentVolumeClaim";
+                  accessMode = "ReadWriteOnce";
+                  size = "5Gi";
+                  storageClass = "longhorn";
+                  labels."recurring-job-group.longhorn.io/media-config" = "enabled";
+                  globalMounts = [
+                    { path = "/app/server"; }
+                    { path = "/app/configs"; }
+                    { path = "/app/logs"; }
+                  ];
+                };
+                # NAS library over NFS, read-only — the server only scans it.
+                data = {
+                  type = "persistentVolumeClaim";
+                  existingClaim = "media-data-nfs";
+                  globalMounts = [
+                    {
+                      path = "/data";
+                      readOnly = true;
+                    }
+                  ];
+                };
+              };
+            };
+          };
+
+          # Raw PodMonitor: no typed accessor without a kube-prometheus-stack
+          # CRDs bridge, so author it directly (mirrors the monitoring aspect).
+          objects = [
+            {
+              apiVersion = "monitoring.coreos.com/v1";
+              kind = "PodMonitor";
+              metadata = {
+                name = "tdarr";
+                namespace = "media";
+              };
+              spec = {
+                selector.matchLabels."app.kubernetes.io/name" = "tdarr";
+                podMetricsEndpoints = [
+                  {
+                    port = "metrics";
+                    path = "/metrics";
+                    interval = "30s";
+                    # Default instance is the ephemeral pod IP:port, which
+                    # churns on every restart; pin it to the stable app name.
+                    relabelings = [
+                      {
+                        sourceLabels = [ "__meta_kubernetes_pod_label_app_kubernetes_io_name" ];
+                        targetLabel = "instance";
+                      }
+                    ];
+                  }
+                ];
+              };
+            }
+          ];
+
+          resources = {
+            ciliumNetworkPolicies = {
+              allow-gateway-ingress-tdarr.spec = {
+                description = "Allow Envoy Gateway proxies to reach tdarr's webUI.";
+                endpointSelector.matchLabels."app.kubernetes.io/name" = "tdarr";
+                ingress = [
+                  {
+                    fromEndpoints = [
+                      { matchLabels."k8s:io.kubernetes.pod.namespace" = "gateways"; }
+                    ];
+                    toPorts = [
+                      {
+                        ports = [
+                          {
+                            port = "8265";
+                            protocol = "TCP";
+                          }
+                        ];
+                      }
+                    ];
+                  }
+                ];
+              };
+
+              allow-metrics-ingress-tdarr.spec = {
+                description = "Allow Prometheus to scrape tdarr's exporter sidecar (9090).";
+                endpointSelector.matchLabels."app.kubernetes.io/name" = "tdarr";
+                ingress = [
+                  {
+                    fromEndpoints = [
+                      {
+                        matchLabels = {
+                          "k8s:io.kubernetes.pod.namespace" = "monitoring";
+                          "app.kubernetes.io/name" = "prometheus";
+                        };
+                      }
+                    ];
+                    toPorts = [
+                      {
+                        ports = [
+                          {
+                            port = "9090";
+                            protocol = "TCP";
+                          }
+                        ];
+                      }
+                    ];
+                  }
+                ];
+              };
+
+              # Node-worker control channel: the gateway-ingress policy above flips
+              # the pod to default-deny ingress, so the tdarr-node workers (same
+              # media namespace) need an explicit ingress to 8266 or they cannot
+              # register with the server.
+              allow-nodeconn-ingress-tdarr.spec = {
+                description = "Allow tdarr-node workers to reach the tdarr server's node port (8266).";
+                endpointSelector.matchLabels."app.kubernetes.io/name" = "tdarr";
+                ingress = [
+                  {
+                    fromEndpoints = [
+                      { matchLabels."app.kubernetes.io/name" = "tdarr-node"; }
+                    ];
+                    toPorts = [
+                      {
+                        ports = [
+                          {
+                            port = "8266";
+                            protocol = "TCP";
+                          }
+                        ];
+                      }
+                    ];
+                  }
+                ];
+              };
+
+              allow-dns-egress-tdarr.spec = {
+                description = "Allow tdarr to resolve via kube-dns.";
+                endpointSelector.matchLabels."app.kubernetes.io/name" = "tdarr";
+                egress = [
+                  {
+                    toEndpoints = [
+                      {
+                        matchLabels = {
+                          "k8s:io.kubernetes.pod.namespace" = "kube-system";
+                          "k8s-app" = "kube-dns";
+                        };
+                      }
+                    ];
+                    toPorts = [
+                      {
+                        ports = [
+                          {
+                            port = "53";
+                            protocol = "UDP";
+                          }
+                          {
+                            port = "53";
+                            protocol = "TCP";
+                          }
+                        ];
+                      }
+                    ];
+                  }
+                ];
+              };
+            };
+
+            httpRoutes.tdarr.spec = {
+              hostnames = [ (cluster.domainFor "tdarr") ];
+              parentRefs = [
+                {
+                  name = "default-gateway";
+                  namespace = "gateways";
+                  sectionName = "${cluster.domainForResource "tdarr"}-https";
+                }
+              ];
+              rules = [
+                {
+                  backendRefs = [
+                    {
+                      name = "tdarr";
+                      port = 8265;
+                    }
+                  ];
+                }
+              ];
+            };
+
+            securityPolicies."tdarr-oidc".spec = {
+              targetRefs = [
+                {
+                  group = "gateway.networking.k8s.io";
+                  kind = "HTTPRoute";
+                  name = "tdarr";
+                }
+              ];
+              oidc = {
+                provider.issuer = cluster.secrets.oidcIssuerFor "tdarr";
+                clientID = "tdarr";
+                clientSecret.name = "tdarr-oidc-client-secret";
+                scopes = [
+                  "email"
+                  "openid"
+                  "profile"
+                ];
+                # If tdarr's UI is later found to reject a forwarded Bearer token,
+                # flip this to false (the arrs forward; the UI is OIDC-gated at the
+                # gateway either way).
+                forwardAccessToken = true;
+              };
+            };
+
+            secrets.tdarr-oidc-client-secret = {
+              type = "Opaque";
+              stringData.client-secret = config.age.secrets.tdarr-oidc-client-secret.sopsRef;
+            };
+          };
+        };
+      };
+  };
+}

--- a/modules/den/aspects/kubernetes/services/monitoring/grafana.nix
+++ b/modules/den/aspects/kubernetes/services/monitoring/grafana.nix
@@ -333,6 +333,24 @@
             fixDatasource = true;
             excludeColonInstances = true;
           };
+          # Tdarr via the homeylab/tdarr-exporter v3 sidecar — the exporter's
+          # own v3 dashboard (examples/dashboard.json pinned at the v3.0.0 tag;
+          # archive/ holds the retired v1/v2 ones). Keyed on the v3 tdarr_*
+          # schema: tdarr_size_diff_bytes (space saved), files/transcode counts,
+          # per-library tdarr_library_transcodes_completed_total joined to
+          # tdarr_library_info for the name, node/worker status
+          # (tdarr_node_worker_status), and tdarr_server_uptime_seconds. No
+          # excludeColonInstances: this dashboard's instance variable is
+          # `tdarr_instance` (the exporter-set server hostname — here `localhost`,
+          # never a colon-form pod-IP), not the prometheus `instance` label our
+          # PodMonitor relabels, so the pod-IP churn that option fixes can't arise.
+          media-tdarr = {
+            title = "Tdarr";
+            folder = "Media";
+            url = "https://raw.githubusercontent.com/homeylab/tdarr-exporter/28de93aaea020744ce246f4eb33ef9e830a52419/examples/dashboard.json";
+            sha256 = "03h41n18csh0jjvxlxqbk9ssf8gaxk4k210wq6nla32zzrlc2n5w";
+            fixDatasource = true;
+          };
         };
       in
       {

--- a/modules/den/aspects/services/security/kanidm.nix
+++ b/modules/den/aspects/services/security/kanidm.nix
@@ -442,6 +442,10 @@ let
       displayName = "Profilarr";
       group = "media.admins";
     };
+    tdarr = {
+      displayName = "Tdarr";
+      group = "media.admins";
+    };
     # The k8s utility dashboard is named "dash" (NOT "homepage"): the uplink host
     # already owns service-domains "homepage" (homepage.json64.dev) via its NixOS
     # homepage-dashboard aspect (modules/den/aspects/services/web/homepage.nix,

--- a/modules/den/clusters/axon.nix
+++ b/modules/den/clusters/axon.nix
@@ -123,6 +123,7 @@
       services.media.whisparr
       services.media.bazarr
       services.media.sabnzbd
+      services.media.tdarr
       services.media.qbittorrent
       services.media.unpackerr
       services.media.profilarr

--- a/pkgs/by-name/tdarr-node-vaapi/package.nix
+++ b/pkgs/by-name/tdarr-node-vaapi/package.nix
@@ -1,0 +1,59 @@
+# Custom tdarr_node OCI image: stock haveagitgat/tdarr_node base + nixpkgs
+# ffmpeg-full (av1_vaapi) + mesa, so the axon AMD Radeon 780M (VCN 4.0) APUs can
+# hardware-encode AV1 via VAAPI.
+#
+# WHY: the stock tdarr_node image ships Ubuntu-jammy Mesa (~22.x), which predates
+# VCN4 AV1 VAAPI encode support (needs Mesa >= 24.1). We layer nixpkgs mesa (26.x)
+# + ffmpeg-full on top and point tdarr at it via the `ffmpegPath` env. The nixpkgs
+# ffmpeg closure carries its own glibc, so there is no ABI clash with the Ubuntu base.
+#
+# Rebuild / ship flow:
+#   1. nix build .#tdarr-node-vaapi        # produces a docker-archive tarball
+#   2. push the loaded image to the cluster registry
+#   3. pin the pushed digest in the tdarr media aspect (later task)
+#
+# GOTCHA: dockerTools.buildLayeredImage with `fromImage` merges ONLY `Env` from the
+# base. It does NOT inherit Entrypoint/Cmd/WorkingDir/User. Those are restated below
+# from `skopeo inspect --config docker://ghcr.io/haveagitgat/tdarr_node:latest`:
+#   Entrypoint = ["/init"];  Cmd = null;  WorkingDir = "/";  User = null;
+{
+  dockerTools,
+  ffmpeg-full,
+  mesa,
+}:
+let
+  # Base image resolved via `nix-prefetch-docker --image-name
+  # ghcr.io/haveagitgat/tdarr_node --image-tag latest --arch amd64 --os linux`.
+  # Pinned by digest for reproducibility (tag `latest` at resolution time).
+  base = dockerTools.pullImage {
+    imageName = "ghcr.io/haveagitgat/tdarr_node";
+    imageDigest = "sha256:a0f47ec35dae7bfec7674a4d5749efe91c3a06ceb15ea038ff0dd83132f8568e";
+    sha256 = "sha256-/9eIz08OuwdT5x2HTq8ZnjEDuQz10kbutBy8AofTonA=";
+    finalImageName = "tdarr_node";
+    finalImageTag = "base";
+  };
+in
+dockerTools.buildLayeredImage {
+  name = "tdarr-node-vaapi";
+  tag = "av1";
+  fromImage = base;
+  contents = [
+    ffmpeg-full
+    mesa
+  ];
+  config = {
+    # Merged with the base image Env; our entries take precedence for duplicate keys.
+    Env = [
+      "ffmpegPath=${ffmpeg-full}/bin/ffmpeg"
+      "LIBVA_DRIVERS_PATH=${mesa}/lib/dri"
+      "LIBVA_DRIVER_NAME=radeonsi"
+    ];
+    # NOT inherited from fromImage by buildLayeredImage — restate from the skopeo
+    # inspect of the base (see header). The base is a linuxserver-style s6 image:
+    # `/init` boots s6-overlay, which drops to PUID/PGID; there is no Cmd.
+    Entrypoint = [ "/init" ];
+    WorkingDir = "/";
+    # Base Cmd and User are both null (root; s6 handles the privilege drop), so we
+    # intentionally do not set Cmd/User here.
+  };
+}


### PR DESCRIPTION
Adds tdarr to the axon media stack: a server (orchestrator-only, OIDC-protected UI, Prometheus exporter, Grafana dashboard in the Media folder) plus a GPU worker DaemonSet that hardware-encodes AV1 on the AMD APU video engines via a custom image (stock tdarr_node base + nixpkgs ffmpeg+mesa for VCN4 AV1). Library over the shared NFS PVC, node-local transcode cache. Deploys to the cluster via GitOps.

Declarative app-state (libraries/Flow) is a follow-on once a live instance exists.