### PR TITLE
feat(romm): expose scan timeout, workers, and replicas as cluster settings

### DIFF
--- a/generated/manifests/prod-axon/romm/Deployment-romm.yaml
+++ b/generated/manifests/prod-axon/romm/Deployment-romm.yaml
@@ -107,6 +107,10 @@ spec:
                   name: media-romm
             - name: ROMM_DB_DRIVER
               value: postgresql
+            - name: SCAN_TIMEOUT
+              value: "1209600"
+            - name: SCAN_WORKERS
+              value: "10"
             - name: STEAMGRIDDB_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/modules/den/aspects/kubernetes/services/media/romm-settings.nix
+++ b/modules/den/aspects/kubernetes/services/media/romm-settings.nix
@@ -1,0 +1,56 @@
+# Settings for the romm aspect. Surfaced onto the cluster as
+# `cluster.settings.kubernetes.services.media.romm.*`; set per cluster via
+# `den.clusters.<name>.settings.kubernetes.services.media.romm.<key>`.
+{ lib, ... }:
+{
+  # SCAN_TIMEOUT — wall-clock cap on a single background scan/rescan job. RomM's
+  # scan is ONE low-prio RQ job; when this elapses the job is killed mid-flight.
+  # A normal (non-"complete") rescan is additive (already-identified ROMs are
+  # skipped), so the library still converges across repeated runs — but a large
+  # first-pass scan (~100k ROMs) wants a single long window. Upstream default
+  # 14400 (4h).
+  den.aspects.kubernetes.services.media.romm.settings.scanTimeout = lib.mkOption {
+    type = lib.types.ints.positive;
+    default = 14400; # 4h — RomM upstream default
+    description = ''
+      Timeout (seconds) for RomM's background scan/rescan job (SCAN_TIMEOUT).
+      The scan runs as a single RQ job and is terminated when this elapses, so
+      raise it for a large first-pass scan. Non-complete rescans are additive, so
+      the library still converges across runs.
+    '';
+  };
+
+  # SCAN_WORKERS — RomM bounds concurrent per-ROM identification with an
+  # asyncio.Semaphore(SCAN_WORKERS) inside the single scan job (backend/endpoints/
+  # sockets/scan.py). This is I/O concurrency over the metadata-provider round
+  # trips (Hasheous / IGDB / SteamGridDB / RetroAchievements), NOT OS processes —
+  # so it is the real throughput lever for a network-bound scan. Default 1 = fully
+  # serial (one ROM at a time). Ceiling is set by provider rate limits (IGDB
+  # ~4 req/s); Hasheous hash-matching is the fast bulk path.
+  den.aspects.kubernetes.services.media.romm.settings.scanWorkers = lib.mkOption {
+    type = lib.types.ints.positive;
+    default = 1; # RomM upstream default (serial)
+    description = ''
+      Concurrent per-ROM identifications within a scan job (SCAN_WORKERS). This is
+      asyncio concurrency over metadata-provider I/O, not OS processes — the
+      primary lever for scan throughput. Bounded by provider rate limits.
+    '';
+  };
+
+  # Deployment replica count. NOTE: replicas do NOT speed a single scan — a scan
+  # is one RQ job run by one worker (intra-job concurrency is SCAN_WORKERS above).
+  # Extra replicas only add web/API + RQ-worker capacity for *other* jobs. Also:
+  # the userdata PVC (romm-userdata) is ReadWriteOnce longhorn, so replicas > 1
+  # scheduled across nodes cannot co-mount it — bumping this first needs an RWX
+  # userdata volume (or same-node affinity). Kept at 1.
+  den.aspects.kubernetes.services.media.romm.settings.replicas = lib.mkOption {
+    type = lib.types.ints.positive;
+    default = 1;
+    description = ''
+      RomM Deployment replica count. Does not accelerate a single scan (that is
+      SCAN_WORKERS); only adds capacity for concurrent web/API and other RQ jobs.
+      Replicas > 1 require an RWX userdata volume — the current romm-userdata PVC
+      is ReadWriteOnce.
+    '';
+  };
+}

--- a/modules/den/aspects/kubernetes/services/media/romm.nix
+++ b/modules/den/aspects/kubernetes/services/media/romm.nix
@@ -162,6 +162,15 @@
         charts,
         ...
       }:
