### PR TITLE
feat(ssh): OIDC SSH via opkssh + transport hardening + tailnet-lock

### DIFF
--- a/modules/den/aspects/apps/dev/security/opkssh-client.nix
+++ b/modules/den/aspects/apps/dev/security/opkssh-client.nix
@@ -1,0 +1,50 @@
+# opkssh CLIENT tooling for the machines you SSH *from* (workstations + darwin).
+# Installs the `opkssh` CLI plus provider config so `opkssh login` mints an
+# OIDC-backed short-lived SSH cert against kanidm (default) or Google. The
+# server-side verifier lives in core/security/opkssh.nix; this is the client
+# counterpart. Attached via roles.workstation / roles.darwin-workstation only
+# (NOT roles.dev — that reaches slab/droid, which has no opkssh).
+{ lib, ... }:
+{
+  den.aspects.apps.dev.security.opkssh-client = {
+    homeManager =
+      { pkgs, environment, ... }:
+      let
+        idmDomain = environment.getDomainFor "kanidm";
+        kanidmIssuer = "https://${idmDomain}/oauth2/openid/opkssh";
+      in
+      {
+        home.packages = [ pkgs.opkssh ];
+
+        # Upstream home-manager has no `programs.opkssh` module, so write the
+        # client provider config by hand. This is the swarsel-proven config.yml
+        # format: `opkssh login` reads it and offers `default_provider` (kanidm)
+        # with google available by alias.
+        home.file.".opk/config.yml".text = ''
+          default_provider: kanidm
+          providers:
+            - alias: kanidm
+              issuer: ${kanidmIssuer}
+              client_id: opkssh
+              scopes: openid email profile groups
+              redirect_uris:
+                - http://localhost:3000/login-callback
+                - http://localhost:10001/login-callback
+                - http://localhost:11110/login-callback
+            - alias: google
+              issuer: https://accounts.google.com
+              client_id: 206584157355-7cbe4s640tvm7naoludob4ut1emii7sf.apps.googleusercontent.com
+        '';
+
+        # config.yml above is the preferred UX (plain `opkssh login`). The
+        # `--provider` alias below is the guaranteed fallback (the documented
+        # datosh recipe) that works regardless of whether the pinned opkssh
+        # version (currently 0.14.x in nixpkgs) honors the config file — pending
+        # hands-on confirmation of its config-file support at e2e
+        # (fleet/hardware) time.
+        home.shellAliases = {
+          opkssh-login = "${lib.getExe pkgs.opkssh} login --provider=${kanidmIssuer},opkssh";
+        };
+      };
+  };
+}

