### PR TITLE
fix(media): per-host tdarr node names

### DIFF
--- a/generated/manifests/prod-axon/tdarr-node/DaemonSet-tdarr-node.yaml
+++ b/generated/manifests/prod-axon/tdarr-node/DaemonSet-tdarr-node.yaml
@@ -37,7 +37,9 @@ spec:
             - name: inContainer
               value: "true"
             - name: nodeName
-              value: axon-tdarr
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: nodeType
               value: mapped
             - name: serverIP

--- a/modules/den/aspects/kubernetes/services/media/tdarr.nix
+++ b/modules/den/aspects/kubernetes/services/media/tdarr.nix
@@ -410,7 +410,11 @@
                     inContainer = "true";
                     serverIP = "tdarr.media.svc.cluster.local";
                     serverPort = "8266";
-                    nodeName = "axon-tdarr";
+                    # Per-host node name so the server tracks each DaemonSet pod as
+                    # its own GPU worker. A static value makes all three register
+                    # under one name (server warns "nodeName ... used by multiple
+                    # Nodes") and muddles per-node worker assignment + stats.
+                    nodeName.valueFrom.fieldRef.fieldPath = "spec.nodeName";
                     nodeType = "mapped";
                     transcodegpuWorkers = "1";
                     transcodecpuWorkers = "0";


### PR DESCRIPTION
All tdarr-node DaemonSet pods used a static `nodeName`, so the server registered them under one name and warned about the collision (muddles per-node worker assignment + stats). Source `nodeName` from each pod's `spec.nodeName` so the three GPU workers are distinct.