### PR TITLE
fix(k3s): nest registry auth under configs in registries.yaml

### DIFF
--- a/modules/den/aspects/services/k3s/k3s.nix
+++ b/modules/den/aspects/services/k3s/k3s.nix
@@ -274,12 +274,22 @@ in
             };
             script =
               let
+                # Build each registry block with explicit indentation so it nests
+                # under `configs:`. A Nix indented string (''…'') strips the common
+                # leading whitespace, which would drop the `"<domain>":` key to
+                # column 0 — a sibling of `configs:` rather than a child — so
+                # containerd reads an empty `configs` and pulls fail with
+                # "no basic auth credentials". Regular strings preserve the indent.
                 configsBlock = concatStringsSep "\n" (
-                  map (reg: ''
-                    "${reg.domain}":
-                      auth:
-                        username: "${reg.username}"
-                        password: "$registry_password"'') registries
+                  map (
+                    reg:
+                    concatStringsSep "\n" [
+                      "  \"${reg.domain}\":"
+                      "    auth:"
+                      "      username: \"${reg.username}\""
+                      "      password: \"$registry_password\""
+                    ]
+                  ) registries
                 );
               in
               ''


### PR DESCRIPTION
The per-registry block in the k3s registries.yaml renderer used a Nix indented string, which dedented the registry key to column 0 (sibling of `configs:` instead of a child). containerd then saw an empty `configs` and authed pulls failed with "no basic auth credentials". Build the block with explicit indentation. Surfaced on the first authenticated registry pull; public-registry pulls were unaffected.