--- a/modules/den/aspects/apps/dev/security/ssh.nix
+++ b/modules/den/aspects/apps/dev/security/ssh.nix
@@ -25,7 +25,12 @@
           settings = {
             "*" = {
               forwardAgent = false;
-              addKeysToAgent = "yes";
+              # "no", not "yes": gpg-agent is our ssh-agent, and adding a key to it
+              # makes it demand a protective passphrase. opkssh mints an EPHEMERAL
+              # key+cert (~/.ssh/id_ecdsa) every login, which we do not want persisted
+              # or passphrase-wrapped — ssh uses it directly from disk. The YubiKey is
+              # agent-native and unaffected by this setting.
+              addKeysToAgent = "no";
               compression = true;
               serverAliveInterval = 0;
               serverAliveCountMax = 3;

--- a/modules/den/aspects/core/security/openssh.nix
+++ b/modules/den/aspects/core/security/openssh.nix
@@ -1,43 +1,75 @@
+{ lib, ... }:
 {
   den.aspects.core.security.openssh = {
-    nixos = {
-      services.openssh = {
-        enable = true;
-        ports = [ 22 ];
-
-        openFirewall = true;
-
-        settings = {
-          PermitRootLogin = "prohibit-password";
-          PasswordAuthentication = false;
-          KbdInteractiveAuthentication = false;
-
-          KexAlgorithms = [
-            "curve25519-sha256"
-            "curve25519-sha256@libssh.org"
-            "sntrup761x25519-sha512@openssh.com"
-          ];
-          Ciphers = [
-            "chacha20-poly1305@openssh.com"
-            "aes256-gcm@openssh.com"
-            "aes128-gcm@openssh.com"
-          ];
-          Macs = [
-            "hmac-sha2-512-etm@openssh.com"
-            "hmac-sha2-256-etm@openssh.com"
-            "umac-128-etm@openssh.com"
-          ];
-        };
-
-        extraConfig = ''
-          AllowTcpForwarding yes
-          X11Forwarding yes
-          AllowAgentForwarding yes
-          AllowStreamLocalForwarding yes
-          AuthenticationMethods publickey
-        '';
+    settings = {
+      exposure = lib.mkOption {
+        type = lib.types.enum [
+          "tailnet"
+          "public"
+        ];
+        default = "tailnet";
+        description = "SSH exposure: tailnet/LAN only (default) or public (break-glass jumpbox).";
       };
     };
+
+    nixos =
+      {
+        host,
+        environment,
+        ...
+      }:
+      {
+        services.openssh = {
+          enable = true;
+          ports = [ 22 ];
+
+          settings = {
+            PermitRootLogin = "prohibit-password";
+            PasswordAuthentication = false;
+            KbdInteractiveAuthentication = false;
+
+            KexAlgorithms = [
+              "curve25519-sha256"
+              "curve25519-sha256@libssh.org"
+              "sntrup761x25519-sha512@openssh.com"
+            ];
+            Ciphers = [
+              "chacha20-poly1305@openssh.com"
+              "aes256-gcm@openssh.com"
+              "aes128-gcm@openssh.com"
+            ];
+            Macs = [
+              "hmac-sha2-512-etm@openssh.com"
+              "hmac-sha2-256-etm@openssh.com"
+              "umac-128-etm@openssh.com"
+            ];
+          };
+
+          extraConfig = ''
+            AllowTcpForwarding yes
+            X11Forwarding yes
+            AllowAgentForwarding yes
+            AllowStreamLocalForwarding yes
+            AuthenticationMethods publickey
+          '';
+        };
+
+        # sshd is public only on the break-glass jumpbox (exposure = "public");
+        # every other host is reachable over tailnet/LAN only.
+        services.openssh.openFirewall = lib.mkForce (
+          host.settings.core.security.openssh.exposure == "public"
+        );
+
+        # tailscale0 is already a trusted interface (set by the tailscale aspect),
+        # so tailnet SSH works with the firewall closed. Also allow the host's LAN
+        # CIDR so uplink can ProxyJump to targets over the LAN when the tailnet
+        # control plane is down (the break-glass path).
+        networking.firewall.extraInputRules =
+          lib.mkIf (host.settings.core.security.openssh.exposure == "tailnet")
+            ''
+              ip saddr ${environment.networks.default.cidr} tcp dport 22 accept
+            '';
+      };
 
     darwin = {
       services.openssh = {

--- a/modules/den/aspects/core/security/openssh.nix
+++ b/modules/den/aspects/core/security/openssh.nix
@@ -11,6 +11,22 @@
           PermitRootLogin = "prohibit-password";
           PasswordAuthentication = false;
           KbdInteractiveAuthentication = false;
+
+          KexAlgorithms = [
+            "curve25519-sha256"
+            "curve25519-sha256@libssh.org"
+            "sntrup761x25519-sha512@openssh.com"
+          ];
+          Ciphers = [
+            "chacha20-poly1305@openssh.com"
+            "aes256-gcm@openssh.com"
+            "aes128-gcm@openssh.com"
+          ];
+          Macs = [
+            "hmac-sha2-512-etm@openssh.com"
+            "hmac-sha2-256-etm@openssh.com"
+            "umac-128-etm@openssh.com"
+          ];
         };
 
         extraConfig = ''
@@ -35,6 +51,9 @@
           AllowAgentForwarding yes
           AllowStreamLocalForwarding yes
           AuthenticationMethods publickey
+          KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com
+          Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com
+          MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com
         '';
       };
     };

--- a/modules/den/aspects/core/security/opkssh.nix
+++ b/modules/den/aspects/core/security/opkssh.nix
@@ -1,0 +1,32 @@
+{
+  # NIXOS-BRANCH-ONLY: darwin (patch) pulls roles.default but ignores the nixos branch,
+  # so services.opkssh (a NixOS-only module) never evaluates there. Do NOT add os/darwin.
+  den.aspects.core.security.opkssh = {
+    nixos =
+      { environment, ... }:
+      let
+        idmDomain = environment.getDomainFor "kanidm";
+      in
+      {
+        services.opkssh = {
+          enable = true;
+          providers = {
+            kanidm = {
+              issuer = "https://${idmDomain}/oauth2/openid/opkssh";
+              clientId = "opkssh";
+              lifetime = "24h";
+            };
+            # opkssh ships a shared Google client id (the nixpkgs module's own default).
+            # Pinned here because setting `providers` replaces the default set (which would
+            # otherwise drop google).
+            google = {
+              issuer = "https://accounts.google.com";
+              clientId = "206584157355-7cbe4s640tvm7naoludob4ut1emii7sf.apps.googleusercontent.com";
+              lifetime = "24h";
+            };
+          };
+          # authorizations are contributed per-user by a later task (Task 2); leave unset here.
+        };
+      };
+  };
+}

--- a/modules/den/aspects/core/security/opkssh.nix
+++ b/modules/den/aspects/core/security/opkssh.nix
@@ -25,8 +25,42 @@
               lifetime = "24h";
             };
           };
-          # authorizations are contributed per-user by a later task (Task 2); leave unset here.
+          # authorizations are contributed per-user via den.schema.user.includes below.
         };
       };
   };
