### PR TITLE
feat(shoko): add internal LB for off-cluster access

### DIFF
--- a/generated/manifests/prod-axon/shoko/CiliumNetworkPolicy-allow-lan-ingress-shoko.yaml
+++ b/generated/manifests/prod-axon/shoko/CiliumNetworkPolicy-allow-lan-ingress-shoko.yaml
@@ -1,0 +1,17 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-lan-ingress-shoko
+  namespace: media
+spec:
+  description: Allow private-LAN clients (e.g. Jellyfin/Shokofin) to reach shoko on 8111, bypassing the OIDC gateway.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: shoko
+  ingress:
+    - fromCIDR:
+        - 10.0.0.0/8
+      toPorts:
+        - ports:
+            - port: "8111"
+              protocol: TCP

--- a/generated/manifests/prod-axon/shoko/Service-shoko-internal.yaml
+++ b/generated/manifests/prod-axon/shoko/Service-shoko-internal.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lbipam.cilium.io/ips: 10.11.0.10
+  labels:
+    app.kubernetes.io/instance: shoko
+    app.kubernetes.io/name: shoko
+    app.kubernetes.io/service: shoko-internal
+  name: shoko-internal
+  namespace: media
+spec:
+  externalTrafficPolicy: Local
+  ports:
+    - name: http
+      port: 8111
+      protocol: TCP
+      targetPort: 8111
+  selector:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: shoko
+    app.kubernetes.io/name: shoko
+  type: LoadBalancer

--- a/modules/den/aspects/kubernetes/services/media/shoko.nix
+++ b/modules/den/aspects/kubernetes/services/media/shoko.nix
@@ -42,6 +42,11 @@
         ...
       }:
       let
+        # Private LB IP (kubernetes-loadbalancers pool) for the internal Shoko
+        # API service below — BGP-advertised to the uplink host, not routable
+        # from the internet.
+        internalAddress = cluster.getAssignment "shoko-internal";
+
         # Alloy River config for the per-pod log-tail sidecar. Shoko (official
         # image, .NET / NLog) writes date-named log files under
         # /home/shoko/.shoko/Shoko.CLI/logs/<date>.log on the state PVC; the glob
@@ -181,6 +186,31 @@
 
               service.main = {
                 controller = "main";
+                # Pin the public service name to `shoko`: bjw-s suffixes every
+                # service with its identifier once a controller owns >1 service
+                # (main would become `shoko-main`), which would dangle the
+                # HTTPRoute backendRef (-> `shoko`) below. forceRename keeps this
+                # the byte-identical single-service name.
+                forceRename = "shoko";
+                ports.http.port = 8111;
+              };
+
+              # Internal-only LoadBalancer so off-cluster callers on the LAN can
+              # reach Shoko's API directly, bypassing the OIDC-gated public route.
+              # Jellyfin/Shokofin runs on the uplink host (outside the cluster)
+              # and only speaks Shoko's native host + username/password login, so
+              # it can't satisfy the Envoy OIDC SecurityPolicy on the public
+              # `shoko` HTTPRoute. The LB IP comes from the private
+              # kubernetes-loadbalancers pool (BGP-advertised to uplink, NOT
+              # internet-routable — haproxy only SNI-forwards :443 to the
+              # gateway), so the auth in front of it is Shoko's own API key.
+              # externalTrafficPolicy=Local preserves the caller's real source
+              # IP; the CNP below scopes ingress to the private LAN range.
+              service.internal = {
+                controller = "main";
+                type = "LoadBalancer";
+                externalTrafficPolicy = "Local";
+                annotations."lbipam.cilium.io/ips" = internalAddress;
                 ports.http.port = 8111;
               };
 
@@ -228,6 +258,34 @@
                     fromEndpoints = [
                       { matchLabels."k8s:io.kubernetes.pod.namespace" = "gateways"; }
                     ];
+                    toPorts = [
+                      {
+                        ports = [
+                          {
+                            port = "8111";
+                            protocol = "TCP";
+                          }
+                        ];
+                      }
+                    ];
+                  }
+                ];
+              };
+
+              # Off-cluster LAN callers (e.g. Jellyfin/Shokofin on uplink) reach
+              # Shoko over the internal LoadBalancer service above, bypassing the
+              # OIDC gateway. Allow the whole private 10.0.0.0/8 range rather than
+              # pinning a single host IP: it's portable (any LAN host, no
+              # per-deployment IP), the LB IP is RFC1918 / not internet-routable,
+              # and Shoko's own login is the auth in front. The wide CIDR also
+              # covers both the externalTrafficPolicy=Local source (the caller's
+              # real IP) and any future node-SNAT (a cluster node's 10.x address).
+              allow-lan-ingress-shoko.spec = {
+                description = "Allow private-LAN clients (e.g. Jellyfin/Shokofin) to reach shoko on 8111, bypassing the OIDC gateway.";
+                endpointSelector.matchLabels."app.kubernetes.io/name" = "shoko";
+                ingress = [
+                  {
+                    fromCIDR = [ "10.0.0.0/8" ];
                     toPorts = [
                       {
                         ports = [

--- a/modules/den/clusters/axon.nix
+++ b/modules/den/clusters/axon.nix
@@ -59,6 +59,10 @@
         assignments = {
           cilium-ingress-controller = "10.11.0.2";
           default-gateway = "10.11.0.1";
+          # Internal-only LB for Shoko's API, reached by Jellyfin/Shokofin on the
+          # uplink host (off-cluster) so it bypasses the OIDC-gated public route.
+          # BGP-advertised to uplink, NOT internet-routable. See media/shoko.nix.
+          shoko-internal = "10.11.0.10";
         };
       };
     };


### PR DESCRIPTION
## What

Shoko's public route sits behind the Envoy OIDC SecurityPolicy. Shokofin (running in the off-cluster Jellyfin deployment) only supports Shoko's native host + username/password login, so it can't satisfy OIDC and there's no token/header to add a parallel auth rule for.

This adds a second, OIDC-free path to Shoko that the SecurityPolicy doesn't cover, reachable only from the private LAN:

- An internal-only `LoadBalancer` Service on the private load-balancer pool (BGP-advertised to the LAN, not internet-routable). `externalTrafficPolicy=Local` preserves the caller's real source IP.
- A CiliumNetworkPolicy permitting private-LAN clients to that port. Shoko's own login remains the auth in front.

Off-cluster integrations point at the internal endpoint directly; browsers keep using the OIDC-gated public route unchanged.

## Notes

- `forceRename` pins the main Service name so the public HTTPRoute backendRef stays valid once the controller owns a second Service (bjw-s otherwise suffixes every service with its identifier). Verified the rendered public Service is byte-identical to before.
- Verified the only manifest delta vs. baseline is the new internal Service + the new CNP (sops re-encryption noise aside).