### PR TITLE
feat(shoko): open additional AniDB UDP egress

### DIFF
--- a/generated/manifests/prod-axon/shoko/CiliumNetworkPolicy-allow-anidb-egress-shoko.yaml
+++ b/generated/manifests/prod-axon/shoko/CiliumNetworkPolicy-allow-anidb-egress-shoko.yaml
@@ -4,7 +4,7 @@ metadata:
   name: allow-anidb-egress-shoko
   namespace: media
 spec:
-  description: Allow shoko to reach the AniDB UDP (9000) and HTTP (9001) APIs.
+  description: Allow shoko to reach the AniDB UDP (9000, 9002) and HTTP (9001) APIs.
   egress:
     - toEntities:
         - world
@@ -14,6 +14,8 @@ spec:
               protocol: UDP
             - port: "9001"
               protocol: TCP
+            - port: "9002"
+              protocol: UDP
   endpointSelector:
     matchLabels:
       app.kubernetes.io/name: shoko

--- a/modules/den/aspects/kubernetes/services/media/shoko.nix
+++ b/modules/den/aspects/kubernetes/services/media/shoko.nix
@@ -8,7 +8,7 @@
 #
 # The service is described inline (formerly built via the mkMediaApp helper).
 #
-# AniDB talks over its own ports: UDP API on 9000, HTTP API on 9001 —
+# AniDB talks over its own ports: UDP API on 9000/9002, HTTP API on 9001 —
 # world egress for those rides an extra CNP next to the standard 80/443
 # (artwork CDN) policy.
 #
@@ -357,7 +357,7 @@
               };
 
               allow-anidb-egress-shoko.spec = {
-                description = "Allow shoko to reach the AniDB UDP (9000) and HTTP (9001) APIs.";
+                description = "Allow shoko to reach the AniDB UDP (9000, 9002) and HTTP (9001) APIs.";
                 endpointSelector.matchLabels."app.kubernetes.io/name" = "shoko";
                 egress = [
                   {
@@ -372,6 +372,10 @@
                           {
                             port = "9001";
                             protocol = "TCP";
+                          }
+                          {
+                            port = "9002";
+                            protocol = "UDP";
                           }
                         ];
                       }


### PR DESCRIPTION
Adds an additional UDP destination port to Shoko's AniDB world-egress CiliumNetworkPolicy so the AniDB UDP API path is fully reachable.

Bundled into the existing AniDB egress policy rather than a new rule — UDP egress to the public internet is, for this pod, exclusively AniDB (the artwork CDNs ride the separate TCP 80/443 policy).