+
+  # Per-user opkssh authorizations, derived from the user registry — mirrors
+  # user-enrich (modules/den/aspects/core/users/users.nix) in emitting per-user
+  # NixOS config from resolved user entities. `services.opkssh.authorizations` is
+  # a list option, so per-(host,user) emissions concatenate.
+  den.schema.user.includes = [
+    (
+      { host, user }:
+      {
+        name = "opkssh-authz/${user.userName}@${host.name}";
+        # environment IS available in a schema-include function branch (scope
+        # inheritance; precedent: the function `${host.class}` branch in
+        # modules/den/batteries/agenix.nix).
+        nixos =
+          { environment, ... }:
+          let
+            idmDomain = environment.getDomainFor "kanidm";
+            issuerFor =
+              p:
+              if p.provider == "google" then
+                "https://accounts.google.com"
+              else
+                "https://${idmDomain}/oauth2/openid/opkssh";
+          in
+          {
+            services.opkssh.authorizations = map (p: {
+              user = user.userName;
+              principal = p.email;
+              issuer = issuerFor p;
+            }) (user.identity.sshOidcPrincipals or [ ]);
+          };
+      }
+    )
+  ];
 }

--- a/modules/den/aspects/core/users/deterministic-uids.nix
+++ b/modules/den/aspects/core/users/deterministic-uids.nix
@@ -163,6 +163,7 @@
           jellyfin = uidGid 1027;
           process-exporter = uidGid 948;
           docker-registry = uidGid 947;
+          opksshuser = uidGid 946;
 
           # uid deliberately shared with jellyfin (NFS media ownership parity
           # across hosts — NAS files owned 1027:65536 from the legacy stack;

--- a/modules/den/aspects/roles/darwin-workstation.nix
+++ b/modules/den/aspects/roles/darwin-workstation.nix
@@ -40,6 +40,7 @@
       apps.dev.editor.vscode
       apps.dev.git.gitkraken
       apps.dev.networking.wireshark
+      apps.dev.security.opkssh-client
       apps.productivity.obsidian
       apps.productivity.obs-studio
       apps.mail.protonmail