+      let
+        # Tunable scan/scale knobs (romm-settings.nix; per-cluster overrides in the
+        # cluster's `settings.kubernetes.services.media.romm.*`).
+        inherit (cluster.settings.kubernetes.services.media.romm)
+          scanTimeout
+          scanWorkers
+          replicas
+          ;
+      in
       {
         applications.romm = {
           namespace = "media";
@@ -171,6 +180,10 @@
             values = {
               controllers.main = {
                 type = "deployment";
+                # Replica count is a cluster setting. NOTE: extra replicas do NOT
+                # speed a single scan (that is SCAN_WORKERS below); see
+                # romm-settings.nix for the RWO-userdata caveat before raising it.
+                inherit replicas;
                 containers.main = {
                   image = {
                     repository = "rommapp/romm";
@@ -180,6 +193,13 @@
                     TZ = "America/Los_Angeles";
                     PUID = "1027";
                     PGID = "65536";
+
+                    # --- scanning (cluster-tunable; see romm-settings.nix) ---
+                    # SCAN_TIMEOUT caps a single scan job; SCAN_WORKERS is the
+                    # asyncio concurrency over per-ROM metadata I/O (the real
+                    # throughput lever — default 1 scans strictly serially).
+                    SCAN_TIMEOUT = toString scanTimeout;
+                    SCAN_WORKERS = toString scanWorkers;
 
                     # --- database (media-pg, postgresql driver) ---
                     ROMM_DB_DRIVER = "postgresql";

--- a/modules/den/clusters/axon.nix
+++ b/modules/den/clusters/axon.nix
@@ -29,6 +29,15 @@
     # modules/den/aspects/kubernetes/services/network/cilium/settings.nix.
     settings.kubernetes.services.network.cilium.devices = "enp+";
 
+    # RomM initial full-library scan: the ~100k-ROM first pass far exceeds RomM's
+    # 4h default scan window, so give the scan job a 14-day timeout and raise the
+    # per-ROM scan concurrency (SCAN_WORKERS — an asyncio semaphore over
+    # metadata-provider I/O) well above the serial default. Replicas stay at 1:
+    # they do not speed a single scan. See
+    # modules/den/aspects/kubernetes/services/media/romm-settings.nix.
+    settings.kubernetes.services.media.romm.scanTimeout = 14 * 24 * 60 * 60; # 14 days
+    settings.kubernetes.services.media.romm.scanWorkers = 10;
+
     networks = {
       control-plane = {
         cidr = "10.10.10.0/24";


### PR DESCRIPTION
## Why

RomM's default scan window is short and scanning runs strictly serially by default, which is inadequate for a large first-pass library scan (the initial scan overruns the default timeout).

## What

New `romm-settings.nix` (mirrors the `garage` settings pattern) declaring three per-cluster settings, auto-surfaced as `cluster.settings.kubernetes.services.media.romm.*`:

| setting | env / field | default |
|---|---|---|
| `scanTimeout` | `SCAN_TIMEOUT` | 4h |
| `scanWorkers` | `SCAN_WORKERS` | 1 (serial) |
| `replicas` | Deployment replicas | 1 |

`romm.nix` wires the settings into the container env + deployment; `axon.nix` overrides `scanTimeout` to 14 days and raises `scanWorkers` for the initial full-library scan.

## Notes (from RomM source)

- `SCAN_WORKERS` is an `asyncio.Semaphore` over per-ROM metadata I/O within a single scan job — not OS processes. Metadata providers self-throttle via a **process-global** rate limiter and back off/retry once on 429, so raising workers overlaps I/O rather than raising provider request rates.
- `replicas` does **not** speed a single scan (one RQ job, one worker) and the RWO userdata PVC blocks scheduling more than one across nodes — exposed for completeness, kept at 1.
- Non-complete rescans are additive, so the library still converges across runs if a single pass is cut short.

## Verification

- `nix build .#nixidyEnvs.x86_64-linux.axon.environmentPackage` succeeds.
- Rendered axon romm Deployment carries `SCAN_TIMEOUT="1209600"` (14d), `SCAN_WORKERS="10"`, `replicas: 1`.
- `nix fmt` clean; `nixidy-sync` + `treefmt` pre-commit hooks pass.