### PR TITLE
fix(media): tdarr node image — fix /init boot + ffmpeg libc resolution

### DIFF
--- a/generated/manifests/prod-axon/tdarr-node/DaemonSet-tdarr-node.yaml
+++ b/generated/manifests/prod-axon/tdarr-node/DaemonSet-tdarr-node.yaml
@@ -48,7 +48,7 @@ spec:
               value: "0"
             - name: transcodegpuWorkers
               value: "1"
-          image: registry.json64.dev/tdarr-node@sha256:9283db46056f42f7efca590cf91d9dc89fad1f73310c2fda37107822236f38b6
+          image: registry.json64.dev/tdarr-node@sha256:7f28f6da015feb112aabc5810135b22396a98bb0436739d2ecc5af951b4e6c77
           name: main
           resources:
             limits:

--- a/images/json64/tdarr-node/default.nix
+++ b/images/json64/tdarr-node/default.nix
@@ -1,7 +1,7 @@
 {
   imageName = "registry.json64.dev/tdarr-node";
   imageTag = "av1";
-  imageDigest = "sha256:9283db46056f42f7efca590cf91d9dc89fad1f73310c2fda37107822236f38b6";
+  imageDigest = "sha256:7f28f6da015feb112aabc5810135b22396a98bb0436739d2ecc5af951b4e6c77";
   # Unused for this image: imageRefs (what the aspect consumes) reads only
   # imageName+imageDigest; the k3s node pulls it at runtime via registries.yaml.
   # Only `images`/`imagesDerivations` (dockerTools.pullImage) read imageHash, and

--- a/pkgs/by-name/tdarr-node-vaapi/package.nix
+++ b/pkgs/by-name/tdarr-node-vaapi/package.nix
@@ -1,30 +1,46 @@
 # Custom tdarr_node OCI image: stock haveagitgat/tdarr_node base + nixpkgs
 # ffmpeg-full (av1_vaapi) + mesa, so the axon AMD Radeon 780M (VCN 4.0) APUs can
-# hardware-encode AV1 via VAAPI.
+# hardware-encode AV1 via VAAPI. tdarr is pointed at it via the `ffmpegPath` env.
 #
-# WHY: the stock tdarr_node image ships Ubuntu-jammy Mesa (~22.x), which predates
-# VCN4 AV1 VAAPI encode support (needs Mesa >= 24.1). We layer nixpkgs mesa (26.x)
-# + ffmpeg-full on top and point tdarr at it via the `ffmpegPath` env. The nixpkgs
-# ffmpeg closure carries its own glibc, so there is no ABI clash with the Ubuntu base.
+# WHY: the stock tdarr_node image ships Ubuntu Mesa too old for VCN4 AV1 VAAPI
+# encode (needs Mesa >= 24.1); we supply nixpkgs mesa 26.x + ffmpeg-full.
 #
-# Rebuild / ship flow:
-#   1. nix build .#tdarr-node-vaapi        # produces a docker-archive tarball
-#   2. push the loaded image to the cluster registry
-#   3. pin the pushed digest in the tdarr media aspect (later task)
+# Three non-obvious things this build gets right (each cost a debugging round):
+#   1. NO `contents`/copyToRoot. Copying ffmpeg-full+mesa to the image root makes
+#      /bin and /lib directories that, under the container's overlayfs, SHADOW the
+#      base Ubuntu usrmerge symlinks (/bin -> usr/bin) — deleting /bin/sh and
+#      breaking /init's `#!/bin/sh` shebang ("exec /init: no such file or
+#      directory"). Instead the ffmpeg+mesa store paths enter the image as the
+#      closure of the wrappers that config.Env references, leaving the base rootfs
+#      untouched.
+#   2. The ffmpeg wrappers carry a LITERAL `#!/bin/sh` shebang so they run under the
+#      image's Ubuntu dash, NOT nix bash. The base sets
+#      LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu, which takes precedence over a nix
+#      binary's RUNPATH — so a nix-shebang wrapper's own interpreter loads Ubuntu
+#      glibc and dies ("symbol lookup error ... GLIBC_PRIVATE") before it can unset
+#      anything. Ubuntu dash expects Ubuntu libc, starts fine, and drops
+#      LD_LIBRARY_PATH before exec'ing the nix ffmpeg.
+#   3. With LD_LIBRARY_PATH dropped, the nix ffmpeg resolves its samba/jansson/glibc
+#      deps from its own closure instead of Ubuntu's older libs (which otherwise
+#      throw `GLIBC_2.42`/`JANSSON_4` not found). The wrapper also sets the VAAPI env.
 #
-# GOTCHA: dockerTools.buildLayeredImage with `fromImage` merges ONLY `Env` from the
-# base. It does NOT inherit Entrypoint/Cmd/WorkingDir/User. Those are restated below
-# from `skopeo inspect --config docker://ghcr.io/haveagitgat/tdarr_node:latest`:
+# GOTCHA: dockerTools.buildLayeredImage with `fromImage` merges ONLY `Env` — it
+# does NOT inherit Entrypoint/Cmd/WorkingDir/User. Restated below from
+# `skopeo inspect --config docker://ghcr.io/haveagitgat/tdarr_node:latest`:
 #   Entrypoint = ["/init"];  Cmd = null;  WorkingDir = "/";  User = null;
+#
+# Rebuild / ship flow: `nix build .#tdarr-node-vaapi --option sandbox true` ->
+# `nix copy --to ssh://uplink <out>` -> on uplink `skopeo copy docker-archive:<out>
+# docker://localhost:5000/tdarr-node:av1` -> update the digest in
+# images/json64/tdarr-node.
 {
   dockerTools,
   ffmpeg-full,
   mesa,
+  writeTextFile,
+  symlinkJoin,
 }:
 let
-  # Base image resolved via `nix-prefetch-docker --image-name
-  # ghcr.io/haveagitgat/tdarr_node --image-tag latest --arch amd64 --os linux`.
-  # Pinned by digest for reproducibility (tag `latest` at resolution time).
   base = dockerTools.pullImage {
     imageName = "ghcr.io/haveagitgat/tdarr_node";
     imageDigest = "sha256:a0f47ec35dae7bfec7674a4d5749efe91c3a06ceb15ea038ff0dd83132f8568e";
@@ -32,28 +48,44 @@ let
     finalImageName = "tdarr_node";
     finalImageTag = "base";
   };
+
+  # ffmpeg/ffprobe wrappers — see header points 2 & 3. Literal `#!/bin/sh` so the
+  # image's Ubuntu dash runs them, drops the base LD_LIBRARY_PATH, sets VAAPI, then
+  # exec's the nix binary. tdarr derives ffprobe from ffmpegPath's sibling, so ship
+  # both under one bin/.
+  mkWrap =
+    name:
+    writeTextFile {
+      name = "tdarr-${name}";
+      executable = true;
+      destination = "/bin/${name}";
+      text = ''
+        #!/bin/sh
+        unset LD_LIBRARY_PATH
+        export LIBVA_DRIVERS_PATH=${mesa}/lib/dri
+        export LIBVA_DRIVER_NAME=radeonsi
+        exec ${ffmpeg-full}/bin/${name} "$@"
+      '';
+    };
+  tdarr-ffmpeg = symlinkJoin {
+    name = "tdarr-ffmpeg";
+    paths = [
+      (mkWrap "ffmpeg")
+      (mkWrap "ffprobe")
+    ];
+  };
 in
 dockerTools.buildLayeredImage {
   name = "tdarr-node-vaapi";
   tag = "av1";
   fromImage = base;
-  contents = [
-    ffmpeg-full
-    mesa
-  ];
   config = {
-    # Merged with the base image Env; our entries take precedence for duplicate keys.
+    # Merged with the base image Env. ffmpegPath -> our wrapper, whose closure
+    # pulls ffmpeg-full + mesa into the image without touching the base rootfs.
     Env = [
-      "ffmpegPath=${ffmpeg-full}/bin/ffmpeg"
-      "LIBVA_DRIVERS_PATH=${mesa}/lib/dri"
-      "LIBVA_DRIVER_NAME=radeonsi"
+      "ffmpegPath=${tdarr-ffmpeg}/bin/ffmpeg"
     ];
-    # NOT inherited from fromImage by buildLayeredImage — restate from the skopeo
-    # inspect of the base (see header). The base is a linuxserver-style s6 image:
-    # `/init` boots s6-overlay, which drops to PUID/PGID; there is no Cmd.
     Entrypoint = [ "/init" ];
     WorkingDir = "/";
-    # Base Cmd and User are both null (root; s6 handles the privilege drop), so we
-    # intentionally do not set Cmd/User here.
   };
 }


### PR DESCRIPTION
The custom AV1 tdarr-node image crashed at container start (`exec /init: no such file or directory`) and ffmpeg wouldn't run. Three fixes in the image build:

- Drop `contents`/copyToRoot — it placed /bin,/lib dirs that overlayfs shadowed the base Ubuntu usrmerge symlinks with, deleting /bin/sh and breaking /init's shebang.
- Wrap ffmpeg/ffprobe with a literal `#!/bin/sh` (the image's Ubuntu dash), immune to the base `LD_LIBRARY_PATH` that crashes a nix-bash launcher.
- The wrapper unsets `LD_LIBRARY_PATH` so the nix ffmpeg resolves its own glibc/jansson closure (not Ubuntu's older libs).

Verified by running the image: /bin/sh works, ffmpeg+ffprobe run, av1_vaapi present. Repins to the rebuilt digest.