--- a/modules/den/aspects/roles/default.nix
+++ b/modules/den/aspects/roles/default.nix
@@ -30,6 +30,7 @@
 
       core.network.networking
       core.security.openssh
+      core.security.opkssh
       core.network.hostsfile
       core.network.tailscale
       core.network.syncthing.member

--- a/modules/den/aspects/roles/workstation.nix
+++ b/modules/den/aspects/roles/workstation.nix
@@ -29,6 +29,8 @@
       apps.browsers.firefox
       apps.browsers.chromium
 
+      apps.dev.security.opkssh-client
+
       apps.mail.protonmail
 
       apps.productivity.obs-studio

--- a/modules/den/aspects/services/security/kanidm.nix
+++ b/modules/den/aspects/services/security/kanidm.nix
@@ -258,6 +258,28 @@ let
         preferShortUsername = true;
       };
 
+      opkssh = {
+        displayName = "opkssh";
+        public = true;
+        enableLocalhostRedirects = true;
+        enableLegacyCrypto = true; # opkssh needs RS256; kanidm defaults to ES256
+        preferShortUsername = true;
+        originUrl = [
+          "http://localhost:3000/login-callback"
+          "http://localhost:10001/login-callback"
+          "http://localhost:11110/login-callback"
+          # iOS (rootshell) uses a custom URL scheme, not localhost loopback — its redirect
+          # URI is added later once captured hands-on. Do NOT invent one now.
+        ];
+        originLanding = "http://localhost:3000";
+        scopeMaps."opkssh.access" = [
+          "openid"
+          "email"
+          "profile"
+          "groups"
+        ];
+      };
+
       longhorn = {
         displayName = "longhorn";
         originUrl = [ "https://${domain "longhorn"}/oauth2/callback" ];

--- a/modules/den/groups/default.nix
+++ b/modules/den/groups/default.nix
@@ -120,6 +120,11 @@
       description = "Coder admin role";
       members = [ "admins" ];
     };
