### PR TITLE
chore(deps): bump gen-schema — reflect nixpkgs-str identity fields

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1249,11 +1249,11 @@
         "gen-types": "gen-types_2"
       },
       "locked": {
-        "lastModified": 1784234127,
-        "narHash": "sha256-W8Wn6FCN9gds7pTUAbCFDB+RZySLjfdPL7ZZmdOtWZ0=",
+        "lastModified": 1784236105,
+        "narHash": "sha256-PnAB6w9NJcyuyPaJ5AtsxDinx3PCxW54GONcvSjwrRc=",
         "owner": "sini",
         "repo": "gen-schema",
-        "rev": "69dcbb14b82da8d872ff5d3cd8b753ae7fc1479a",
+        "rev": "e6dbe8e7724810a448b2157c87ed5c051e36c9d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
gen-schema id-hash reflection now recognizes nixpkgs `lib.types.str` (type name `str`) alongside gen-types `string`, so entity identity fields declared with nixpkgs lib.types are hashed. Two same-named entities differing only in a str field (e.g. a home's system) no longer collapse to one id_hash.

cortex toplevel drvPath is byte-identical to the prior pin.