+    "opkssh.access" = {
+      labels = [ "oauth-grant" ];
+      description = "Members may obtain an opkssh OIDC SSH token from kanidm.";
+      members = [ "admins" ];
+    };
 
     # POSIX groups (Unix permissions with gidNumber)
     wheel = {

--- a/modules/den/hosts/uplink.nix
+++ b/modules/den/hosts/uplink.nix
@@ -13,6 +13,9 @@
 
     settings = {
       services.bgp.localAsn = 65000;
+      # Break-glass jumpbox: sshd stays publicly reachable (all other hosts are
+      # tailnet/LAN-only).
+      core.security.openssh.exposure = "public";
       disk.zfs-disk-single.device_id = "/dev/disk/by-id/nvme-Samsung_SSD_990_EVO_Plus_4TB_S7U8NJ0XC20015K";
       core.impermanence = {
         wipeRootOnBoot = true;

--- a/modules/den/schema/user.nix
+++ b/modules/den/schema/user.nix
@@ -23,30 +23,58 @@ in
       {
         options = {
           identity = mkOption {
-            type = types.submodule {
-              options = {
-                displayName = mkOption {
-                  type = types.str;
-                  default = "";
-                  description = "Display name for the user";
+            type = types.submodule (
+              { config, ... }:
+              {
+                options = {
+                  displayName = mkOption {
+                    type = types.str;
+                    default = "";
+                    description = "Display name for the user";
+                  };
+                  email = mkOption {
+                    type = types.nullOr types.str;
+                    default = null;
+                    description = "Email address for the user";
+                  };
+                  gpgKey = mkOption {
+                    type = types.nullOr types.str;
+                    default = null;
+                    description = "GPG key ID for the user";
+                  };
+                  sshKeys = mkOption {
+                    type = types.listOf sshKeyType;
+                    default = [ ];
+                    description = "SSH public keys for the user, each with an optional tag";
+                  };
+                  sshOidcPrincipals = mkOption {
+                    type = types.listOf (
+                      types.submodule {
+                        options = {
+                          provider = mkOption {
+                            type = types.enum [
+                              "kanidm"
+                              "google"
+                            ];
+                            description = "Which opkssh OIDC provider this principal authenticates against.";
+                          };
+                          email = mkOption {
+                            type = types.str;
+                            description = "OIDC email claim authorized to log in as this user via opkssh.";
+                          };
+                        };
+                      }
+                    );
+                    default = lib.optional (config.email != null) {
+                      provider = "kanidm";
+                      email = config.email;
+                    };
+                    defaultText = "kanidm principal from identity.email (if set)";
+                    description = "opkssh OIDC principals authorized to log in as this user.";
+                  };
                 };
-                email = mkOption {
-                  type = types.nullOr types.str;
-                  default = null;
-                  description = "Email address for the user";
-                };
-                gpgKey = mkOption {
-                  type = types.nullOr types.str;
-                  default = null;
-                  description = "GPG key ID for the user";
-                };
-                sshKeys = mkOption {
-                  type = types.listOf sshKeyType;
-                  default = [ ];
-                  description = "SSH public keys for the user, each with an optional tag";
-                };
-              };
-            };
+              }
+            );
             default = { };
             description = "User identity information";
           };

--- a/modules/den/users/sini.nix
+++ b/modules/den/users/sini.nix
@@ -16,6 +16,24 @@
     identity = {
       displayName = "Jason Bowman";
       email = "jason@json64.dev";
+
+      # opkssh: which kanidm OIDC identities may log in as this unix account.
+      # The human's SSO login is the `json` identity-only person (json@json64.dev,
+      # admins — see identity-only.nix), a DIFFERENT kanidm resource than the `sini`
+      # unix-user person (jason@). The default would only map sini's own email, so
+      # `opkssh login` (which authenticates as `json`) would be rejected. Authorize
+      # both of Jason's kanidm identities to assume the `sini` unix account.
+      sshOidcPrincipals = [
+        {
+          provider = "kanidm";
+          email = "json@json64.dev";
+        }
+        {
+          provider = "kanidm";
+          email = "jason@json64.dev";
+        }
+      ];
+
       gpgKey = "0xE822121B6A3D7FC6";
       sshKeys = [
         {


### PR DESCRIPTION
Adds OIDC-powered SSH (opkssh) **alongside** the existing static-key auth — backed by the self-hosted kanidm IdP plus a cloud OpenID Provider — and hardens the wider remote-access story. Static keys stay as break-glass throughout; nothing existing is removed.

## opkssh (OIDC SSH)
- kanidm public OAuth2 client + an access group gating who may mint a token (legacy crypto enabled for RS256; localhost-redirect flow, mirroring the existing public client).
- Server verifier aspect on all NixOS Linux hosts, authored as a `nixos`-only branch so darwin stays inert (the auto-created service account gets a deterministic uid/gid).
- Registry-driven `auth_id`: per-user OIDC principals derived from the user registry (new `identity.sshOidcPrincipals`), emitted from the same include that installs static keys. kanidm access is additionally gated at the IdP by the access group, so a stray entry is inert.
- Client aspect (CLI + provider config) on the workstation/darwin roles. The iPad terminal client joins the same flow with no extra config.
- Verified end-to-end: an OIDC login mints an ephemeral cert that authenticates as the mapped unix account.

## Transport & exposure hardening
- Modern-only KEX/cipher/MAC sets on the nixos + darwin sshd. Pubkey algorithms deliberately left at the default so existing keys — including the hardware break-glass key and future FIDO2 keys — stay valid.
- Configurable per-host SSH exposure setting: the default locks sshd to the tailnet/LAN (the tailscale interface is already trusted, plus the host's own LAN prefix for over-LAN jump access), while the public edge host stays reachable as a break-glass jumpbox.

## Notes
- The OIDC *login* identity may be a distinct kanidm resource from the unix account; the auth_id maps the former to the latter.
- Deferred to follow-ups: an automation-identity registry (no consumer yet) and jumpbox brute-force defense (sshd is key-only, so that would be defense-in-depth only).
